### PR TITLE
build(test): keep asserts live in test builds; remove dead macros; rename ADD_TEST (#89)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,11 @@ toolbox/        Helper scripts for artifacts, releases, build info
    do not commit them.
 7. **Use `project.py` for routine work.** It handles environment checks, version propagation,
    and test filtering consistently across platforms.
+8. **Assertions:** the default build is `Release` (`automation/build.py`), so `assert` is dead
+   code in production. Test targets strip `NDEBUG` (`src/test/CMakeLists.txt`, #89), so asserts
+   ARE live inside test binaries — `build_integrity_test.cpp` guards this. The error contract:
+   public input validation must `throw` (fail-fast, independent of build type); `assert` is only
+   for internal invariants, never as an input guard.
 
 ## AI do / don't
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,8 +248,9 @@ toolbox/        Helper scripts for artifacts, releases, build info
    and test filtering consistently across platforms.
 8. **Assertions:** the default build is `Release` (`automation/build.py`), so `assert` is dead
    code in production. Test targets strip `NDEBUG` (`src/test/CMakeLists.txt`, #89), so asserts
-   ARE live inside test binaries — `build_integrity_test.cpp` guards this. The error contract:
-   public input validation must `throw` (fail-fast, independent of build type); `assert` is only
+   ARE live inside test binaries — `build_integrity_test.cpp` guards this. The error contract
+   (target state; legacy violations are being migrated in #77, #67, #64, #70): public input
+   validation must `throw` (fail-fast, independent of build type); `assert` is only
    for internal invariants, never as an input guard.
 
 ## AI do / don't

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -7,8 +7,15 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
   cmake_policy(SET CMP0135 NEW)
 endif()
 
-add_compile_definitions(TESTING=1)
-add_compile_definitions(DEBUG=1)
+# #89: The default build type is Release (`automation/build.py`), which defines NDEBUG and would
+# turn every `assert` in the library headers into dead code — even inside test binaries. Strip
+# NDEBUG for test targets so internal-invariant asserts stay verifiable; production targets
+# (`shared_lib`) keep NDEBUG untouched.
+if (MSVC)
+  add_compile_options(/UNDEBUG)
+else()
+  add_compile_options(-UNDEBUG)
+endif()
 
 include(FetchContent)
 FetchContent_Declare(
@@ -28,7 +35,9 @@ target_compile_options(gmock_main PRIVATE -w)
 enable_testing()
 include(GoogleTest)
 
-macro(ADD_TEST test_path test_name)
+# Named `CELESTIAL_ADD_TEST`, not `ADD_TEST`: CMake command names are case-insensitive, so a macro
+# called `ADD_TEST` would shadow the built-in `add_test` for the rest of this directory scope. (#89)
+macro(CELESTIAL_ADD_TEST test_path test_name)
   message("Adding ${test_name}")
   add_executable(${test_name} ${test_path})
   target_link_libraries(
@@ -43,5 +52,5 @@ file(GLOB_RECURSE SRC_PATHS "*.cpp")
 foreach(src_path IN LISTS SRC_PATHS)
   get_filename_component(test_name ${src_path} NAME_WE)
   message("Found test: ${src_path}")
-  ADD_TEST(${src_path} ${test_name})
+  CELESTIAL_ADD_TEST(${src_path} ${test_name})
 endforeach()

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -35,8 +35,9 @@ target_compile_options(gmock_main PRIVATE -w)
 enable_testing()
 include(GoogleTest)
 
-# Named `CELESTIAL_ADD_TEST`, not `ADD_TEST`: CMake command names are case-insensitive, so a macro
-# called `ADD_TEST` would shadow the built-in `add_test` for the rest of this directory scope. (#89)
+# Named `CELESTIAL_ADD_TEST`, not `ADD_TEST`: CMake command names are case-insensitive, and command
+# definitions are global once executed — a macro called `ADD_TEST` would shadow the built-in
+# `add_test` for everything processed afterwards (including sibling directories). (#89)
 macro(CELESTIAL_ADD_TEST test_path test_name)
   message("Adding ${test_name}")
   add_executable(${test_name} ${test_path})

--- a/src/test/build_integrity_test.cpp
+++ b/src/test/build_integrity_test.cpp
@@ -1,0 +1,17 @@
+#include <gtest/gtest.h>
+
+namespace build::test {
+
+// #89: The default build type is Release (automation/build.py), which defines NDEBUG and turns
+// every `assert` in the library headers into dead code — even inside test binaries.
+// `src/test/CMakeLists.txt` strips NDEBUG for test targets; this test fails loudly if that
+// ever regresses (e.g. someone reorders or removes the -UNDEBUG option).
+TEST(BuildIntegrity, AssertionsAreLive) {
+#ifdef NDEBUG
+  FAIL() << "Test binary built with NDEBUG: every internal-invariant `assert` is dead code here.";
+#else
+  SUCCEED();
+#endif
+}
+
+} // namespace build::test

--- a/src/test/build_integrity_test.cpp
+++ b/src/test/build_integrity_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2026 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 
 namespace build::test {


### PR DESCRIPTION
## 动机

#89：默认 Release 构建（`automation/build.py` → `-DNDEBUG`）让全库 21 处运行时 `assert` 在**测试二进制里同样是死代码**，`TESTING=1`/`DEBUG=1` 两行宏造成相反的印象（实际无人读取），`macro(ADD_TEST)` 遮蔽 CMake 内置 `add_test`。这直接挡住 #77 的验收（release 行为无法写成会失败的测试）。

## 改动（口径已与维护者确认：输入守卫陆续 throw 化走 #77/#67/#64/#70，本 PR 只做测试基建）

- `src/test/CMakeLists.txt`：对 test 目录加 `-UNDEBUG`（用 `add_compile_options` 且置于 FetchContent 之前——见下方 review 记录的 ODR 论证），测试 TU 的 assert 恢复生效；`shared_lib` 保持 NDEBUG 不变
- 删除 `TESTING=1` / `DEBUG=1` 死宏（全仓 grep 确认无人读取；`DEBUG=1` 还是颗雷：任何 `#include "lib.hpp"` 的测试都会撞上 `Verbosity::DEBUG` 枚举）
- `macro(ADD_TEST)` → `CELESTIAL_ADD_TEST`，消除对内置命令的（全局）遮蔽
- 新增 `build_integrity_test.cpp`：`#ifdef NDEBUG → FAIL()`，把「测试里 assert 是活的」变成可执行验收
- `AGENTS.md` 第 8 条：记录错误契约目标态（公共输入守卫必须 throw、assert 仅限内部不变量；存量违例迁移见 #77/#67/#64/#69/#70）

## 验证

- `./project.py --all`（官方入口，Windows clang++ 21.1.8 + MSVC STL）：全绿，131/131
- 检出率实测：同一测试在 HEAD 构建配置（无 `-UNDEBUG`）下 **1/1 失败**，本分支通过
- `ruff check` 绿；clang-tidy 21.1.8 与 HEAD 基线逐条 diff：**零新增**（本地红的 80 项全是 21.x 新版本检查与既有 MSVC 项，归 #73/#78）
- 其余四个平台以 CI 为准，特别是 `linters-and-static-analysis`——这是 clang-tidy 第一次以「assert 活着」的路径分析 `src/**`

## PR 前本地 review（Claude / Codex；Grok 本机 headless 异常，维护者批准跳过）

- Claude：**APPROVE**。采纳 3 条（GPL 头、CMake 注释作用域改为「全局」、AGENTS.md 措辞标注目标态）→ `f00511e`；清单外发现 `random.hpp` `min < max` 严格小于陷阱与公共输入 assert 违例清单 → 已落 #69、#89 评论
- Codex：需修改 → 已解决。有效 2 条（AGENTS.md 措辞、同 Claude）；**反驳 1 条**：建议 `-UNDEBUG` 改为每个测试 executable `target_compile_options(PRIVATE)` 以免动 gtest 编译配置——不采纳：gtest 库 NDEBUG + 测试 TU 非 NDEBUG 会让 gtest 头文件 inline 函数的 assert 展开 ODR 不一致，目录级且置于 FetchContent 之前是正确顺序（Claude 独立给出同一结论与编译行证据）