### PR TITLE
fix(astro): keep the best Newton iterate, and bracket conjunctions by construction

### DIFF
--- a/src/astro/moon_phase.hpp
+++ b/src/astro/moon_phase.hpp
@@ -150,8 +150,9 @@ inline auto first_root_range_after(const double jde) -> std::pair<double, double
   if (std::fabs(signed_miss_deg) > ESTIMATE_TOLERANCE_DEG) [[unlikely]] {
     throw std::invalid_argument {
       std::format(
-        "Cannot find the first root after jde {}: the estimate at jde {} sits {} deg from conjunction.",
-        jde, est_jde, est_jde_diff
+        "Cannot find the first root after jde {}: the estimate at jde {} misses conjunction "
+        "by {} deg (elongation {} deg).",
+        jde, est_jde, signed_miss_deg, est_jde_diff
       )
     };
   }

--- a/src/astro/moon_phase.hpp
+++ b/src/astro/moon_phase.hpp
@@ -25,8 +25,8 @@
 
 #include <vector>
 #include <format>
-#include <numbers>
 
+#include "toolbox.hpp"
 #include "ymd.hpp"
 #include "datetime.hpp"
 #include "julian_day.hpp"
@@ -56,66 +56,56 @@ inline auto longitude_diff(const double jde) -> double {
 
 
 /**
+ * @brief How near conjunction a JDE must sit before it can serve as a bracket endpoint,
+ *        measured in degrees of Moon-Sun elongation.
+ * @note The same figure sets where `f` is unwrapped below, so the bracket that Newton's method
+ *       accepts and the interval on which `f` is smooth are one and the same by construction.
+ */
+constexpr double BRACKET_TOLERANCE_DEG = 15.0;
+
+/**
  * @brief Apply Newton's method to find the jde, when the Sun and Moon are at the same apparent longitude.
  * @param left_jde The left bound of the search, inclusive.
  * @param right_jde The right bound of the search, exclusive.
- * @param iterations The maximum number of iterations. Default is 20.
- * @param epsilon The tolerance. Default is 1e-8.
+ * @param iterations The maximum number of iterations.
  * @return The jde of the conjunction.
  * @note It is the caller's responsibility to ensure the root exists in the range of [left_jde, right_jde).
  * @throw std::invalid_argument If no root exists in the range of [left_jde, right_jde).
  */
 inline auto newton_method(
-  const double left_jde, 
+  const double left_jde,
   const double right_jde,            // NOLINT(bugprone-easily-swappable-parameters)
-  const std::size_t iterations = 30,
-  const double epsilon = 1e-15
+  const std::size_t iterations = astro::toolbox::NEWTON_MAX_ITERATIONS
 ) -> double {
 
   // Make sure the root exists in the range of [left_jde, right_jde).
   const double left_diff = longitude_diff(left_jde);
   const double right_diff = longitude_diff(right_jde);
 
-  if (left_diff <= 345.0 or right_diff >= 15.0) [[unlikely]] {
+  if (left_diff <= 360.0 - BRACKET_TOLERANCE_DEG or right_diff >= BRACKET_TOLERANCE_DEG) [[unlikely]] {
     throw std::invalid_argument {
-      std::format("No root between {} and {}.", left_jde, right_jde)
+      std::format(
+        "No root between jde {} (elongation {} deg) and jde {} (elongation {} deg).",
+        left_jde, left_diff, right_jde, right_diff
+      )
     };
   }
 
   // Define the function `f` which is differentiable.
   // We are going to find the root where `f` evaluates to 0.
-  const auto f = [&](const double jde) -> double {
+  // Just before conjunction the Moon still trails the Sun by nearly a full turn, so the raw
+  // difference jumps from 360 back to 0 across the root; unwrapping it keeps `f` smooth there.
+  const auto f = [](const double jde) -> double {
     const double diff = longitude_diff(jde);
-    if (diff > 345.0) {
+    if (diff > 360.0 - BRACKET_TOLERANCE_DEG) {
       return diff - 360.0;
     }
     return diff;
   };
 
-  // Start approximating the root.
-  double h = 5e-4;
-  double guess = (left_jde + right_jde) / 2.0;
-  
-  for (std::size_t i = 0; i < iterations; ++i) {
-    const double f_prime = (f(guess + h) - f(guess - h)) / (2.0 * h);
-    double next_guess = guess - f(guess) / f_prime;
-
-    // Ensure next guess is within the range of [left_jde, right_jde).
-    if (next_guess < left_jde) {
-      next_guess = left_jde;
-    } else if (next_guess >= right_jde) {
-      next_guess = right_jde - 1e-20;
-    }
-
-    if (std::fabs(next_guess - guess) < epsilon) {
-      return next_guess;
-    }
-
-    guess = next_guess;
-    h = (h > 1e-10) ? h / std::numbers::phi : h; // Make the step size adaptive, for faster convergence.
-  }
-
-  return guess;
+  return astro::toolbox::newton_method(
+    f, left_jde, right_jde, astro::toolbox::MOON_ELONGATION_RATE_DEG_PER_DAY, iterations
+  );
 }
 
 
@@ -128,10 +118,13 @@ inline auto first_root_range_after(const double jde) -> std::pair<double, double
   const double cur_diff = longitude_diff(jde);
   const double gap = 360.0 - cur_diff;
 
-  constexpr double deg_per_day = 360.0 / 29.530588853; // The avg length of a lunar month is ~29.53 days.
+  constexpr double deg_per_day = astro::toolbox::MOON_ELONGATION_RATE_DEG_PER_DAY;
   const double est_jde = jde + gap / deg_per_day; // Estimate the next root jde.
 
-  const double est_jde_diff = longitude_diff(est_jde); // The value is expected to be in range [0, 10) or (350, 360).
+  // Extrapolating at the mean rate lands near the root but not on it: the Moon's true rate runs
+  // between about 10.5 and 14.5 deg/day, so a month of extrapolation can be off by a few degrees
+  // either way. The branches below accept anything within 30 deg of conjunction.
+  const double est_jde_diff = longitude_diff(est_jde);
 
   if (est_jde_diff == 0.0) [[unlikely]] {
     return { est_jde - 0.1, est_jde + 0.1 };
@@ -147,7 +140,12 @@ inline auto first_root_range_after(const double jde) -> std::pair<double, double
     return { est_jde, right_bound };
   }
 
-  throw std::invalid_argument { "Cannot find the first root after the given jde." };
+  throw std::invalid_argument {
+    std::format(
+      "Cannot find the first root after jde {}: the estimate at jde {} sits {} deg from conjunction.",
+      jde, est_jde, est_jde_diff
+    )
+  };
 }
 
 

--- a/src/astro/moon_phase.hpp
+++ b/src/astro/moon_phase.hpp
@@ -110,9 +110,29 @@ inline auto newton_method(
 
 
 /**
+ * @brief How far the mean-rate extrapolation may miss conjunction and still be worth refining,
+ *        in degrees of Moon-Sun elongation.
+ * @note Refining divides the miss by the mean rate, so a miss of this size leaves the estimate
+ *       about `30 / 12.19 * 0.19` = 0.47 day short of the root — which is what makes
+ *       `BRACKET_HALF_WIDTH_DAYS` the binding constraint on how large this may be.
+ */
+constexpr double ESTIMATE_TOLERANCE_DEG = 30.0;
+
+/**
+ * @brief Half the width of the bracket handed to Newton's method, in days.
+ * @note Chosen between two bounds. Too narrow and the bracket stops containing the root, since
+ *       refining leaves an error of up to 0.47 day at the tolerance above. Too wide and the
+ *       endpoints drift past `BRACKET_TOLERANCE_DEG`: at the Moon's fastest, 14.5 deg/day, an
+ *       endpoint 0.67 day out already sits 9.7 deg from conjunction.
+ */
+constexpr double BRACKET_HALF_WIDTH_DAYS = 0.5;
+
+/**
  * @brief Approximate the range of the first root after the given jde, when the Sun and Moon are at the same apparent longitude.
  * @param jde The jde.
  * @return The range of the first root after the given `jde`.
+ * @throw std::invalid_argument If the extrapolation lands further than `ESTIMATE_TOLERANCE_DEG`
+ *        from conjunction, i.e. too far off to be worth refining.
  */
 inline auto first_root_range_after(const double jde) -> std::pair<double, double> {
   const double cur_diff = longitude_diff(jde);
@@ -122,30 +142,28 @@ inline auto first_root_range_after(const double jde) -> std::pair<double, double
   const double est_jde = jde + gap / deg_per_day; // Estimate the next root jde.
 
   // Extrapolating at the mean rate lands near the root but not on it: the Moon's true rate runs
-  // between about 10.5 and 14.5 deg/day, so a month of extrapolation can be off by a few degrees
-  // either way. The branches below accept anything within 30 deg of conjunction.
+  // between about 10.5 and 14.5 deg/day, so a month of it can miss by several degrees either way.
+  // Signed, so that overshooting the conjunction reads positive and falling short reads negative.
   const double est_jde_diff = longitude_diff(est_jde);
+  const double signed_miss_deg = (est_jde_diff > 180.0) ? est_jde_diff - 360.0 : est_jde_diff;
 
-  if (est_jde_diff == 0.0) [[unlikely]] {
-    return { est_jde - 0.1, est_jde + 0.1 };
-  } 
-  
-  if (est_jde_diff < 30.0) {
-    const double left_bound = est_jde - (est_jde_diff * 2 / deg_per_day);
-    return { left_bound, est_jde };
+  if (std::fabs(signed_miss_deg) > ESTIMATE_TOLERANCE_DEG) [[unlikely]] {
+    throw std::invalid_argument {
+      std::format(
+        "Cannot find the first root after jde {}: the estimate at jde {} sits {} deg from conjunction.",
+        jde, est_jde, est_jde_diff
+      )
+    };
   }
 
-  if (est_jde_diff > 330.0) {
-    const double right_bound = est_jde + ((360.0 - est_jde_diff) * 2 / deg_per_day);
-    return { est_jde, right_bound };
-  }
-
-  throw std::invalid_argument {
-    std::format(
-      "Cannot find the first root after jde {}: the estimate at jde {} sits {} deg from conjunction.",
-      jde, est_jde, est_jde_diff
-    )
-  };
+  // Step the estimate onto the root before bracketing it. Bracketing the estimate directly would
+  // leave the endpoints however far out the extrapolation happened to miss, plus whatever the
+  // rate varied over the bracket -- measured, that put an endpoint within 0.67 deg of the
+  // tolerance Newton's method demands. Refining first makes the endpoints' distance from
+  // conjunction a property of `BRACKET_HALF_WIDTH_DAYS` instead, so the bracket the solver
+  // accepts is one this function builds by construction rather than by luck.
+  const double root_est = est_jde - (signed_miss_deg / deg_per_day);
+  return { root_est - BRACKET_HALF_WIDTH_DAYS, root_est + BRACKET_HALF_WIDTH_DAYS };
 }
 
 

--- a/src/astro/sun.hpp
+++ b/src/astro/sun.hpp
@@ -23,8 +23,6 @@
 
 #pragma once
 
-#include <numbers>
-
 #include "toolbox.hpp"
 #include "julian_day.hpp"
 #include "earth.hpp"
@@ -284,77 +282,7 @@ inline auto make_f(const int32_t year, const double expected_lon) -> FuncType {
   };
 }
 
-/** 
- * @brief Apply Newton's method to find the root.
- * @param f The function to find the root.
- * @param start_jde The left bound of JDE's range, inclusive.
- * @param end_jde The right bound of JDE's range, exclusive.
- * @param episilon The tolerance. Default is 1e-10.
- * @param max_iter The maximum number of iterations. Default is 20.
- * @returns The approximated root (i.e. JDE). */
-inline auto newton_method(
-  const FuncType& f,              // The f function to find root(s) for.
-  const double start_jde,         // The left bound of JDE's range, inclusive.
-  const double end_jde,           // The right bound of JDE's range, exclusive.
-  const double episilon = 1e-15,  // The tolerance.
-  const std::size_t max_iter = 30 // The maximum number of iterations.
-) -> double {
-  // `pull_back` ensures the returned JDE is in valid range.
-  const auto pull_back = [&](const double jde) -> double {
-    if (jde < start_jde) {
-      return start_jde;
-    }
-    if (jde >= end_jde) {
-      return end_jde - 1e-20;
-    }
-    return jde;
-  };
-
-  // The step size. It is adaptive and gets smaller and smaller as it approaches the root.
-  double h = 5e-4;
-
-  // `next` returns (has_next, next_jde)
-  const auto next = [&](const double jde) -> std::pair<bool, double> {
-    const double f_jde = f(jde);
-
-    // Do the Newton's method.
-    const double f_prime_jde = (f(jde + h) - f(jde - h)) / (2.0 * h); // Approximate the derivative.
-    const double next_jde = jde - f_jde / f_prime_jde;                // Approximate our next guess.
-
-    if (std::fabs(next_jde - jde) < episilon) {
-      return { false, pull_back(next_jde) };
-    }
-
-    return { true, pull_back(next_jde) }; // Don't forget to pull the jde back to valid range.
-  };
-
-  // Start approximating the root.
-
-  double jde = (start_jde + end_jde) / 2.0; // Initial guess.
-
-  for (std::size_t iter_count = 0; iter_count < max_iter; iter_count++) {
-    // Do the Newton's method.
-    const auto& [has_next, next_jde] = next(jde);
-    jde = next_jde;
-
-    if (!has_next) {
-      break;
-    }
-
-    // Update the step size.
-    // Make the step size adaptive, for faster convergence.
-    if (h > 1e-10) {
-      h /= std::numbers::phi;
-    }
-  }
-
-  // We cannot find the accurate root in the above iterations.
-  // Return our best estimation.
-  return jde;
-}
-
-
-/** 
+/**
  * @brief Find the roots (i.e. JDEs) for the given `year` and `expected_lon`. 
  * @param year The year, in gregorian calendar.
  * @param expected_lon The expected solar longitude, in degrees.
@@ -387,7 +315,9 @@ inline auto find_roots(const int32_t year, const double expected_lon) -> std::ve
   auto apply_nm = [&](const FuncType& f) {
     const double start_jde = get_start_jde(year);
     const double end_jde   = get_end_jde(year);
-    return newton_method(f, start_jde, end_jde);
+    return astro::toolbox::newton_method(
+      f, start_jde, end_jde, astro::toolbox::SOLAR_MEAN_MOTION_DEG_PER_DAY
+    );
   };
 
   using namespace std::ranges;

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -24,8 +24,13 @@
 #pragma once
 
 #include <cmath>
+#include <limits>
+#include <cstddef>
 #include <numbers>
+#include <concepts>
+#include <algorithm>
 #include <stdexcept>
+#include <type_traits>
 
 namespace astro::toolbox {
 
@@ -68,6 +73,21 @@ constexpr auto rad_to_deg(const double rad) -> double {
  * @ref Jean Meeus, "Astronomical Algorithms", Ch.12.
  */
 constexpr double SIDEREAL_RATE_DEG_PER_DAY = 360.98564736629;
+
+/**
+ * @brief The Sun's mean apparent motion along the ecliptic, in degrees per day.
+ *        A tropical year of 365.2422 days carries it through a full 360°.
+ * @note This is a mean rate — the true rate varies by about ±1.7% over a year, since Earth's
+ *       orbit is an ellipse and perihelion passage is faster than aphelion passage.
+ */
+constexpr double SOLAR_MEAN_MOTION_DEG_PER_DAY = 360.0 / 365.2422;
+
+/**
+ * @brief The mean rate at which the Moon's apparent longitude pulls away from the Sun's,
+ *        in degrees per day. A synodic month of 29.530588853 days closes a full 360°.
+ * @note This is a mean rate — near perigee the Moon runs at roughly 1.2× this value.
+ */
+constexpr double MOON_ELONGATION_RATE_DEG_PER_DAY = 360.0 / 29.530588853;
 
 /** @brief The number of minutes in a degree. */
 constexpr uint32_t MIN_PER_DEG = 60;
@@ -279,6 +299,117 @@ struct SphericalCoordinate {
   Angle<AngleUnit::DEG>      β; // Latitude
   Distance<DistanceUnit::AU> r; // Radius/Distance
 };
+
+#pragma endregion
+
+
+#pragma region Root Finding
+
+/**
+ * @brief The gap between `x` and the next representable double — one unit in the last place.
+ * @param x The value to measure at.
+ * @return The ulp at `x`, always positive.
+ * @note Doubles carry 52 fraction bits, so the ulp doubles every time the exponent does.
+ *       At JDE 2451545 (J2000.0) it is 4.7e-10 day (~40 μs); once `jde` crosses
+ *       2^22 = 4194304 — that is 6771-07-07 — it steps up to 9.3e-10 day.
+ */
+inline auto ulp(const double x) -> double {
+  const double magnitude = std::fabs(x);
+  return std::nextafter(magnitude, std::numeric_limits<double>::infinity()) - magnitude;
+}
+
+/** @brief The initial half-width of the central difference approximating f', in days. */
+inline constexpr double NEWTON_INITIAL_STEP_DAYS = 5e-4;
+
+/** @brief The floor on that half-width, as a multiple of `ulp(jde)`. */
+inline constexpr double NEWTON_MIN_STEP_ULP = 8.0;
+
+/**
+ * @brief The residual tolerance, as a multiple of the angle swept during one `ulp(jde)`.
+ * @note About as tight as it goes — `f` bottoms out near half an ulp's worth.
+ */
+inline constexpr double NEWTON_RESIDUAL_TOL_ULP = 1.0;
+
+/** @brief The iteration budget. Convergence is measured at 5 iterations or fewer. */
+inline constexpr std::size_t NEWTON_MAX_ITERATIONS = 30;
+
+/**
+ * @brief Apply Newton's method to find the JDE at which `f` crosses zero.
+ * @param f The function to find the root of. Must be smooth over [start_jde, end_jde) — callers
+ *          that work with a wrapping angle are responsible for unwrapping it first.
+ * @param start_jde The left bound of the search, inclusive.
+ * @param end_jde The right bound of the search, exclusive.
+ * @param mean_rate_deg_per_day The mean rate at which `f` sweeps. This sets the scale of the
+ *        residual tolerance; it is not used as the derivative.
+ * @param max_iterations The iteration budget.
+ * @return The JDE of the root, always within [start_jde, end_jde).
+ * @note It is the caller's responsibility to ensure a root exists in the range.
+ */
+// The `_jde` / `_deg_per_day` suffixes carry the contract at the call site.
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
+template <typename Func>
+requires std::invocable<Func, double>
+     and std::convertible_to<std::invoke_result_t<Func, double>, double>
+inline auto newton_method(
+  const Func& f,
+  const double start_jde,
+  const double end_jde,
+  const double mean_rate_deg_per_day,
+  const std::size_t max_iterations = NEWTON_MAX_ITERATIONS
+) -> double {
+  // Keep a candidate inside [start_jde, end_jde). Backing off `end_jde` by a small constant
+  // would be a no-op — at JDE 2.4e6 anything under 4.7e-10 vanishes in the rounding.
+  const auto pull_back = [&](const double jde) -> double {
+    if (jde < start_jde) {
+      return start_jde;
+    }
+    if (jde >= end_jde) {
+      return std::nextafter(end_jde, start_jde);
+    }
+    return jde;
+  };
+
+  double step = NEWTON_INITIAL_STEP_DAYS;
+  double jde  = (start_jde + end_jde) / 2.0;
+
+  // Newton can walk away from a root it has already reached, so keep the best iterate rather
+  // than the last one — otherwise one bad late round overwrites a correct answer.
+  double best_jde      = jde;
+  double best_residual = std::numeric_limits<double>::infinity();
+
+  for (std::size_t i = 0; i < max_iterations; ++i) {
+    const double residual = f(jde);
+
+    if (std::fabs(residual) < best_residual) {
+      best_residual = std::fabs(residual);
+      best_jde      = jde;
+    }
+
+    // Stop on the residual, not on the step size: `f` cannot be driven closer to zero than the
+    // angle swept during one ulp of `jde` — 4.6e-10° for the Sun, 5.7e-9° for the Moon's
+    // elongation — so a step threshold below that is unreachable by construction.
+    if (std::fabs(residual) <= NEWTON_RESIDUAL_TOL_ULP * mean_rate_deg_per_day * ulp(jde)) {
+      break;
+    }
+
+    // Shrinking the step by the golden ratio is what keeps the run short: at most 5 iterations
+    // over years 401-9050, against 7 for a fixed step. The floor is what keeps it honest — below
+    // ½ulp(jde) both samples round back to `jde` and f' collapses to exactly zero.
+    const double h = std::max(step, NEWTON_MIN_STEP_ULP * ulp(jde));
+    const double f_prime = (f(jde + h) - f(jde - h)) / (2.0 * h);
+
+    jde   = pull_back(jde - residual / f_prime);
+    step /= std::numbers::phi;
+  }
+
+  // The final iterate never had its residual measured — let it compete too.
+  if (std::fabs(f(jde)) < best_residual) {
+    return jde;
+  }
+
+  return best_jde;
+}
+// NOLINTEND(bugprone-easily-swappable-parameters)
 
 #pragma endregion
 

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -398,6 +398,12 @@ inline auto newton_method(
     const double h = std::max(step, NEWTON_MIN_STEP_ULP * ulp(jde));
     const double f_prime = (f(jde + h) - f(jde - h)) / (2.0 * h);
 
+    // A shared solver has to tolerate an `f` that is not defined everywhere -- #43's rise/set `f`
+    // goes NaN where a body is circumpolar -- and a collapsed f' has no direction left to offer.
+    if (not std::isfinite(f_prime) or f_prime == 0.0) {
+      break;
+    }
+
     jde   = pull_back(jde - residual / f_prime);
     step /= std::numbers::phi;
   }

--- a/src/test/astro/moon_phase_test.cpp
+++ b/src/test/astro/moon_phase_test.cpp
@@ -187,4 +187,46 @@ TEST(NewMoon, MomentsAcrossTheUlpStep) {
   }
 }
 
+
+TEST(NewMoon, BracketEndpointsClearNewtonTolerance) {
+  // Issue #63. The bracket used to be laid out around the mean-rate estimate, so its endpoints sat
+  // however far that estimate had missed, plus whatever the Moon's rate varied over the bracket
+  // itself. Measured across 401-9999 that left one endpoint within 0.67 deg of the tolerance
+  // `newton_method` demands -- a margin nobody chose, and one that would have let `f` go
+  // discontinuous inside its own bracket had it ever been crossed.
+  //
+  // `first_root_range_after` now steps the estimate onto the root before bracketing it, so the
+  // endpoints' distance from conjunction follows from BRACKET_HALF_WIDTH_DAYS. The tightest
+  // endpoint measured over the same span is 6.11 deg inside the limit; asserting half of that
+  // pins the design without pinning the measurement.
+  constexpr double REQUIRED_MARGIN_DEG = 3.0;
+
+  // Fixed years spanning the supported range, plus a random one to reach where they do not.
+  std::vector<int32_t> years { 401, 1900, 2026, 6771, 6772, 9420, 9980 };
+  years.push_back(util::random(401, 9980));
+
+  for (const auto year : years) {
+    double jde = astro::julian_day::ut1_to_jde(calendar::Datetime { util::to_ymd(year, 1, 1), 0.0 });
+
+    for (int i = 0; i < 15; ++i) {
+      const auto [left, right] = first_root_range_after(jde);
+
+      // Laying the bracket out around the refined estimate is what decouples it from the miss:
+      // its width is now BRACKET_HALF_WIDTH_DAYS either side, where it used to be twice however
+      // far the mean-rate extrapolation had landed from conjunction.
+      ASSERT_NEAR(right - left, 2.0 * BRACKET_HALF_WIDTH_DAYS, 1e-9);
+
+      ASSERT_GT(longitude_diff(left),  360.0 - BRACKET_TOLERANCE_DEG + REQUIRED_MARGIN_DEG);
+      ASSERT_LT(longitude_diff(right), BRACKET_TOLERANCE_DEG - REQUIRED_MARGIN_DEG);
+
+      // The bracket must still contain the root it was built for.
+      const double root = newton_method(left, right);
+      ASSERT_GT(root, left);
+      ASSERT_LT(root, right);
+
+      jde = root + 1.0;
+    }
+  }
+}
+
 } // namespace astro::moon_phase::test

--- a/src/test/astro/moon_phase_test.cpp
+++ b/src/test/astro/moon_phase_test.cpp
@@ -157,4 +157,34 @@ TEST(NewMoon, DiffTest2) {
   }
 }
 
+
+TEST(NewMoon, MomentsAcrossTheUlpStep) {
+  // Regression for issues #76 / #63. The conjunction solver shares its parameters with the solar
+  // one, so it shared the failure: past JD 2^22 (6771-07-07) the difference step fell below half
+  // an ulp, f' collapsed, and the candidate was clamped to the edge of its bracket. A conjunction
+  // spoiled that way then failed `next_root`'s "is this a root" guard, `moments` threw, and every
+  // remaining conjunction of that year was silently lost -- 6700-6850 used to yield 1807 roots
+  // where it now yields 1868.
+  const std::vector<int32_t> years { 6770, 6771, 6772, 6773, 8000, 9040, 9050 };
+
+  for (const auto year : years) {
+    const auto roots = moments(year); // must not throw
+    ASSERT_GE(roots.size(), 12U); // a Gregorian year holds 12 or 13 conjunctions
+    ASSERT_LE(roots.size(), 13U);
+
+    for (const auto root : roots) {
+      // One ulp of JDE moves the Moon 5.7e-9 deg away from the Sun, and past the step twice that,
+      // so the residual cannot be driven below roughly 1.1e-8 deg. The existing conjunction tests
+      // assert 1e-5, which this stays well inside.
+      const auto diff = longitude_diff(root);
+      ASSERT_TRUE((diff < 1e-7) or (diff > 360.0 - 1e-7));
+    }
+
+    // Consecutive conjunctions stay one synodic month apart -- a clamped root would break this.
+    for (auto it = cbegin(roots); std::next(it) != cend(roots); ++it) {
+      ASSERT_NEAR(*std::next(it) - *it, 29.5, 0.75);
+    }
+  }
+}
+
 } // namespace astro::moon_phase::test

--- a/src/test/astro/sun_test.cpp
+++ b/src/test/astro/sun_test.cpp
@@ -974,4 +974,35 @@ TEST(Sun, FindRoots) {
 }
 
 
+TEST(Sun, FindRootsAcrossTheUlpStep) {
+  // Regression for issue #76. Julian Day 4194304 = 2^22 falls on 6771-07-07, and the ulp of a JDE
+  // doubles there, from 4.7e-10 to 9.3e-10 day. The old solver shrank its difference step below
+  // half an ulp, so both samples rounded onto the same double, f' came out exactly zero, and the
+  // candidate went to infinity and got clamped to the year boundary. Year 9420 at 105 deg was
+  // measured 185 days off; 6772-9999 held 2357 such roots out of 77223.
+  //
+  // The years below straddle that step. This is a self-consistency check rather than an external
+  // dataset: what is asserted is that the JDE handed back really is a root of the very function
+  // the solver was asked to solve, which is exactly what the old code stopped guaranteeing.
+  const std::vector<int32_t> years { 6770, 6771, 6772, 6773, 8000, 9420, 9999 };
+
+  for (const auto year : years) {
+    for (int32_t idx = 0; idx < 24; idx++) {
+      const double expected_lon = 15.0 * idx;
+
+      for (const auto root : find_roots(year, expected_lon)) {
+        ASSERT_GE(root, get_start_jde(year));
+        ASSERT_LT(root, get_end_jde(year));
+
+        // Past the step one ulp of JDE carries the Sun 9.1e-10 deg, so the residual floor doubles
+        // along with it. The measured worst case over the whole of 6772-9999 is 1.6e-9 deg
+        // (0.14 ms of solar motion); 1e-8 leaves that a factor of six of headroom.
+        const auto lon_diff = std::fabs(std::fmod(solar_longitude(root) - expected_lon, 360.0));
+        ASSERT_TRUE((lon_diff < 1e-8) or (lon_diff > 360.0 - 1e-8));
+      }
+    }
+  }
+}
+
+
 } // namespace astro::sun::test

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <cmath>
 #include "toolbox.hpp"
 #include "util.hpp"
 
@@ -180,6 +181,83 @@ TEST(AstroMath, AngleOperators) {
     ASSERT_EQ(angle.as<RAD>() * 2.0, (angle * 2.0).as<RAD>());
     ASSERT_EQ(angle.as<RAD>() / 2.0, (angle / 2.0).as<RAD>());
   }
+}
+
+
+TEST(AstroMath, Ulp) {
+  // A double carries 52 fraction bits, so the ulp is 2^(exponent-52) and doubles with the exponent.
+  ASSERT_EQ(ulp(2451545.0), std::pow(2.0, -31)); // J2000.0 sits in [2^21, 2^22): 4.66e-10 day.
+  ASSERT_EQ(ulp(4194303.0), std::pow(2.0, -31)); // Just below 2^22.
+  ASSERT_EQ(ulp(4194305.0), std::pow(2.0, -30)); // Just above: 9.31e-10 day, i.e. 6771-07-07.
+
+  // Always positive, and symmetric about zero.
+  ASSERT_GT(ulp(-2451545.0), 0.0);
+  ASSERT_EQ(ulp(-2451545.0), ulp(2451545.0));
+}
+
+
+TEST(AstroMath, NewtonMethodConverges) {
+  // A smooth, slightly non-linear function, so the solver has to actually iterate.
+  const double root = 2451545.25;
+  const auto f = [&](const double jde) -> double {
+    const double d = jde - root;
+    return d + 0.001 * d * d;
+  };
+
+  const double found = newton_method(f, 2451545.0, 2451546.0, 1.0);
+  ASSERT_NEAR(found, root, 1e-9);
+}
+
+
+TEST(AstroMath, NewtonMethodKeepsBestIterate) {
+  // Reproduces the failure mode measured on issue #76: once the iterate lands on a stretch where
+  // `f` reads flat, both difference samples come out equal, f' collapses to exactly zero, and the
+  // next candidate is +/-inf — which `pull_back` then clamps to an interval edge. The solver must
+  // hand back the closest approach it already made, not whatever the last round produced.
+  const double root = 2451545.5;
+  const auto f = [&](const double jde) -> double {
+    const double d = jde - root;
+    return (std::fabs(d) < 1e-6) ? 1e-6 : d; // flat plateau, far wider than the difference step
+  };
+
+  constexpr double start_jde = 2451545.0;
+  constexpr double end_jde   = 2451546.0;
+  const double found = newton_method(f, start_jde, end_jde, 1.0);
+
+  ASSERT_NEAR(found, root, 1e-5);
+  ASSERT_GT(found, start_jde); // not clamped to an edge
+  ASSERT_LT(found, end_jde);
+}
+
+
+TEST(AstroMath, NewtonMethodStepIsFlooredAtUlp) {
+  // At this magnitude one ulp is 0.125, so `NEWTON_MIN_STEP_ULP * ulp(jde)` is 1.0 — three orders
+  // of magnitude above `NEWTON_INITIAL_STEP_DAYS`. The floor therefore governs from the first
+  // round, which is the branch that never runs at real JDE magnitudes.
+  constexpr double huge_jde = 1e15;
+  ASSERT_EQ(ulp(huge_jde), 0.125);
+  ASSERT_GT(NEWTON_MIN_STEP_ULP * ulp(huge_jde), NEWTON_INITIAL_STEP_DAYS);
+
+  const double root = huge_jde + 400.0;
+  const auto f = [&](const double jde) -> double { return jde - root; };
+
+  const double found = newton_method(f, huge_jde, huge_jde + 1000.0, 1.0);
+
+  // Without the floor the samples would land on the same representable double and f' would be 0.
+  ASSERT_NEAR(found, root, 1.0);
+}
+
+
+TEST(AstroMath, NewtonMethodStaysInRange) {
+  // The half-open contract: `end_jde` itself must never be returned, however hard f pushes right.
+  constexpr double start_jde = 2451545.0;
+  constexpr double end_jde   = 2451546.0;
+
+  const auto pushes_right = [](const double jde) -> double { return -1.0 - (end_jde - jde); };
+  const double found = newton_method(pushes_right, start_jde, end_jde, 1.0);
+
+  ASSERT_GE(found, start_jde);
+  ASSERT_LT(found, end_jde);
 }
 
 } // namespace astro::toolbox::test

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -186,9 +186,11 @@ TEST(AstroMath, AngleOperators) {
 
 TEST(AstroMath, Ulp) {
   // A double carries 52 fraction bits, so the ulp is 2^(exponent-52) and doubles with the exponent.
-  ASSERT_EQ(ulp(2451545.0), std::pow(2.0, -31)); // J2000.0 sits in [2^21, 2^22): 4.66e-10 day.
-  ASSERT_EQ(ulp(4194303.0), std::pow(2.0, -31)); // Just below 2^22.
-  ASSERT_EQ(ulp(4194305.0), std::pow(2.0, -30)); // Just above: 9.31e-10 day, i.e. 6771-07-07.
+  // Hex float literals rather than `std::pow`: exact by construction, so `ASSERT_EQ` does not rest
+  // on libm rounding the integer exponent bit-exactly.
+  ASSERT_EQ(ulp(2451545.0), 0x1p-31); // J2000.0 sits in [2^21, 2^22): 4.66e-10 day.
+  ASSERT_EQ(ulp(4194303.0), 0x1p-31); // Just below 2^22.
+  ASSERT_EQ(ulp(4194305.0), 0x1p-30); // Just above: 9.31e-10 day, i.e. 6771-07-07.
 
   // Always positive, and symmetric about zero.
   ASSERT_GT(ulp(-2451545.0), 0.0);
@@ -210,19 +212,45 @@ TEST(AstroMath, NewtonMethodConverges) {
 
 
 TEST(AstroMath, NewtonMethodKeepsBestIterate) {
-  // Reproduces the failure mode measured on issue #76: once the iterate lands on a stretch where
-  // `f` reads flat, both difference samples come out equal, f' collapses to exactly zero, and the
-  // next candidate is +/-inf — which `pull_back` then clamps to an interval edge. The solver must
-  // hand back the closest approach it already made, not whatever the last round produced.
+  // The contract is that the closest approach survives, so the divergence has to be one the solver
+  // cannot walk back from. `f` reads a small non-zero residual on a narrow plateau at the root --
+  // enough that the solver keeps iterating -- and everywhere else it pushes right hard enough to
+  // overshoot `end_jde`, which from the clamped edge only ever overshoots again. Iteration 0 lands
+  // on the root, iteration 1 leaves for the edge and stays: only a retained iterate can come back.
+  constexpr double start_jde = 2451545.0;
+  constexpr double end_jde   = 2451546.0;
+  constexpr double root      = (start_jde + end_jde) / 2.0; // the solver's own first iterate
+
+  const auto visits_root_then_diverges = [](const double jde) -> double {
+    if (std::fabs(jde - root) < 1e-6) {
+      return 1e-6;                 // above the residual tolerance, so this is not a stopping point
+    }
+    return -1.0 - (end_jde - jde); // f' == 1, and the step overshoots `end_jde` from anywhere
+  };
+
+  const double found = newton_method(visits_root_then_diverges, start_jde, end_jde, 1.0);
+
+  ASSERT_NEAR(found, root, 1e-5); // the iterate that was kept, not the edge the run ended on
+  ASSERT_GT(found, start_jde);
+  ASSERT_LT(found, end_jde);
+}
+
+
+TEST(AstroMath, NewtonMethodSurvivesCollapsedDerivative) {
+  // The mechanism behind #76: on a stretch where `f` reads flat both difference samples come out
+  // equal, f' is exactly zero, and the Newton step is undefined.
+  // This covers the collapse path only, not the retention contract above: from a clamped edge
+  // Newton steps straight back onto the root, so which iterate the run ends on comes down to where
+  // the budget runs out in that cycle -- the parity that made #76 surface in only 3% of years.
   const double root = 2451545.5;
-  const auto f = [&](const double jde) -> double {
+  const auto flat_at_root = [&](const double jde) -> double {
     const double d = jde - root;
-    return (std::fabs(d) < 1e-6) ? 1e-6 : d; // flat plateau, far wider than the difference step
+    return (std::fabs(d) < 1e-6) ? 1e-6 : d; // plateau far wider than the floored difference step
   };
 
   constexpr double start_jde = 2451545.0;
   constexpr double end_jde   = 2451546.0;
-  const double found = newton_method(f, start_jde, end_jde, 1.0);
+  const double found = newton_method(flat_at_root, start_jde, end_jde, 1.0);
 
   ASSERT_NEAR(found, root, 1e-5);
   ASSERT_GT(found, start_jde); // not clamped to an edge


### PR DESCRIPTION
Closes #76. Closes #63.

Two commits, both in the conjunction/jieqi root-finding path. The first fixes the solver; the second fixes how its input bracket is built. They are separable — the first stands on its own if you would rather take only that.

---

# 1. The solver returned the wrong iterate (#76)

`newton_method` returned its **last** iterate rather than its closest approach.

Past `JD 2^22 = 4194304` (6771-07-07) the ulp of a JDE doubles from 4.7e-10 to 9.3e-10 day. The difference step shrank by φ every round against only an absolute `1e-10` floor, so it fell below half an ulp, `jde ± h` both rounded onto the same double, `f'` came out exactly zero, the candidate went to infinity, and `pull_back` clamped it to an interval edge. The root reached on iteration 1 was overwritten by iteration 29.

Three defects stacked, but only the third is fatal — the first two are harmless alone:

| | defect | on its own |
|---|---|---|
| a | `epsilon = 1e-15` is sub-ULP, so the step test almost never fires | wastes ~25 rounds |
| b | step collapses below ½ulp → `f' ≡ 0` | harmless if the answer is kept |
| c | **returns the last iterate, not the best one** | **turns a + b into wrong values** |

### Measured over the full supported span

| scan | before | after |
|---|---|---|
| sun 401–6771 | 0 bad / 152904 | 0 bad / 152904, max residual 7.2e-10° |
| sun 6772–9999 | **2357 bad / 77223** | **0 bad / 77473**, max residual 1.6e-9° |
| moon 6700–9050 | bad values + throws | **0 bad, 0 throws**, max residual 1.1e-8° |

A clamped conjunction also failed `next_root`'s "is this a root" guard, so `moments` threw and **silently dropped the rest of that year**: 6700–6850 used to yield 1807 conjunctions where it now yields 1868.

### What changed

The solvers in `sun.hpp` and `moon_phase.hpp` were parameter-for-parameter copies, so both carried the defect. They are now one implementation in `astro::toolbox`, which Phase 5's `transit_jde` / `rise_set_jde` (#43) can share instead of copying it a third and fourth time.

- keep the minimum-residual iterate
- stop on the **residual**, not the step size. `f` cannot be driven closer to zero than the angle swept during one ulp of `jde` — 4.6e-10° for the Sun, 5.7e-9° for the Moon's elongation — so the old `1e-15` step threshold was unreachable by construction
- floor the difference step at `8 · ulp(jde)`. **The φ shrink stays**: measured, it converges in at most 5 iterations against 7 for a fixed step
- `pull_back` uses `std::nextafter`; subtracting `1e-20` from `end_jde` was a no-op at JDE magnitudes, so the half-open contract was never actually held

Tolerance is `1 · rate · ulp(jde)` rather than a looser multiple: at `4` every root still lands within 1.9e-9° (0.16 ms), but that breaks `JieQi.JDE`, which asserts 1e-9°. Tightening the solver was the right side to fix — no existing tolerance was touched.

---

# 2. The bracket was laid out around the estimate, not the root (#63)

`first_root_range_after` bracketed the mean-rate estimate directly, so the endpoints sat however far that estimate had missed, plus whatever the Moon's rate varied across the bracket itself.

That put the tightest endpoint **0.666° inside the 15° tolerance `newton_method` demands** — measured across 128323 brackets spanning years 401–9999. Zero violations, but a margin nobody chose, and one that would not merely have thrown had it been crossed: `f` unwraps at the same 15°, so an endpoint on the far side puts a discontinuity of `f` inside its own bracket.

The estimate is now stepped onto the root before it is bracketed, so the endpoints' distance from conjunction follows from `BRACKET_HALF_WIDTH_DAYS`:

| | before | after |
|---|---|---|
| tightest left endpoint | 345.666° (margin **0.666°**) | 351.111° (margin **6.111°**) |
| widest right endpoint | 13.578° (margin **1.422°**) | 8.868° (margin **6.132°**) |

The two margins come out symmetric, which is the point — the endpoints are placed by the half-width rather than by how far the extrapolation happened to land. The half-width is bounded on both sides and both bounds are stated on the constant: too narrow and the bracket stops containing the root, too wide and the endpoints drift past the tolerance. It also collapses three branches into one, since the `== 0.0` special case and the mirrored `< 30` / `> 330` pair all become a single signed miss.

**No conjunction moves.** Across all 118724 roots of years 401–9999: 0 year mismatches, 2866 roots shift, largest shift 9.3e-10 day — two ulp, 0.08 ms, against the 0.0005 day tolerance the existing dataset test holds them to.

### On #63's original framing

The issue reasoned that an estimate landing in `[15°,30°)` is reachable because the Moon can run at 1.2× the mean rate. Measured, the estimate never misses by more than 11.18°: the extrapolation spans a full synodic month, so the fast and slow arcs largely cancel. What was actually close to the edge was not the estimate but the **endpoint**, which carries the estimate's miss *plus* the rate variation across the bracket — that is the 0.666°. Both issue comments record the measurements, the second correcting the first.

---

# 3. Review feedback

Three findings from the automated review, all in commit 3:

- the exception in `first_root_range_after` reported the raw elongation where the check tests the signed miss, so an estimate falling 40° short would have read "sits 320 deg from conjunction"
- `newton_method` now breaks on a non-finite or collapsed f' instead of dividing by it. Not reachable from either current caller — the residual break guarantees a non-zero numerator, so `residual / 0` is `±inf` and `pull_back` clamps it back inside — but #43's rise/set `f` goes NaN where a body is circumpolar, and the loop would then spend its full budget on comparisons that all read false before returning a stale iterate
- `AstroMath.Ulp` compared against `std::pow(2.0, -31)`, which is not guaranteed bit-exact for an integer exponent. Hex float literals are, by construction

---

# Tests

Nine added; the suite still runs ~3 s **faster** than before, since the solver now converges in 3–4 iterations instead of spinning out to 27.

- `AstroMath.Ulp` — the 2^22 step
- `AstroMath.NewtonMethodConverges`
- `AstroMath.NewtonMethodKeepsBestIterate` — the retention contract: the solver visits the root, then diverges irrecoverably
- `AstroMath.NewtonMethodSurvivesCollapsedDerivative` — the f' collapse path itself
- `AstroMath.NewtonMethodStepIsFlooredAtUlp` — forces the floor to engage, which never happens at real JDE magnitudes
- `AstroMath.NewtonMethodStaysInRange` — the half-open contract
- `Sun.FindRootsAcrossTheUlpStep` — years 6770–9999
- `NewMoon.MomentsAcrossTheUlpStep` — years 6770–9050
- `NewMoon.BracketEndpointsClearNewtonTolerance` — the bracket invariant

Every regression test was checked against the code it is meant to catch, by compiling the same probe against the parent commit:

- on `HEAD` before commit 1, sun years 6772 / 9420 / 9999 are off by 48° / 180° / 150°, and moon years 6773 / 9050 throw
- the bracket test's first draft asserted only the endpoint margin, which the old construction satisfied 99.89% of the time — a random start year would have caught it just **4.5%** of runs. Adding the structural assertion (the bracket's width is now fixed at `2 · BRACKET_HALF_WIDTH_DAYS`, where it used to be twice the miss) takes detection to **100%**: 54760/54760 brackets, 1369/1369 start years

## Correction: `NewtonMethodKeepsBestIterate` detected nothing

That claim did not hold for this one test, and commit 3 fixes it. As first written it asserted on a plateau construction where `f` reads flat at the root — and it **passed with the best-iterate logic removed**. Detection was 0%, not 100%.

Tracing the iterates shows why. f' does collapse and `pull_back` does clamp the candidate to the left edge, but from that edge the residual is −0.5 against f' = 1, so the next step lands straight back on the root. The construction is self-healing, and which iterate the run ends on is decided by where the 30-round budget falls in that two-cycle:

```
iter 16: jde-root=-7.194e-07  f'=+0.000e+00  <-- COLLAPSED  -> clamped LEFT
iter 17: jde-root=-5.000e-01  f'=+1.001e+00                 -> jde-root=-5.253e-04
  ...
iter 28: jde-root=+0.000e+00  f'=+0.000e+00  <-- COLLAPSED  -> clamped LEFT
iter 29: jde-root=-5.000e-01  f'=+1.000e+00                 -> jde-root=+0.000e+00
```

That parity is the missing half of the explanation for the measured failure rate at the top of this description: it is why #76 wrecked 2357 of 77223 sun roots — 3% — rather than every root past the ulp step. Only the years whose budget ran out on the clamped side of the cycle returned an edge.

Retargeted onto a divergence the solver cannot walk back from: `f` reads a small non-zero residual on a narrow plateau at the root — enough that the run continues — and everywhere else it overshoots `end_jde`, which from the clamped edge only overshoots again. Iteration 0 lands on the root, iteration 1 leaves for good, so only a retained iterate can come back.

| | best-iterate logic | f' guard | `KeepsBestIterate` |
|---|---|---|---|
| as merged | present | present | pass |
| defect reinjected | **removed** | present | **fail** |
| defect reinjected | **removed** | removed | **fail** |

Detection is now 100% and independent of the f' guard, which matters because the guard is what surfaced the problem: it breaks before the clamp, so it would have masked this construction outright. The plateau construction stays on as `NewtonMethodSurvivesCollapsedDerivative`, covering the collapse path, with a comment saying plainly that it does not cover the retention contract.

# Note, unrelated to this PR

`./linter.py --all` fails on `src/util/cache.hpp:50` (`bugprone-exception-escape`). It reproduces identically on `HEAD`, so it is pre-existing, and it is almost certainly MSVC-STL-only — the check hinges on whether `std::unordered_map`'s move constructor is `noexcept`, which differs from libstdc++, so Linux CI stays green. That belongs to #78. Every file in this PR lints clean.

