### PR TITLE
[sunrise-sunset] Phase 0: toolbox 扩展 (normalize_pm180 / SIDEREAL_RATE)

### DIFF
--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -43,6 +43,12 @@ constexpr auto normalize_rad(const double rad) -> double {
   return _rad < 0.0 ? _rad + 2.0 * std::numbers::pi : _rad;
 }
 
+/** @brief Normalize degree to [-180, 180). Useful for hour angles, where sign carries meaning. */
+constexpr auto normalize_pm180(const double deg) -> double {
+  const double _deg = normalize_deg(deg);
+  return _deg >= 180.0 ? _deg - 360.0 : _deg;
+}
+
 /** @brief The number of degrees in a radian. */
 constexpr double DEG_PER_RAD = 180.0 / std::numbers::pi;
 
@@ -55,6 +61,13 @@ constexpr auto deg_to_rad(const double deg) -> double {
 constexpr auto rad_to_deg(const double rad) -> double {
   return rad * DEG_PER_RAD;
 }
+
+/**
+ * @brief The mean angular rate of Earth's rotation relative to the stars, in degrees per day.
+ *        Used to convert between time offsets and hour angle offsets.
+ * @ref Jean Meeus, "Astronomical Algorithms", Ch.12.
+ */
+constexpr double SIDEREAL_RATE_DEG_PER_DAY = 360.98564736629;
 
 /** @brief The number of minutes in a degree. */
 constexpr uint32_t MIN_PER_DEG = 60;

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -33,6 +33,48 @@ TEST(AstroMath, NormalizedDeg) {
   }
 }
 
+TEST(AstroMath, NormalizedPm180) {
+  {
+    const auto x = normalize_pm180(0);
+    ASSERT_EQ(x, 0);
+  }
+  {
+    // Half-open range [-180, 180): 180 wraps to -180.
+    const auto x = normalize_pm180(180);
+    ASSERT_EQ(x, -180);
+  }
+  {
+    const auto x = normalize_pm180(-180);
+    ASSERT_EQ(x, -180);
+  }
+  {
+    const auto x = normalize_pm180(270);
+    ASSERT_EQ(x, -90);
+  }
+  {
+    const auto x = normalize_pm180(-90);
+    ASSERT_EQ(x, -90);
+  }
+  {
+    const auto x = normalize_pm180(450);
+    ASSERT_EQ(x, 90);
+  }
+  {
+    const auto x = normalize_pm180(-360.05);
+    ASSERT_FLOAT_EQ(x, -0.05);
+  }
+
+  for (auto i = 0; i < 1000; ++i) {
+    const double random_deg = util::random(-720.0, 720.0);
+    const double x = normalize_pm180(random_deg);
+
+    ASSERT_GE(x, -180.0);
+    ASSERT_LT(x, 180.0);
+    // Result is congruent to the input modulo 360.
+    ASSERT_FLOAT_EQ(normalize_deg(x), normalize_deg(random_deg));
+  }
+}
+
 TEST(AstroMath, RadDegConversion) {
   for (auto i = 0; i < 1000; ++i) {
     const double random_deg = util::random(-720.0, 720.0);


### PR DESCRIPTION
## 内容

- `normalize_pm180()`: 角度归一化到 **[-180°, 180°)**,供后续时角计算使用(日出时角为负、日落为正)
- `SIDEREAL_RATE_DEG_PER_DAY = 360.98564736629`: 恒星日角速度常量 (Meeus Ch.12),后续 Phase 用于时间↔时角换算
- 顺手修复 bit-rot:g++ 15 在 C++23 下把 `operator"" _deg`(带空格)按 `-Werror=deprecated-literal-operator` 报错,已去空格(对旧编译器同样合法)

## 边界语义说明

Spec 的测试期望里写了 `normalize_pm180(180) → 180`,但这与 `[-180, 180)` 半开区间和 spec 自己的实现(`deg >= 180 ? deg-360 : deg`)矛盾。本 PR 按严格半开区间实现:**180 → -180**,并在测试中固化该语义。

## 测试

- 新增 `AstroMath.NormalizedPm180`:边界用例 + 1000 组随机性质测试(值域 + mod 360 同余)
- 本地全量 87/87 通过 (g++ 15.2, Release)

Closes #38 · Milestone: v0.3.0 Sunrise & Sunset

🤖 Generated with [Claude Code](https://claude.com/claude-code)