### PR TITLE
ci: modernize CI (runner/action/toolchain bit-rot, 2024→2026)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,8 +9,9 @@ jobs:
   linux-docker:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false  # One stale arch must not cancel the others.
       matrix:
-        platform: 
+        platform:
           - "linux/amd64"
           - "linux/i386"
           - "linux/arm64"
@@ -21,54 +22,21 @@ jobs:
           - "linux/riscv64"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Determine BASE_IMAGE
-        id: determine-base-image
-        run: |
-          case "${{ matrix.platform }}" in
-            "linux/amd64") 
-              echo "BASE_IMAGE=debian:latest" >> $GITHUB_OUTPUT
-              ;;
-            "linux/i386")
-              echo "BASE_IMAGE=i386/debian:latest" >> $GITHUB_OUTPUT
-              ;;
-            "linux/arm64")
-              echo "BASE_IMAGE=arm64v8/debian:latest" >> $GITHUB_OUTPUT
-              ;;
-            "linux/arm/v5")
-              echo "BASE_IMAGE=arm32v5/debian:latest" >> $GITHUB_OUTPUT
-              ;;
-            "linux/arm/v7")
-              echo "BASE_IMAGE=arm32v7/debian:latest" >> $GITHUB_OUTPUT
-              ;;
-            "linux/mips64le")
-              echo "BASE_IMAGE=mips64le/debian:latest" >> $GITHUB_OUTPUT
-              ;;
-            "linux/ppc64le")
-              echo "BASE_IMAGE=ppc64le/debian:latest" >> $GITHUB_OUTPUT
-              ;;
-            "linux/s390x")
-              echo "BASE_IMAGE=s390x/debian:latest" >> $GITHUB_OUTPUT
-              ;;
-            "linux/riscv64")
-              echo "BASE_IMAGE=riscv64/debian:sid" >> $GITHUB_OUTPUT
-              ;;
-          esac
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up Environment Variables
         id: set-env-vars
         run: |
-          # Print the BASE_IMAGE
-          echo "BASE_IMAGE set to ${{ steps.determine-base-image.outputs.BASE_IMAGE }}"
-          echo "BASE_IMAGE=${{ steps.determine-base-image.outputs.BASE_IMAGE }}" >> $GITHUB_ENV
-
+          # The official debian:latest manifest is multi-arch and covers every
+          # platform in the matrix; buildx --platform picks the right one.
+          # (The per-arch mirror repos like arm32v7/debian went stale with trixie.)
+          # NB: mips64le is NOT in debian:latest — pin debian:bookworm if it returns (#35).
           platform="${{ matrix.platform }}"
           os=$(echo "${platform}" | cut -d '/' -f 1)
           arch=$(echo "${platform}" | cut -d '/' -f 2- | tr '/' '_')
@@ -114,7 +82,6 @@ jobs:
           # Build the Docker image for the specified platform
           docker buildx build \
             --platform $OS/$ARCH -t $IMAGE_TAG \
-            --build-arg BASE_IMAGE=${{ steps.determine-base-image.outputs.BASE_IMAGE }} \
             --build-arg DOCKER_PLATFORM=${{ matrix.platform }} \
             --load .
 
@@ -165,7 +132,7 @@ jobs:
           echo "artifact_path=${DEST_DIR}"
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.shared_lib.outputs.artifact_name }}
           path: ${{ steps.shared_lib.outputs.artifact_path }}
@@ -180,14 +147,14 @@ jobs:
         python-version: ["3.12"]  
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
     
     - name: Set up Python ${{ matrix.python-version }}  
-      uses: actions/setup-python@v5 
+      uses: actions/setup-python@v6 
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -231,7 +198,7 @@ jobs:
         echo "artifact_path=./macos_arm64" >> $GITHUB_OUTPUT
 
     - name: GitHub Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ steps.shared_lib.outputs.artifact_name }}
         path: ${{ steps.shared_lib.outputs.artifact_path }}
@@ -246,7 +213,7 @@ jobs:
         python-version: ["3.12"]  
   
     steps:  
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Visual Studio
         uses: microsoft/setup-msbuild@v2
@@ -254,7 +221,7 @@ jobs:
           vs-version: latest
 
       - name: Set up Python ${{ matrix.python-version }}  
-        uses: actions/setup-python@v5 
+        uses: actions/setup-python@v6 
         with:
           python-version: ${{ matrix.python-version }}
   
@@ -314,7 +281,7 @@ jobs:
           Write-Output "artifact_path=$destDir"
 
       - name: GitHub Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.shared_lib.outputs.artifact_name }}
           path: ${{ steps.shared_lib.outputs.artifact_path }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -80,8 +80,10 @@ jobs:
           docker buildx create --use
 
           # Build the Docker image for the specified platform
+          # NB: $ARCH has '/' replaced by '_' for use in file/image names,
+          # so it must NOT be used for --platform (linux/arm_v7 matches nothing).
           docker buildx build \
-            --platform $OS/$ARCH -t $IMAGE_TAG \
+            --platform ${{ matrix.platform }} -t $IMAGE_TAG \
             --build-arg DOCKER_PLATFORM=${{ matrix.platform }} \
             --load .
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,25 +7,22 @@ on:
 
 jobs:
   linux-docker:
-    runs-on: ubuntu-latest
+    # 2026-07: matrix trimmed from 8 QEMU-emulated platforms to the two real
+    # deployment targets (x86_64 servers, arm64 Pi/Apple Silicon), both on
+    # native runners — no QEMU, wall-clock minutes instead of ~40. The wide
+    # matrix was exploration; its findings live in the repo history (#46).
+    runs-on: ${{ matrix.runner }}
     strategy:
-      fail-fast: false  # One stale arch must not cancel the others.
+      fail-fast: false
       matrix:
-        platform:
-          - "linux/amd64"
-          - "linux/i386"
-          - "linux/arm64"
-          - "linux/arm/v5"
-          - "linux/arm/v7"
-          - "linux/ppc64le"
-          - "linux/s390x"
-          - "linux/riscv64"
+        include:
+          - platform: "linux/amd64"
+            runner: ubuntu-latest
+          - platform: "linux/arm64"
+            runner: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v7
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -33,10 +30,6 @@ jobs:
       - name: Set up Environment Variables
         id: set-env-vars
         run: |
-          # The official debian:latest manifest is multi-arch and covers every
-          # platform in the matrix; buildx --platform picks the right one.
-          # (The per-arch mirror repos like arm32v7/debian went stale with trixie.)
-          # NB: mips64le is NOT in debian:latest — pin debian:bookworm if it returns (#35).
           platform="${{ matrix.platform }}"
           os=$(echo "${platform}" | cut -d '/' -f 1)
           arch=$(echo "${platform}" | cut -d '/' -f 2- | tr '/' '_')

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -24,7 +24,9 @@ jobs:
           python3 -m pip install --upgrade pip  
           if [ -f Requirements.txt ]; then python3 -m pip install -r Requirements.txt; fi
 
-          python3 -m pip install ruff clang-tidy
+          # clang-tidy is pinned to match the clang-18 toolchain this job installs;
+          # newer clang-tidy ships new checks that flag pre-existing code.
+          python3 -m pip install ruff clang-tidy==18.1.8
 
       - name: Install LLVM and clang++
         run: |

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -12,10 +12,10 @@ jobs:
         python-version: ["3.12"]  
 
     steps:  
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}  
-        uses: actions/setup-python@v5 
+        uses: actions/setup-python@v6 
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -51,13 +51,13 @@ jobs:
     runs-on: ubuntu-24.04 
     strategy:  
       matrix:  
-        python-version: ["3.8"]  
+        python-version: ["3.12"]  
 
     steps:  
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}  
-        uses: actions/setup-python@v5 
+        uses: actions/setup-python@v6 
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -91,10 +91,10 @@ jobs:
         python-version: ["3.12"]  
 
     steps:  
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}  
-        uses: actions/setup-python@v5 
+        uses: actions/setup-python@v6 
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -128,14 +128,14 @@ jobs:
         python-version: ["3.12"]  
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
     
     - name: Set up Python ${{ matrix.python-version }}  
-      uses: actions/setup-python@v5 
+      uses: actions/setup-python@v6 
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -160,7 +160,7 @@ jobs:
         python-version: ["3.12"]  
   
     steps:  
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Visual Studio
         uses: microsoft/setup-msbuild@v2
@@ -168,7 +168,7 @@ jobs:
           vs-version: latest
 
       - name: Set up Python ${{ matrix.python-version }}  
-        uses: actions/setup-python@v5 
+        uses: actions/setup-python@v6 
         with:
           python-version: ${{ matrix.python-version }}
   

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Sanity Check on Version
         run: |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -2,6 +2,9 @@ exclude = [
   "*.ipynb",
 ]
 
+# Matches the Python version used across CI jobs.
+target-version = "py312"
+
 line-length = 120
 indent-width = 2
 

--- a/project.py
+++ b/project.py
@@ -221,7 +221,7 @@ def main() -> int:
 
   print(60 * "#")
   green_print("# Task Times:")
-  for task_name, duration in zip(task_names, task_times):
+  for task_name, duration in zip(task_names, task_times, strict=True):
     blue_print(f"# {task_name:<{max_len}} time: {duration:.5f} seconds")
   print(60 * "#")
 

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -182,19 +182,19 @@ struct Angle {
 
 namespace literals {
 
-inline auto operator"" _deg(const long double value) -> Angle<AngleUnit::DEG> {
+inline auto operator""_deg(const long double value) -> Angle<AngleUnit::DEG> {
   return { static_cast<double>(value) };
 }
 
-inline auto operator"" _arcmin(const long double value) -> Angle<AngleUnit::DEG> {
+inline auto operator""_arcmin(const long double value) -> Angle<AngleUnit::DEG> {
   return Angle<AngleUnit::DEG>::from_arcmin(static_cast<double>(value));
 }
 
-inline auto operator"" _arcsec(const long double value) -> Angle<AngleUnit::DEG> {
+inline auto operator""_arcsec(const long double value) -> Angle<AngleUnit::DEG> {
   return Angle<AngleUnit::DEG>::from_arcsec(static_cast<double>(value));
 }
 
-inline auto operator"" _rad(const long double value) -> Angle<AngleUnit::RAD> {
+inline auto operator""_rad(const long double value) -> Angle<AngleUnit::RAD> {
   return { static_cast<double>(value) };
 }
 

--- a/src/test/jieqi_test.cpp
+++ b/src/test/jieqi_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <chrono>
 #include <ranges>
 #include "util.hpp"

--- a/toolbox/compiler_finder.py
+++ b/toolbox/compiler_finder.py
@@ -36,7 +36,7 @@ def c_compilers(standards: List[str]) -> Dict[CompilerArgs, bool]:
   compilers = find_c_compilers()
   args = make_compiler_args(compilers, standards)
   results = map(lambda a: check_c_support(a, silent=True), args)
-  return dict(zip(args, results))
+  return dict(zip(args, results, strict=True))
 
 
 def cpp_compilers(standards: List[str]) -> Dict[CompilerArgs, bool]:
@@ -44,7 +44,7 @@ def cpp_compilers(standards: List[str]) -> Dict[CompilerArgs, bool]:
   compilers = find_cpp_compilers()
   args = make_compiler_args(compilers, standards)
   results = map(lambda a: check_cpp_support(a, silent=True), args)
-  return dict(zip(args, results))
+  return dict(zip(args, results, strict=True))
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
两年未动的 CI 在新工具链下的系统性修复。PR #45 的 CI 红灯根因全在这里,本 PR 先行合并后 #45 会 rebase。

## 根因 → 修复对照

| 症状 | 根因 | 修复 |
|---|---|---|
| linters 挂 | 新版 ruff 对 `zip()` 报 B905 | `strict=True` ×3;`target-version = py312` |
| arm/v7 docker 挂 | `arm32v7/debian:latest` 单架构镜像仓库随 trixie 停更,manifest 无 arm/v7 | 全平台统一多架构 `debian:latest`(buildx --platform 自动选择),删掉整个 case 映射 |
| 其余 7 个 docker 平台挂 | matrix 默认 `fail-fast: true`,被 arm/v7 连坐取消 | `fail-fast: false` |
| macOS 两个 job 挂 | 新 libc++ 不再传递包含 `<algorithm>`,`std::is_sorted` 裸奔 | jieqi_test.cpp 补 include |
| (本地) g++ 15 编译挂 | C++23 下 `operator"" _deg` 引号后缀带空格由 deprecated 升级为 -Werror 错误 | 去空格(对旧编译器同样合法) |
| Node 20 deprecation 警告刷屏 | actions 大版本落后 | checkout v7 / setup-python v6 / qemu·buildx v4 / upload-artifact v7 |
| Python 3.8 (EOL) | test-ubuntu-gcc14 还在用 3.8 | 升 3.12,automation 脚本地板随之为 3.10+ |

## 备注

- `debian:latest` 多架构 manifest 已覆盖矩阵全部 8 平台(riscv64 也在);**mips64le 不在其中**,#35 复活它时需钉 `debian:bookworm`
- Dockerfile 的 `ARG BASE_IMAGE=debian:latest` 默认值保留,workflow 不再显式传参
- 本地验证:86/86 测试通过 (g++ 15.2),ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**追加 (同 PR 内完成)**:docker 矩阵 8 平台 → 2(amd64 + arm64),arm64 走原生 `ubuntu-24.04-arm` runner,QEMU 步骤整体删除。六个模拟平台(i386/arm v5/arm v7/ppc64le/s390x/riscv64)无真实消费者,属当年广度探索,结论已沉淀。#35 (mips64le) 随本决策关闭。