### PR TITLE
fix(astro): 统一 julian_day 输入校验为 throw 契约,修正 401 下界 (#77)

### DIFF
--- a/src/astro/julian_day.hpp
+++ b/src/astro/julian_day.hpp
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <cassert>
 #include <format>
 #include <stdexcept>
@@ -109,7 +110,7 @@ inline auto ut1_to_jd(const calendar::Datetime& ut1_dt) -> double {
  * @brief Convert julian day number to UT1 datetime.
  * @param jd The julian day number.
  * @return The datetime in UT1.
- * @throw std::runtime_error if the estimated gregorian year is < 401.
+ * @throw std::runtime_error if `jd` is not finite, or the estimated gregorian year is < 401.
  */
 inline auto jd_to_ut1(const double jd) -> calendar::Datetime {
   /*
@@ -135,11 +136,20 @@ inline auto jd_to_ut1(const double jd) -> calendar::Datetime {
      It is also mentioned that "the method fails if Y<400".
    */
 
+  // #77: NaN/Inf would slip past the range check below (NaN comparisons are false) and reach
+  // undefined float→int conversions. Reject them first.
+  if (not std::isfinite(jd)) {
+    throw std::runtime_error {
+      std::format("The julian day number {} is not finite.", jd)
+    };
+  }
+
   assert(jd > 0);
 
-  // The algorithm fails if Y < 400, so reject everything before 401-01-01 (gregorian), whose
-  // julian day number is exactly 1867522.5 (#77: the old cutoff 1867524.457118 sat ~2 days
-  // high and wrongly rejected the first two days of year 401).
+  // The reference says the method fails if Y < 400, so reject everything below year 401 — the
+  // smallest full year safely inside the method's domain. 401-01-01 (gregorian) is exactly
+  // JD 1867522.5 (#77: the old cutoff 1867524.457118 sat ~2 days high and wrongly rejected
+  // the first two days of year 401).
   if (jd < 1867522.5) {
     throw std::runtime_error("The estimated gregorian year is < 401.");
   }

--- a/src/astro/julian_day.hpp
+++ b/src/astro/julian_day.hpp
@@ -144,8 +144,6 @@ inline auto jd_to_ut1(const double jd) -> calendar::Datetime {
     };
   }
 
-  assert(jd > 0);
-
   // The reference says the method fails if Y < 400, so reject everything below year 401 — the
   // smallest full year safely inside the method's domain. 401-01-01 (gregorian) is exactly
   // JD 1867522.5 (#77: the old cutoff 1867524.457118 sat ~2 days high and wrongly rejected

--- a/src/astro/julian_day.hpp
+++ b/src/astro/julian_day.hpp
@@ -24,6 +24,8 @@
 #pragma once
 
 #include <cassert>
+#include <format>
+#include <stdexcept>
 
 #include "delta_t.hpp"
 
@@ -49,6 +51,9 @@ constexpr double J2000 = 2451545.0;
  * @brief Convert UT1 datetime to julian day number.
  * @param ut1_dt The datetime in UT1.
  * @return The julian day number.
+ * @throw std::runtime_error if the gregorian year is < 1.
+ * @note Years 1-400 convert forward, but sit below `jd_to_ut1`'s year-401 bound — round-trips
+ *       only close from 401-01-01 onwards.
  */
 inline auto ut1_to_jd(const calendar::Datetime& ut1_dt) -> double {
   /*
@@ -71,7 +76,14 @@ inline auto ut1_to_jd(const calendar::Datetime& ut1_dt) -> double {
   assert(ut1_dt.ok());
   
   const auto& [g_y, g_m, g_d] = util::from_ymd(ut1_dt.ymd);
-  assert(g_y > 0);
+
+  // #77: the unsigned arithmetic below wraps for year < 1 (`g_y - 1` as `uint32_t`) and would
+  // silently return a garbage JD. Throw instead, mirroring `jd_to_ut1`'s error contract.
+  if (g_y < 1) {
+    throw std::runtime_error {
+      std::format("The year {} is < 1, not supported by this algorithm.", g_y)
+    };
+  }
 
   // NOLINTBEGIN
   // The following code is doing narrowing-conversions. 
@@ -97,6 +109,7 @@ inline auto ut1_to_jd(const calendar::Datetime& ut1_dt) -> double {
  * @brief Convert julian day number to UT1 datetime.
  * @param jd The julian day number.
  * @return The datetime in UT1.
+ * @throw std::runtime_error if the estimated gregorian year is < 401.
  */
 inline auto jd_to_ut1(const double jd) -> calendar::Datetime {
   /*
@@ -124,9 +137,10 @@ inline auto jd_to_ut1(const double jd) -> calendar::Datetime {
 
   assert(jd > 0);
 
-  // The algorithm fails if Y < 400, so we need to check it.
-  if (jd < 1867524.457118) {
-    // Julian day number of 401-01-01 (gregorian) is roughly 1867524.457118
+  // The algorithm fails if Y < 400, so reject everything before 401-01-01 (gregorian), whose
+  // julian day number is exactly 1867522.5 (#77: the old cutoff 1867524.457118 sat ~2 days
+  // high and wrongly rejected the first two days of year 401).
+  if (jd < 1867522.5) {
     throw std::runtime_error("The estimated gregorian year is < 401.");
   }
 

--- a/src/test/astro/julian_day_test.cpp
+++ b/src/test/astro/julian_day_test.cpp
@@ -109,6 +109,7 @@ TEST(JulianDay, InvalidInput) {
   // Both directions throw the same exception type on out-of-domain input. Their domains differ:
   // `ut1_to_jd` accepts years 1-400 that sit below `jd_to_ut1`'s bound, so round-trips only
   // close from 401-01-01 onwards.
+  ASSERT_THROW(jd_to_ut1(-5.0), std::runtime_error); // Negative finite values throw, not abort.
   ASSERT_THROW(jd_to_ut1(1.0), std::runtime_error);
   ASSERT_THROW(jd_to_ut1(1867522.4999), std::runtime_error); // 400-12-31, just below the bound.
 

--- a/src/test/astro/julian_day_test.cpp
+++ b/src/test/astro/julian_day_test.cpp
@@ -94,6 +94,32 @@ TEST(JulianDay, Consistency) {
   }
 }
 
+TEST(JulianDay, InvalidInput) {
+  // #77: `ut1_to_jd` rejects year < 1 explicitly — its unsigned arithmetic would otherwise
+  // wrap around and silently produce a garbage JD (release builds included).
+  ASSERT_THROW(ut1_to_jd(Datetime { to_ymd(0, 1, 1), 0.0 }), std::runtime_error);
+  ASSERT_THROW(ut1_to_jd(Datetime { to_ymd(0, 2, 29), 0.5 }), std::runtime_error);
+  ASSERT_THROW(ut1_to_jd(Datetime { to_ymd(-1, 12, 31), 0.99 }), std::runtime_error);
+  ASSERT_THROW(ut1_to_jd(Datetime { to_ymd(-4712, 1, 1), 0.0 }), std::runtime_error);
+
+  // The wrappers propagate the throw (this is what turns the C-ABI garbage into an error).
+  ASSERT_THROW(tt_to_jde(Datetime { to_ymd(0, 1, 1), 0.0 }), std::runtime_error);
+
+  // Both directions throw the same exception type on out-of-domain input. Their domains differ:
+  // `ut1_to_jd` accepts years 1-400 that sit below `jd_to_ut1`'s bound, so round-trips only
+  // close from 401-01-01 onwards.
+  ASSERT_THROW(jd_to_ut1(1.0), std::runtime_error);
+  ASSERT_THROW(jd_to_ut1(1867522.4999), std::runtime_error); // 400-12-31, just below the bound.
+
+  // Smallest supported year converts correctly: JD of 1-01-01 00:00 (gregorian) is 1721425.5.
+  ASSERT_NEAR(ut1_to_jd(Datetime { to_ymd(1, 1, 1), 0.0 }), 1721425.5, EPSILON);
+
+  // The inverse's lower bound is exactly 401-01-01 00:00, and both directions agree on it.
+  const auto y401 = jd_to_ut1(1867522.5);
+  ASSERT_EQ(y401.ymd, to_ymd(401, 1, 1));
+  ASSERT_NEAR(ut1_to_jd(Datetime { to_ymd(401, 1, 1), 0.0 }), 1867522.5, EPSILON);
+}
+
 TEST(JulianDay, JulianMillennium) {
   ASSERT_EQ(jde_to_jm(J2000), 0.0);
   ASSERT_EQ(jm_to_jde(0.0), J2000);

--- a/src/test/astro/julian_day_test.cpp
+++ b/src/test/astro/julian_day_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <limits>
 #include <unordered_map>
 #include "util.hpp"
 #include "datetime.hpp"
@@ -110,6 +111,11 @@ TEST(JulianDay, InvalidInput) {
   // close from 401-01-01 onwards.
   ASSERT_THROW(jd_to_ut1(1.0), std::runtime_error);
   ASSERT_THROW(jd_to_ut1(1867522.4999), std::runtime_error); // 400-12-31, just below the bound.
+
+  // Non-finite JDs bypass ordinary range checks (NaN comparisons are false) — rejected first.
+  ASSERT_THROW(jd_to_ut1(std::numeric_limits<double>::quiet_NaN()), std::runtime_error);
+  ASSERT_THROW(jd_to_ut1(std::numeric_limits<double>::infinity()), std::runtime_error);
+  ASSERT_THROW(jd_to_ut1(-std::numeric_limits<double>::infinity()), std::runtime_error);
 
   // Smallest supported year converts correctly: JD of 1-01-01 00:00 (gregorian) is 1721425.5.
   ASSERT_NEAR(ut1_to_jd(Datetime { to_ymd(1, 1, 1), 0.0 }), 1721425.5, EPSILON);


### PR DESCRIPTION
Closes #77。

## 问题

- `ut1_to_jd` 对年份只有 `assert(g_y > 0)` 防线:release(NDEBUG)下消失,年份 < 1 时 `uint32_t Y = g_y - 1` 回绕,**无声产出垃圾 JD**;反向 `jd_to_ut1` 却是 throw。同一文件两个方向防线强度不一致(#36 同族)。

## 改动

1. **统一 throw 契约**:`ut1_to_jd` 对 year < 1 抛 `std::runtime_error`(镜像 `jd_to_ut1`);经 C-ABI(`lib_astro.cpp` 已有 `catch (std::exception)`)从"垃圾值"变为规范的 invalid 返回。
2. **修正 `jd_to_ut1` 下界**(交叉审阅发现):旧阈值 `1867524.457118` 注释自称"401-01-01 的 JD",实际 401-01-01 00:00 = **1867522.5**——旧值偏高 ~2 天,误拒 401 年头两天。已正反两向验证(forward(401-01-01)=1867522.5,inverse(1867522.5)=401-01-01;参考文献仅声明 Y<400 失效)。
3. **文档**:两方向补 `@throw`;`@note` 记录域不对称(1–400 年可正向、不可逆向,round-trip 自 401-01-01 起闭合)。
4. **测试 `JulianDay.InvalidInput`**:0 年/负年/-4712、wrapper 传播(`tt_to_jde`)、双向边界钉死金值(JD(1-01-01)=1721425.5,JD(401-01-01)=1867522.5)。

## 验证

- 本地(Windows clang 18)全量构建+测试绿。
- **检出率 1/1**:working tree 打回旧代码后新测试确定性失败(活体 assert abort;NDEBUG 下则 6 条 ASSERT_THROW 全数触发)——两种构建形态都能检出。
- **交叉审阅**(Kimi / Codex;Grok CLI 非交互无输出,未纳入):
  - Codex:1 major——发现上述 401 阈值偏差,已采纳修正。
  - Kimi:1 minor + 3 nit——域不对称文档化、阈值钉死、年 1 金值断言、wrapper 传播覆盖,全部采纳。

## 行为变化

- 非法年份(<1):NDEBUG 下从垃圾 JD → throw / C-ABI invalid。
- `jd_to_ut1` 对 [1867522.5, 1867524.457118):从误抛 → 正确转换(401-01-01 ~ 401-01-02)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
