### PR TITLE
[sunrise-sunset] Phase 1: 黄赤交角 obliquity (earth.hpp 扩展)

### DIFF
--- a/src/astro/earth.hpp
+++ b/src/astro/earth.hpp
@@ -393,6 +393,46 @@ inline auto obliquity(const double jde, const Model model = Model::IAU_1980) -> 
 } // namespace astro::earth::nutation
 
 
+namespace astro::earth::obliquity {
+
+// The obliquity of the ecliptic is the angle between the ecliptic and the celestial equator.
+// It is needed whenever converting between ecliptic and equatorial coordinates.
+
+/**
+ * @brief Calculates the mean obliquity of the ecliptic (ε₀) for the given julian day.
+ * @param jde The julian ephemeris day number, which is based on TT.
+ * @return The mean obliquity (ε₀) in degrees.
+ * @details Accuracy ~1" over ±2000 years from J2000; the polynomial degrades farther out.
+ * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 22, Formula (22.2).
+ */
+inline auto mean(const double jde) -> Angle<DEG> {
+  // Get the Julian century since J2000.
+  const double jc = astro::julian_day::jde_to_jc(jde);
+
+  // IAU 1980: ε₀ = 23°26'21".448 - 46".8150T - 0".00059T² + 0".001813T³
+  // The polynomial is evaluated in arcseconds.
+  const double ε0_arcsec = 84381.448 + jc * (-46.8150 + jc * (-0.00059 + jc * 0.001813));
+
+  return Angle<DEG>::from_arcsec(ε0_arcsec);
+}
+
+/**
+ * @brief Calculates the true obliquity of the ecliptic (ε) for the given julian day.
+ * @param jde The julian ephemeris day number, which is based on TT.
+ * @param model The nutation model to use. Defaults to `nutation::Model::IAU_1980`.
+ * @return The true obliquity (ε = ε₀ + Δε) in degrees.
+ * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 22.
+ */
+inline auto true_obliquity(
+  const double jde,
+  const nutation::Model model = nutation::Model::IAU_1980
+) -> Angle<DEG> {
+  return mean(jde) + nutation::obliquity(jde, model);
+}
+
+} // namespace astro::earth::obliquity
+
+
 namespace astro::earth::aberration {
 
 /**

--- a/src/test/astro/earth_test.cpp
+++ b/src/test/astro/earth_test.cpp
@@ -260,7 +260,7 @@ TEST(Earth, NutationMeeus) {
       #endif
     });
 
-    ASSERT_NEAR(obliquity(jde, Model::MEEUS).as<DEG>(), obl_nut, obl_epsilon);
+    ASSERT_NEAR(nutation::obliquity(jde, Model::MEEUS).as<DEG>(), obl_nut, obl_epsilon);
   }
 }
 
@@ -464,7 +464,42 @@ TEST(Earth, NutationIau1980) {
     const auto& [lon_nut, obl_nut] = expected;
 
     ASSERT_NEAR(longitude(jde, Model::IAU_1980).as<RAD>(), lon_nut, 4e-12);
-    ASSERT_NEAR(obliquity(jde, Model::IAU_1980).as<RAD>(), obl_nut, 2e-12);
+    ASSERT_NEAR(nutation::obliquity(jde, Model::IAU_1980).as<RAD>(), obl_nut, 2e-12);
+  }
+}
+
+TEST(Earth, ObliquityMeeus22a) {
+  using namespace obliquity;
+
+  // Meeus Example 22.a: 1987-04-10, 0h TD, JDE = 2446895.5.
+  const double jde = 2446895.5;
+
+  // Expected mean obliquity: ε₀ = 23°26'27".407
+  const double expected_mean = 23.0 + 26.0 / 60.0 + 27.407 / 3600.0;
+  ASSERT_NEAR(mean(jde).as<DEG>(), expected_mean, 1e-5);
+
+  // Expected true obliquity: ε = ε₀ + Δε = 23°26'36".850
+  const double expected_true = 23.0 + 26.0 / 60.0 + 36.850 / 3600.0;
+  ASSERT_NEAR(true_obliquity(jde).as<DEG>(), expected_true, 1e-4);
+}
+
+TEST(Earth, ObliquityJ2000) {
+  using namespace obliquity;
+
+  // At J2000.0 the polynomial reduces to its constant term: 84381.448" = 23.4392911...°
+  const double j2000 = astro::julian_day::J2000;
+  ASSERT_NEAR(mean(j2000).as<DEG>(), 84381.448 / 3600.0, 1e-9);
+
+  // Sanity: within ±1 century of J2000, mean obliquity stays in a narrow band around 23.4°.
+  for (auto i = 0; i < 100; ++i) {
+    const double jde = j2000 + util::random(-36525.0, 36525.0);
+    const double ε0 = mean(jde).as<DEG>();
+    ASSERT_GT(ε0, 23.4);
+    ASSERT_LT(ε0, 23.5);
+
+    // True obliquity differs from mean only by nutation (|Δε| < ~10").
+    const double Δ = std::fabs(true_obliquity(jde).as<DEG>() - ε0);
+    ASSERT_LT(Δ, 10.0 / 3600.0);
   }
 }
 


### PR DESCRIPTION
## 内容

- `earth::obliquity::mean(jde)`: IAU 1980 平黄赤交角多项式 (Meeus 22.2),arcsec 域内 Horner 形式求值
- `earth::obliquity::true_obliquity(jde, model)`: ε = ε₀ + Δε,复用现有 `nutation::obliquity`
- 连带修复:新命名空间使测试里裸的 `obliquity(...)` 产生歧义,已限定为 `nutation::obliquity(...)`

## 测试

- Meeus Example 22.a:mean 与 true 双断言 (JDE 2446895.5 → 23°26'27".407 / 23°26'36".850)
- J2000 常数项恒等 (84381.448")
- 随机性质:J2000 ±1 世纪内 ε₀ ∈ (23.4°, 23.5°),|ε − ε₀| < 10"
- 本地全量 89/89 通过

Closes #39 · Milestone: v0.3.0 Sunrise & Sunset · 依赖 #45 (已合并)

🤖 Generated with [Claude Code](https://claude.com/claude-code)