### PR TITLE
docs(agents): record ΔT algo4 provenance (AstroTime-Analysis)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,12 @@ This is precision astronomy, not vibes. Every algorithm traces to a named refere
   author, debug it carefully, and confirm case-by-case that it's an algorithm/reference issue,
   not a code bug. The default is to surface the discrepancy, not to make the test green.
 - Cite the source of any new algorithm / coefficients in a comment.
+- **ΔT provenance lives out-of-repo**: `delta_t.hpp` algo4 (the default) was curve-fitted in
+  [AstroTime-Analysis](https://github.com/0xf3cd/AstroTime-Analysis) (`DeltaT/models.ipynb`,
+  Bulletin A 2005.0–2024.5); in-repo `statistics/` holds evaluation notebooks only. That repo
+  also carries the raw IERS/USNO EOP data and the full VSOP87 coefficient files — the data
+  substrate for a #64 refit (two years of post-2024.5 truth now exist to measure algo4's
+  extrapolation error) and for coefficient-level audits under #94.
 
 ## Tech Stack
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,12 +45,15 @@ This is precision astronomy, not vibes. Every algorithm traces to a named refere
   author, debug it carefully, and confirm case-by-case that it's an algorithm/reference issue,
   not a code bug. The default is to surface the discrepancy, not to make the test green.
 - Cite the source of any new algorithm / coefficients in a comment.
-- **ΔT provenance lives out-of-repo**: `delta_t.hpp` algo4 (the default) was curve-fitted in
-  [AstroTime-Analysis](https://github.com/0xf3cd/AstroTime-Analysis) (`DeltaT/models.ipynb`,
-  Bulletin A 2005.0–2024.5); in-repo `statistics/` holds evaluation notebooks only. That repo
-  also carries the raw IERS/USNO EOP data and the full VSOP87 coefficient files — the data
-  substrate for a #64 refit (two years of post-2024.5 truth now exist to measure algo4's
-  extrapolation error) and for coefficient-level audits under #94.
+- **ΔT provenance lives out-of-repo**: `delta_t.hpp` algo4 (the default) is **two** polynomials
+  curve-fitted in [AstroTime-Analysis](https://github.com/0xf3cd/AstroTime-Analysis)
+  (`DeltaT/models.ipynb`): the pre-2024.0 branch fits Bulletin A *observations*
+  (2004.85–2024.42), the post-2024.0 branch fits USNO `deltat.preds` *predictions* — the
+  dispatch splits at 2024.0 (`delta_t.hpp:365/:372`); the header comment's "2024.5" describes
+  data coverage, not the boundary. In-repo `statistics/` holds evaluation notebooks only. That
+  repo also carries the raw IERS/USNO EOP data and the full VSOP87 coefficient files — the
+  substrate for a #64 refit (post-2024 observed ΔT now exists to measure how far the
+  prediction-fitted segment drifted from truth) and for coefficient-level audits under #94.
 
 ## Tech Stack
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,11 +47,11 @@ This is precision astronomy, not vibes. Every algorithm traces to a named refere
 - Cite the source of any new algorithm / coefficients in a comment.
 - **ΔT provenance lives out-of-repo**: `delta_t.hpp` algo4 (the default) is **two** polynomials
   curve-fitted in [AstroTime-Analysis](https://github.com/0xf3cd/AstroTime-Analysis)
-  (`DeltaT/models.ipynb`): the pre-2024.0 branch fits Bulletin A *observations*
-  (2004.85–2024.42), the post-2024.0 branch fits USNO `deltat.preds` *predictions* — the
-  dispatch splits at 2024.0 (`delta_t.hpp:365/:372`); the header comment's "2024.5" describes
-  data coverage, not the boundary. In-repo `statistics/` holds evaluation notebooks only. That
-  repo also carries the raw IERS/USNO EOP data and the full VSOP87 coefficient files — the
+  (`DeltaT/models.ipynb`): the pre-2024.0 branch fits Bulletin A *observations* (2004.85–2024.42
+  in the notebook's 2024-08 snapshot), the post-2024.0 branch fits USNO `deltat.preds`
+  *predictions* — the dispatch splits at 2024.0 (`algo4::compute`, the `year < 2024` /
+  `year >= 2024` branches). In-repo `statistics/` holds evaluation notebooks only. That repo
+  also carries the raw IERS/USNO EOP data and the full VSOP87 coefficient files — the
   substrate for a #64 refit (post-2024 observed ΔT now exists to measure how far the
   prediction-fitted segment drifted from truth) and for coefficient-level audits under #94.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,13 +47,14 @@ This is precision astronomy, not vibes. Every algorithm traces to a named refere
 - Cite the source of any new algorithm / coefficients in a comment.
 - **ΔT provenance lives out-of-repo**: `delta_t.hpp` algo4 (the default) is **two** polynomials
   curve-fitted in [AstroTime-Analysis](https://github.com/0xf3cd/AstroTime-Analysis)
-  (`DeltaT/models.ipynb`): the pre-2024.0 branch fits Bulletin A *observations* (2004.85–2024.42
-  in the notebook's 2024-08 snapshot), the post-2024.0 branch fits USNO `deltat.preds`
-  *predictions* — the dispatch splits at 2024.0 (`algo4::compute`, the `year < 2024` /
-  `year >= 2024` branches). In-repo `statistics/` holds evaluation notebooks only. That repo
-  also carries the raw IERS/USNO EOP data and the full VSOP87 coefficient files — the
-  substrate for a #64 refit (post-2024 observed ΔT now exists to measure how far the
-  prediction-fitted segment drifted from truth) and for coefficient-level audits under #94.
+  (`DeltaT/models.ipynb`): the 2005.0–2024.0 branch fits Bulletin A *observations* (2004.85–2024.42
+  in the notebook's 2024-08 snapshot), the 2024.0–2035.0 branch fits USNO `deltat.preds`
+  *predictions* — the dispatch splits at 2024.0 (`algo4::compute`, the `year >= 2005 and year < 2024`
+  / `year >= 2024` branches; below 2005.0 algo4 delegates to algo2). In-repo `statistics/` holds
+  evaluation notebooks only. That repo also carries the raw IERS/USNO EOP data and the full
+  VSOP87 coefficient files — the substrate for a #64 refit (post-2024 observed ΔT now exists to
+  measure how far the prediction-fitted segment drifted from truth) and for coefficient-level
+  audits under #94.
 
 ## Tech Stack
 

--- a/src/astro/delta_t.hpp
+++ b/src/astro/delta_t.hpp
@@ -331,8 +331,11 @@ namespace algo4 {
 // Algo4 is a polynomial model fitting the ΔT values.
 // Model training: https://github.com/0xf3cd/AstroTime-Analysis/blob/main/DeltaT/models.ipynb
 // The model is based on:
-//   Below year 2024.0: IERS's Bulletin A observations (https://www.iers.org/IERS/EN/Publications/Bulletins/bulletins.html) — 2004.85-2024.42 in the 2024-08 fit.
-//   Year 2024.0 onwards: USNO's ΔT predictions (deltat.preds, https://maia.usno.navy.mil/ser7/deltat.preds).
+//   Year 2005.0 - 2024.0: IERS's Bulletin A observations
+//                         (https://www.iers.org/IERS/EN/Publications/Bulletins/bulletins.html),
+//                         fitted over 2004.85-2024.42 in the 2024-08 snapshot.
+//   Year 2024.0 - 2035.0: USNO's ΔT predictions
+//                         (deltat.preds, https://maia.usno.navy.mil/ser7/deltat.preds).
 
 /**
  * @brief The function to compute △T of a given gregorian year, using algorithm 4.
@@ -343,13 +346,13 @@ namespace algo4 {
  * @example `compute(2005.99999999....)` returns the delta T for the last moment of year 2005.
  * @example `compute(1984.0)` returns the delta T for the first moment of year 1984.
  * 
- * @ref Bulletin A data - https://www.iers.org/IERS/EN/Publications/Bulletins/bulletins.html
+ * @ref IERS Bulletin A observations - https://www.iers.org/IERS/EN/Publications/Bulletins/bulletins.html
  * @ref USNO ΔT predictions (deltat.preds) - https://maia.usno.navy.mil/ser7/deltat.preds
  * @ref Models - https://github.com/0xf3cd/AstroTime-Analysis/blob/main/DeltaT/models.ipynb
  * 
  * @note For year < 2005.0, algo2 is used instead.
  * @note For 2005.0 <= year < 2024.0, poly model trained on Bulletin A data is used.
- * @note For 2024.0 <= year < 2035.0, poly model trained on USNO long-term data is used.
+ * @note For 2024.0 <= year < 2035.0, poly model trained on USNO ΔT predictions (deltat.preds) is used.
  */
 constexpr auto compute(const double year) -> double {
   if (year >= 2035) {

--- a/src/astro/delta_t.hpp
+++ b/src/astro/delta_t.hpp
@@ -331,8 +331,8 @@ namespace algo4 {
 // Algo4 is a polynomial model fitting the ΔT values.
 // Model training: https://github.com/0xf3cd/AstroTime-Analysis/blob/main/DeltaT/models.ipynb
 // The model is based on:
-//   Year 2005.0 - 2024.5: IERS's bulletin A data (https://www.iers.org/IERS/EN/Publications/Bulletins/bulletins.html). 
-//   Year 2024.5 - 2035.0: USNO's "Long-term" data (https://maia.usno.navy.mil/products/deltaT).
+//   Below year 2024.0: IERS's Bulletin A observations (https://www.iers.org/IERS/EN/Publications/Bulletins/bulletins.html) — 2004.85-2024.42 in the 2024-08 fit.
+//   Year 2024.0 onwards: USNO's ΔT predictions (deltat.preds, https://maia.usno.navy.mil/ser7/deltat.preds).
 
 /**
  * @brief The function to compute △T of a given gregorian year, using algorithm 4.
@@ -344,7 +344,7 @@ namespace algo4 {
  * @example `compute(1984.0)` returns the delta T for the first moment of year 1984.
  * 
  * @ref Bulletin A data - https://www.iers.org/IERS/EN/Publications/Bulletins/bulletins.html
- * @ref USNO Long-term data - https://maia.usno.navy.mil/products/deltaT
+ * @ref USNO ΔT predictions (deltat.preds) - https://maia.usno.navy.mil/ser7/deltat.preds
  * @ref Models - https://github.com/0xf3cd/AstroTime-Analysis/blob/main/DeltaT/models.ipynb
  * 
  * @note For year < 2005.0, algo2 is used instead.


### PR DESCRIPTION
## 动机

AstroTime-Analysis 盘点(2026-07-26)确认:`delta_t.hpp` algo4(默认 ΔT 算法)的训练 notebook 与数据在外部仓库,但 AGENTS.md 从未记录这条血缘——2026-07-25 review 核对时已因「statistics/ 只有评估 notebook」的描述陷阱踩过一次(vault 记录在案)。

## 改动

- AGENTS.md「Correctness is numerical」节末尾新增一条:algo4 出处(AstroTime-Analysis `DeltaT/models.ipynb`,Bulletin A 2005.0–2024.5)、仓内 `statistics/` 仅评估、该仓的 IERS/USNO/VSOP87 原始数据对 #64(外推误差量化)与 #94(系数级审计)的价值

## 关联

- 参考文档与 backlog 盘点记录已直推私有归档
- #64 / #94 不在本 PR 内动,仅记录数据基座

🤖 Generated with [Claude Code](https://claude.com/claude-code)