### PR TITLE
fix(util): make_cached 线程安全与拷贝共享缓存;删 algo1/algo3 多余 memo (#75, #78)

### DIFF
--- a/src/calendar/lunar/algo1.hpp
+++ b/src/calendar/lunar/algo1.hpp
@@ -85,17 +85,8 @@ inline auto calc_lunar_year(int32_t year) -> LunarYear {
   return parse_lunar_year(year, LUNAR_DATA[year - START_YEAR]); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
 }
 
-/**
- * @brief Same function as `calc_lunar_year`, but cached. 
-          与 `calc_lunar_year` 功能相同，但使用缓存。
- * @attention The input year should be in the range of [START_YEAR, END_YEAR].
- * @param year The Lunar year. 阴历年份。
- * @return The lunar year information. 阴历年信息。
- */
-const inline auto get_info_for_year = util::cache::cache_func(calc_lunar_year);
-
 /** @brief The bounds of the algorithm, i.e. the supported range of lunar and Gregorian dates. */
-const inline auto bounds = calc_bounds(START_YEAR, END_YEAR, get_info_for_year);
+const inline auto bounds = calc_bounds(START_YEAR, END_YEAR, calc_lunar_year);
 
 } // namespace calendar::lunar::algo1
 
@@ -105,8 +96,9 @@ namespace calendar::lunar::common {
 /** @brief Specialize `AlgoMetadata` for `Algo::ALGO_1`. */
 template <>
 struct AlgoMetadata<Algo::ALGO_1> {
-  static const inline auto get_info_for_year = algo1::get_info_for_year;
-  static const inline auto bounds = algo1::bounds;
+  // Not memoized: a `LUNAR_DATA[]` lookup is cheaper than the cache wrapper (#75).
+  static auto get_info_for_year(const int32_t year) -> LunarYear { return algo1::calc_lunar_year(year); }
+  static const inline auto& bounds = algo1::bounds;
 };
 
 } // namespace calendar::lunar::common

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -440,8 +440,10 @@ namespace calendar::lunar::common {
 /** @brief Specialize `AlgoMetadata` for `Algo::ALGO_2`. */
 template <>
 struct AlgoMetadata<Algo::ALGO_2> {
-  static const inline auto get_info_for_year = algo2::get_info_for_year;
-  static const inline auto bounds = algo2::bounds;
+  // Bind, don't copy: a copied `std::function` would fork its own cache replica,
+  // recomputing every year already cached on the namespace-level path (#78).
+  static const inline auto& get_info_for_year = algo2::get_info_for_year;
+  static const inline auto& bounds = algo2::bounds;
 };
 
 } // namespace calendar::lunar::common

--- a/src/calendar/lunar/algo3.hpp
+++ b/src/calendar/lunar/algo3.hpp
@@ -129,28 +129,20 @@ inline auto calc_lunar_year(int32_t year) -> LunarYear {
   return parse_lunar_year(year, LUNAR_DATA[year - START_YEAR]); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
 }
 
-/**
- * @brief Same function as `calc_lunar_year`, but cached. 
-          与 `calc_lunar_year` 功能相同，但使用缓存。
- * @attention The input year should be in the range of [START_YEAR, END_YEAR].
- * @param year The Lunar year. 阴历年份。
- * @return The lunar year information. 阴历年信息。
- */
-const inline auto get_info_for_year = util::cache::cache_func(calc_lunar_year);
-
 /** @brief The bounds of the algorithm, i.e. the supported range of lunar and Gregorian dates. */
-const inline auto bounds = calc_bounds(START_YEAR, END_YEAR, get_info_for_year);
+const inline auto bounds = calc_bounds(START_YEAR, END_YEAR, calc_lunar_year);
 
 } // namespace calendar::lunar::algo3
 
 
 namespace calendar::lunar::common {
 
-/** @brief Specialize `AlgoMetadata` for `Algo::ALGO_1`. */
+/** @brief Specialize `AlgoMetadata` for `Algo::ALGO_3`. */
 template <>
 struct AlgoMetadata<Algo::ALGO_3> {
-  static const inline auto get_info_for_year = algo3::get_info_for_year;
-  static const inline auto bounds = algo3::bounds;
+  // Not memoized: a `LUNAR_DATA[]` lookup is cheaper than the cache wrapper (#75).
+  static auto get_info_for_year(const int32_t year) -> LunarYear { return algo3::calc_lunar_year(year); }
+  static const inline auto& bounds = algo3::bounds;
 };
 
 } // namespace calendar::lunar::common

--- a/src/calendar/lunar/common.hpp
+++ b/src/calendar/lunar/common.hpp
@@ -27,6 +27,7 @@
 #include <vector>
 #include <ranges>
 #include <numeric>
+#include <functional>
 
 #include "ymd.hpp"
 
@@ -108,9 +109,9 @@ struct AlgoBounds {
 
 /** @brief Calculate the bounds of the luanr algorithm. */
 inline auto calc_bounds(
-  const int32_t start_lunar_year, 
-  const int32_t end_lunar_year, 
-  std::function<LunarYear(int32_t)> algo_f
+  const int32_t start_lunar_year,
+  const int32_t end_lunar_year,
+  const std::function<LunarYear(int32_t)>& algo_f
 ) -> AlgoBounds {
   const auto first_lunar_date = util::to_ymd(start_lunar_year, 1, 1);
 
@@ -147,11 +148,13 @@ inline auto calc_bounds(
 /** @brief Algorithm version. */
 enum class Algo : uint8_t { ALGO_1, ALGO_2, ALGO_3 };
 
-/** 
- * @struct The type trait for the lunar algorithm, 
- *         expected specializations in every algorithm implementation. 
+/**
+ * @struct The type trait for the lunar algorithm,
+ *         expected specializations in every algorithm implementation.
  * @param get_info_for_year The function to get the lunar year information for the given year.
  *                          用于使用该算法获取给定年份的阴历年信息的函数。
+ *                          Either a plain forwarding function (algo1/3) or a reference binding
+ *                          to the algorithm's cached callable (algo2, #78) — same call syntax.
  * @param bounds The bounds of the algorithm, i.e. the supported range of lunar and Gregorian dates.
  *               算法支持的阴历和公历日期的范围。
  */

--- a/src/calendar/lunar/common.hpp
+++ b/src/calendar/lunar/common.hpp
@@ -107,7 +107,7 @@ struct AlgoBounds {
 };
 
 
-/** @brief Calculate the bounds of the luanr algorithm. */
+/** @brief Calculate the bounds of the lunar algorithm. */
 inline auto calc_bounds(
   const int32_t start_lunar_year,
   const int32_t end_lunar_year,

--- a/src/shared_lib/lib_lunar.cpp
+++ b/src/shared_lib/lib_lunar.cpp
@@ -99,7 +99,7 @@ auto get_lunar_year_info(const uint8_t algo, const int32_t year) -> LunarYearInf
 
     const auto raw = std::invoke([=] {
       if (algo == 1) {
-        return calendar::lunar::algo1::get_info_for_year(year);
+        return calendar::lunar::algo1::calc_lunar_year(year);
       }
       return calendar::lunar::algo2::get_info_for_year(year);
     });

--- a/src/test/lunar/algo1_test.cpp
+++ b/src/test/lunar/algo1_test.cpp
@@ -1,7 +1,5 @@
 #include <gtest/gtest.h>
 #include <vector>
-#include <print>
-#include "ymd.hpp"
 #include "random.hpp"
 #include "lunar/algo1.hpp"
 
@@ -57,8 +55,6 @@ TEST(LunarAlgo1, LunarYear) {
 }
 
 TEST(LunarAlgo1, Copy) {
-  using namespace util::ymd_operator;
-
   for (auto _ = 0; _ < 100; ++_) {
     auto info = calc_lunar_year(util::random(START_YEAR, END_YEAR));
     auto info2 = info;
@@ -75,79 +71,15 @@ TEST(LunarAlgo1, Copy) {
   }
 }
 
-TEST(LunarAlgo1, CachePerf) {
-  const uint64_t elapsed_time_uncached = std::invoke([] {
-    const auto start_time = std::chrono::steady_clock::now();
-    for (auto _ = 0; _ < 800; ++_) {
-      for (auto year = START_YEAR; year <= END_YEAR; ++year) {
-        calc_lunar_year(year);
-      }
-    }
-    for (auto year = START_YEAR; year <= END_YEAR; ++year) {
-      for (auto _ = 0; _ < 800; ++_) {
-        calc_lunar_year(year);
-      }
-    }
-    for (auto _ = 0; _ < 2000; ++_) {
-      const int32_t random_year = util::random(START_YEAR, END_YEAR);
-      calc_lunar_year(random_year);
-    }
-    const auto end_time = std::chrono::steady_clock::now();
-    return static_cast<uint64_t>((end_time - start_time).count());
-  });
-
-  const uint64_t elapsed_time_cached = std::invoke([] {
-    const auto start_time = std::chrono::steady_clock::now();
-    for (auto _ = 0; _ < 800; ++_) {
-      for (auto year = START_YEAR; year <= END_YEAR; ++year) {
-        [[maybe_unused]] const auto& result = get_info_for_year(year);
-      }
-    }
-    for (auto year = START_YEAR; year <= END_YEAR; ++year) {
-      for (auto _ = 0; _ < 800; ++_) {
-        [[maybe_unused]] const auto& result = get_info_for_year(year);
-      }
-    }
-    for (auto _ = 0; _ < 2000; ++_) {
-      const int32_t random_year = util::random(START_YEAR, END_YEAR);
-      [[maybe_unused]] const auto& result = get_info_for_year(random_year);
-    }
-    const auto end_time = std::chrono::steady_clock::now();
-    return static_cast<uint64_t>((end_time - start_time).count());
-  });
-  
-  std::println("Elapsed time for uncached: {}ns", elapsed_time_uncached);
-  std::println("Elapsed time for cached:   {}ns", elapsed_time_cached);
-  std::println("Cached is {}x faster", static_cast<double>(elapsed_time_uncached) / static_cast<double>(elapsed_time_cached));
-
-  EXPECT_LT(elapsed_time_cached, elapsed_time_uncached);
-}
-
-TEST(LunarAlgo1, CacheCorrectness) {
-  using namespace util::ymd_operator;
-
+TEST(LunarAlgo1, MetadataConsistency) {
+  // #75: the memo wrapper is gone — `AlgoMetadata` forwards straight to `calc_lunar_year`.
   for (auto _ = 0; _ < 100; ++_) {
     const auto year = util::random(START_YEAR, END_YEAR);
     const auto info = calc_lunar_year(year);
-    const auto& info2 = get_info_for_year(year);
+    const auto info2 = AlgoMetadata<Algo::ALGO_1>::get_info_for_year(year);
     EXPECT_EQ(info.date_of_first_day, info2.date_of_first_day);
     EXPECT_EQ(info.leap_month, info2.leap_month);
     EXPECT_EQ(info.month_lengths, info2.month_lengths);
-  }
-
-  for (auto year = START_YEAR; year <= END_YEAR; ++year) {
-    std::vector<LunarYear> results;
-    for (auto _ = 0; _ < 32; ++_) {
-      results.emplace_back(get_info_for_year(year)); // NOLINT(performance-inefficient-vector-operation)
-    }
-
-    for (const auto& info1 : results) { // TODO: Use `std::views::cartesian_product` when supported.
-      for (const auto& info2 : results) {
-        EXPECT_EQ(info1.date_of_first_day, info2.date_of_first_day);
-        EXPECT_EQ(info1.leap_month, info2.leap_month);
-        EXPECT_EQ(info1.month_lengths, info2.month_lengths);
-      }
-    }
   }
 }
 

--- a/src/test/lunar/algo2_test.cpp
+++ b/src/test/lunar/algo2_test.cpp
@@ -286,4 +286,12 @@ TEST(LunarAlgo2, GetLunarInfo) {
   }
 }
 
+
+TEST(LunarAlgo2, MetadataSharesCache) {
+  // #78: `AlgoMetadata` must bind the namespace-level cached function, not copy it —
+  // a copied `std::function` forks its own cache replica and recomputes from scratch.
+  ASSERT_EQ(&AlgoMetadata<Algo::ALGO_2>::get_info_for_year, &algo2::get_info_for_year);
+  ASSERT_EQ(&AlgoMetadata<Algo::ALGO_2>::bounds, &algo2::bounds);
+}
+
 } // namespace calendar::lunar::algo2::test

--- a/src/test/lunar/diff_test.cpp
+++ b/src/test/lunar/diff_test.cpp
@@ -50,7 +50,7 @@ TEST(LunarAlgoDiff, Perf) {
   std::vector<double> algo2_results;
 
   for (const auto year : years) {
-    algo1_results.push_back(tracked_run([&] { algo1::get_info_for_year(year); }));
+    algo1_results.push_back(tracked_run([&] { algo1::calc_lunar_year(year); }));
     algo2_results.push_back(tracked_run([&] { algo2::get_info_for_year(year); }));
   }
 
@@ -72,7 +72,7 @@ TEST(LunarAlgoDiff, Consistency) {
   for (const auto year : years) {
     std::println("year: {}", year);
 
-    const auto info1 = algo1::get_info_for_year(year);
+    const auto info1 = algo1::calc_lunar_year(year);
     const auto info2 = algo2::get_info_for_year(year);
 
     ASSERT_EQ(info1.date_of_first_day, info2.date_of_first_day);

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <print>
+#include <atomic>
 #include <ranges>
 #include <thread>
 #include <unordered_set>
@@ -298,8 +299,81 @@ TEST(Util, MakeCached2) {
 
   ASSERT_GT(original_elapsed_time, cached_elapsed_time);
   std::println("original_elapsed_time = {}ms, cached_elapsed_time = {}ms, {}x faster",
-               original_elapsed_time, cached_elapsed_time, 
+               original_elapsed_time, cached_elapsed_time,
                static_cast<double>(original_elapsed_time) / static_cast<double>(cached_elapsed_time));
+}
+
+
+TEST(Util, MakeCachedCopyShares) {
+  // #78: copies of a cached function must share one cache, not fork divergent replicas.
+  std::atomic<int32_t> call_count { 0 };
+  const auto f = [&call_count](int32_t a) {
+    ++call_count;
+    return a * 2;
+  };
+  const auto cached_f = util::cache::cache_func(f);
+
+  ASSERT_EQ(cached_f(21), 42);
+  ASSERT_EQ(call_count, 1);
+
+  const auto copied_f = cached_f; // NOLINT(performance-unnecessary-copy-initialization): the copy is the point.
+  ASSERT_EQ(copied_f(21), 42);
+  ASSERT_EQ(call_count, 1); // Hit through the copy — no recomputation.
+
+  ASSERT_EQ(copied_f(4), 8);
+  ASSERT_EQ(call_count, 2);
+  ASSERT_EQ(cached_f(4), 8);
+  ASSERT_EQ(call_count, 2); // The original sees the copy's insertion.
+}
+
+
+TEST(Util, MakeCachedThreadSafe) {
+  // #78: concurrent callers used to race on the captured `unordered_map` (UB, TSAN-verified).
+  std::atomic<int32_t> call_count { 0 };
+  const auto f = [&call_count](int32_t a) {
+    ++call_count;
+    return a * a;
+  };
+  const auto cached_f = util::cache::cache_func(f);
+
+  constexpr int32_t THREAD_COUNT = 8;
+  constexpr int32_t KEY_COUNT = 64;
+  constexpr int32_t ROUND_COUNT = 4;
+
+  // gtest assertions are not thread-safe everywhere — threads only record, main thread asserts.
+  std::vector<std::vector<int32_t>> results(THREAD_COUNT);
+
+  {
+    std::vector<std::thread> threads;
+    threads.reserve(THREAD_COUNT);
+    for (int32_t t = 0; t < THREAD_COUNT; ++t) {
+      threads.emplace_back([&cached_f, &results, t] {
+        auto& thread_results = results[t];
+        thread_results.reserve(static_cast<size_t>(ROUND_COUNT) * KEY_COUNT);
+        for (int32_t round = 0; round < ROUND_COUNT; ++round) {
+          for (int32_t k = 0; k < KEY_COUNT; ++k) {
+            thread_results.emplace_back(cached_f(k));
+          }
+        }
+      });
+    }
+    for (auto& thread : threads) {
+      thread.join();
+    }
+  }
+
+  for (const auto& thread_results : results) {
+    ASSERT_EQ(thread_results.size(), ROUND_COUNT * KEY_COUNT);
+    for (int32_t round = 0; round < ROUND_COUNT; ++round) {
+      for (int32_t k = 0; k < KEY_COUNT; ++k) {
+        ASSERT_EQ(thread_results[(round * KEY_COUNT) + k], k * k);
+      }
+    }
+  }
+
+  // Every key computed at least once; concurrent misses on a key may compute a few extras.
+  ASSERT_GE(call_count, KEY_COUNT);
+  ASSERT_LE(call_count, THREAD_COUNT * KEY_COUNT);
 }
 
 } // namespace util::test

--- a/src/util/cache.hpp
+++ b/src/util/cache.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <mutex>
+#include <tuple>
 #include <memory>
 #include <utility>
 #include <functional>

--- a/src/util/cache.hpp
+++ b/src/util/cache.hpp
@@ -67,7 +67,8 @@ inline auto make_cached(const std::function<RetType(Args...)>& func) -> std::fun
     // Compute outside the lock: misses on different keys don't serialize, and `func`
     // may itself call another cached function without holding two locks at once.
     // Concurrent misses on the same key both compute; `try_emplace` keeps the first.
-    auto result = func(args...);
+    // Forward only here — the key above was built from copies, so nothing is moved twice.
+    auto result = func(std::forward<Args>(args)...);
 
     const std::lock_guard lock { state->mtx };
     return state->cache.try_emplace(std::move(key), std::move(result)).first->second;

--- a/src/util/cache.hpp
+++ b/src/util/cache.hpp
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <mutex>
+#include <memory>
 #include <utility>
 #include <functional>
 #include <type_traits>
@@ -36,31 +38,39 @@ using util::hash::TupleHash;
 
 // TODO:
 // 1. Add a way to clear the cache (LRU, or something).
-// 2. Maybe support multi-threading? Currently, `std::unordered_map` is not thread-safe.
 
 /**
  * @brief A wrapper that caches the result of a function.
- * @param func The function to cache.
- * @return The cached function.
+ * @param func The function to cache. Must be pure — same arguments ⇒ same result.
+ * @return The cached function. Thread-safe; copies share one cache (#78).
  */
 template <typename RetType, typename... Args>
 inline auto make_cached(const std::function<RetType(Args...)>& func) -> std::function<RetType(Args...)> {
-  std::unordered_map<std::tuple<std::decay_t<Args>...>, RetType, TupleHash<std::decay_t<Args>...>> cache;
+  // Cache and mutex live behind a `shared_ptr`, so copying the returned
+  // `std::function` shares one cache instead of forking divergent replicas (#78).
+  struct State {
+    std::mutex mtx;
+    std::unordered_map<std::tuple<std::decay_t<Args>...>, RetType, TupleHash<std::decay_t<Args>...>> cache;
+  };
 
-  return [cache = std::move(cache), func = func](Args... args) mutable {
-    // Create a tuple from the arguments
-    auto key = std::make_tuple(std::forward<Args>(args)...);
+  return [state = std::make_shared<State>(), func = func](Args... args) -> RetType {
+    auto key = std::make_tuple(args...);
 
-    // Check if the result is already in the cache
-    const auto found = cache.find(key);
-    if (found != cache.end()) {
-      return found->second;
+    {
+      const std::lock_guard lock { state->mtx };
+      const auto found = state->cache.find(key);
+      if (found != state->cache.end()) {
+        return found->second;
+      }
     }
-    
-    // Compute the result and cache it
-    auto result = func(std::forward<Args>(args)...);
-    cache[key] = result;
-    return result;
+
+    // Compute outside the lock: misses on different keys don't serialize, and `func`
+    // may itself call another cached function without holding two locks at once.
+    // Concurrent misses on the same key both compute; `try_emplace` keeps the first.
+    auto result = func(args...);
+
+    const std::lock_guard lock { state->mtx };
+    return state->cache.try_emplace(std::move(key), std::move(result)).first->second;
   };
 }
 

--- a/src/util/hash.hpp
+++ b/src/util/hash.hpp
@@ -23,6 +23,12 @@
 
 #pragma once
 
+#include <tuple>
+#include <cstddef>
+#include <utility>
+#include <functional>
+#include <type_traits>
+
 namespace util::hash {
 
 template <typename T>


### PR DESCRIPTION
Closes #75 · Closes #78

# fix(util): make_cached 线程安全与共享缓存;去掉 algo1/algo3 多余 memo (#75, #78)

## #78 — `make_cached` 数据竞争 + 分叉缓存 + 双查表

`cache.hpp` 重写要点:

- **数据竞争修复**:缓存与 `std::mutex` 一起放进 `shared_ptr<State>`。原实现是 mutable lambda 直写按值捕获的 `unordered_map`,`const std::function` 外观下每次调用都可能写共享状态 = UB。
  **TSAN 实证(WSL Ubuntu, g++ 11, `-fsanitize=thread`, 8 线程 × 6400 次调用)**:旧实现 **7 处 data race**(全部落在 `_Hashtable::_M_bucket_index`,即被捕获的 map),exit 66;新实现 **0 race**,exit 0。
- **拷贝共享缓存**:拷贝返回的 `std::function` 现在共享同一份 `State`,不再深拷贝 map 分叉副本。
- **计算不持锁**:miss 时先解锁再算,不同 key 的并发 miss 不互相串行;同 key 并发 miss 允许重复计算,`try_emplace` 保第一份(函数是纯的,结果相同)。
- **单次插入**:`find` + `operator[]`(两次哈希 + 要求默认可构造)改为 `try_emplace` 直接安放结果。
- 顺带修掉旧实现对 `args` 的双重 `std::forward`(make_tuple 后再 forward 给 func,对 move-sensitive 类型是 use-after-move;现用小 trivially-copyable 类型,未曾实际咬人)。

`AlgoMetadata` 绑定修复(issue 评论里量过:converter 路径每个新年份多花 ~10.5 ms + 双份记忆表常驻):

- `AlgoMetadata<ALGO_2>::get_info_for_year` 由**按值拷贝**改为**引用绑定** `algo2::get_info_for_year` —— converter 用户与命名空间级路径共享同一缓存对象。
- `calc_bounds` 的 `algo_f` 参数改 `const&`(#67 记过的按值传参,顺带收掉)。

## #75 — algo1/algo3 的 memo 是过度优化

`get_info_for_year` 在 algo1/algo3 本质是 `LUNAR_DATA[]` 查表 + 位解析,比 cache 包装(类型擦除 + 哈希 + 命中按值拷出)更便宜;clang Release 下 `CachePerf` 门禁曾确定性失败(cached/direct ≈ 0.83)。

- 按 review 讨论,**直接删掉 algo1/algo3 命名空间级 `get_info_for_year` 别名**(不是替换为无缓存别名):缓存一删,同一命名空间两个名字指同一函数就是纯间接层;统一入口的职责在 `AlgoMetadata` trait(converter 只经它走)。trait 成员改为一行转发函数。
- 唯一测试外调用方 `lib_lunar.cpp` 改为直调 `calc_lunar_year`。
- `LunarAlgo1.CachePerf` 门禁删除(它量的是 wrapper 不是 lunar 逻辑);`CacheCorrectness` 随包装层一起失去对象,由新的 `MetadataConsistency`(trait 转发 ≡ 直算)接棒。
- **algo2 / jieqi 的 memo 保留不动**(真·贵计算,algo2 冷调用 ~36 ms)。

## 测试与验证

| 验证 | 结果 |
|---|---|
| 本地全量(clang 18.1.8, MSVC STL, Windows) | 136/136 绿(干净重建,退出码直查) |
| TSAN 探针 old vs new(WSL g++11,8 线程×6400 调用) | **7 data race → 0**(全部落在被捕获的 `unordered_map`) |
| 新测试检出率(worktree 拉旧代码实测) | `MakeCachedCopyShares` FAIL✓、`MetadataSharesCache` FAIL✓;`MakeCachedThreadSafe` 普通构建 PASS(其检出维度在 TSAN,如实标注) |
| linter `--clang-tidy` 全量 | 0 findings;**`cache.hpp:50` 既有 MSVC-STL `bugprone-exception-escape` 随重写消失**(lambda 捕获只剩 `shared_ptr`+`std::function`,move 均 noexcept) |

## 本地双审(kimi + codex,PR 前)

- **Blocking(两家同报,已修)**:`diff_test.cpp:53,75` 漏改已删除的 `algo1::get_info_for_year`。此前"全量绿"是假绿:构建失败退出码被管道 `tail` 吞掉,ctest 跑了陈旧二进制。已改直调 + 干净重建复验。
- **kimi minor(已采纳,文档路线)**:trait 两种成员形状(algo1/3 转发函数 vs algo2 引用绑定)写进 `common.hpp` trait 契约注释;不统一形状——统一会毁掉 `MetadataSharesCache` 的地址断言(#78 的回归锁)。
- **nit(已采纳)**:测试注释里的测量数据(~10ms)移出;`NOLINT(performance-inefficient-vector-operation)` 改为 `reserve()` 根治。
- **nit(记录不改)**:`make_cached` 的 `args` 从 forward 退化为拷贝——有意为之,旧实现 double-forward 对 move-sensitive 类型是 use-after-move;现实例化均为小 trivially-copyable 类型。

新增测试:

- `Util.MakeCachedCopyShares` — 拷贝命中不重算、原件看得到拷贝的插入(计数器断言)。
- `Util.MakeCachedThreadSafe` — 8 线程 × 4 轮 × 64 key 并发压打;子线程只记录、主线程断言(gtest 断言非全平台线程安全)。
- `LunarAlgo2.MetadataSharesCache` — `&AlgoMetadata<ALGO_2>::get_info_for_year == &algo2::get_info_for_year` 结构性断言,直接锁死「拷贝分叉」回归。
- `LunarAlgo1.MetadataConsistency` — trait 转发 ≡ `calc_lunar_year`(编译/形状守卫,判别力有限,双审知悉后保留)。

连带改动:`diff_test.cpp` 改直调 `calc_lunar_year`(其 `Perf` 测试从「缓存 vs 缓存」变为「裸查表 vs 缓存」,只 println 无断言门禁);`common.hpp` 补 `#include <functional>`(此前靠传递包含,#71 同类)。

## 验收标准对照

#75:
- [x] `LunarAlgo1.CachePerf` 不再作为 ctest 门禁(删除)
- [x] algo1/algo3 无 `cache_func`(别名整体删除,经作者确认)
- [x] 正确性测试保留(`MetadataConsistency` + algo2 侧重复调用一致性仍在)
- [x] jieqi / algo2 的 memo 未动

#78:
- [x] 并发调用无数据竞争(TSAN:7 race → 0)
- [x] 拷贝 cached 函数不产生分叉缓存(shared_ptr 状态 + `MakeCachedCopyShares`)
- [x] 单次查表(`try_emplace`)
- [x] `AlgoMetadata` 三处成员拷贝修复(algo2 引用绑定;algo1/3 随别名删除消灭)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)