### PR TITLE
feat(astro): 日出日落核心 transit/rise/set/曙暮光/极地判定 (#43)

### DIFF
--- a/src/astro/astro.hpp
+++ b/src/astro/astro.hpp
@@ -21,9 +21,14 @@
  * along with this project. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "julian_day.hpp"
 #include "delta_t.hpp"
 #include "earth.hpp"
+#include "coord_transform.hpp"
+#include "sidereal_time.hpp"
 #include "sun.hpp"
 #include "moon.hpp"
 #include "moon_phase.hpp"
+#include "sunrise_sunset.hpp"

--- a/src/astro/sunrise_sunset.hpp
+++ b/src/astro/sunrise_sunset.hpp
@@ -280,7 +280,8 @@ struct SunLocal {
  * @param h0 The target altitude.
  * @return The (positive) hour angle H₀ ∈ [0°, 180°]; the body is at h₀ at hour angles ±H₀.
  *         Returns `nullopt` when the altitude is never reached (polar day/night) or when the
- *         equation degenerates (observer at a pole).
+ *         equation degenerates — |cos φ · cos δ| < `POLAR_DENOMINATOR_EPSILON`, i.e. the
+ *         observer at a geographic pole or the body at/near a celestial pole.
  * @throw std::invalid_argument If any argument is not finite or lies outside [-90°, 90°]
  *        (outside that domain sin/cos alias and (15.1) returns a physically meaningless H₀).
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 15, Formula (15.1).
@@ -427,14 +428,16 @@ struct SunLocal {
     return is_sunrise ? (f_lo < 0.0 and f_hi > 0.0) : (f_lo > 0.0 and f_hi < 0.0);
   };
 
-  // The residual guard turns a degenerate solve into "no event" instead of a wrong instant;
-  // see `RISE_SET_RESIDUAL_GUARD_DEG` (robustness only, per review).
-  const auto solve = [&f](const double lo, const double hi) -> std::optional<double> {
+  // The residual guard keeps a degenerate solve from shipping a wrong instant; see
+  // `RISE_SET_RESIDUAL_GUARD_DEG` (robustness only, per review). The residual is returned
+  // alongside the root so a guard rejection can be reported with context.
+  struct Solved {
+    double root;
+    double residual_deg;
+  };
+  const auto solve = [&f](const double lo, const double hi) -> Solved {
     const double root = astro::toolbox::newton_method(f, lo, hi, astro::toolbox::SIDEREAL_RATE_DEG_PER_DAY);
-    if (std::fabs(f(root)) > RISE_SET_RESIDUAL_GUARD_DEG) [[unlikely]] {
-      return std::nullopt;
-    }
-    return root;
+    return { .root = root, .residual_deg = std::fabs(f(root)) };
   };
 
   // First try: a tight bracket around the mean-rate extrapolation of H₀ from transit's δ.
@@ -452,8 +455,9 @@ struct SunLocal {
     if (straddles(lo, hi)) {
       // On a guard rejection fall THROUGH to the fallback rather than reporting "no event":
       // the straddle proved a root exists, so the tight bracket must never be the last word.
-      if (const auto root = solve(lo, hi); root.has_value()) {
-        return root;
+      const auto solved = solve(lo, hi);
+      if (solved.residual_deg <= RISE_SET_RESIDUAL_GUARD_DEG) [[likely]] {
+        return solved.root;
       }
     }
   }
@@ -464,13 +468,21 @@ struct SunLocal {
   const double lo = is_sunrise ? culmination : transit;
   const double hi = is_sunrise ? transit : culmination;
   if (straddles(lo, hi)) {
-    if (const auto root = solve(lo, hi); root.has_value()) {
-      return root;
+    const auto solved = solve(lo, hi);
+    if (solved.residual_deg <= RISE_SET_RESIDUAL_GUARD_DEG) [[likely]] {
+      return solved.root;
     }
     // The straddle just proved a crossing exists, so a guard rejection here is a numerical
     // failure, not a polar verdict — surface it loudly instead of returning nullopt, which
     // `calculate` would compound into a wrong polar-day/night flag (per review).
-    throw std::runtime_error { "rise_set_jde: bracketed root failed to converge" };
+    throw std::runtime_error {
+      std::format(
+        "rise_set_jde: bracketed {} root failed to converge: |altitude - h0| = {} deg at jde {} "
+        "(bracket [{}, {}], guard {} deg)",
+        is_sunrise ? "sunrise" : "sunset",
+        solved.residual_deg, solved.root, lo, hi, RISE_SET_RESIDUAL_GUARD_DEG
+      )
+    };
   }
 
   return std::nullopt;

--- a/src/astro/sunrise_sunset.hpp
+++ b/src/astro/sunrise_sunset.hpp
@@ -112,9 +112,10 @@ inline constexpr double LOWER_CULMINATION_BRACKET_HALF_WIDTH_DAYS = 0.1;
  * @brief The residual guard on a rise/set root, in degrees of altitude.
  * @note Robustness only: after a directed sign check the bracketed Newton solve converges to
  *       residuals ~1e-7° for the Sun; this guard (4 orders looser) exists so that a degenerate
- *       solve — `newton_method` may return a best-effort iterate when f′ collapses — surfaces
- *       as "no event" instead of a wrong instant, and to keep the contract honest if this
- *       solver is ever reused for the Moon.
+ *       solve — `newton_method` may return a best-effort iterate when f′ collapses — never
+ *       ships a wrong instant: the tight bracket falls through to the fallback, and the
+ *       fallback (whose straddle has proved a root) throws instead of mislabeling the day
+ *       as polar. Also keeps the contract honest if this solver is ever reused for the Moon.
  */
 inline constexpr double RISE_SET_RESIDUAL_GUARD_DEG = 1e-3;
 
@@ -381,6 +382,9 @@ struct SunLocal {
  *         between the transit and the adjacent lower culmination (polar day/night).
  * @throw std::invalid_argument If `transit` is not finite, `location` is out of range, or `h0`
  *        is not finite or outside [-90°, 90°].
+ * @throw std::runtime_error If a sign change proved a crossing exists but the solve failed the
+ *        residual guard — a numerical failure that must not masquerade as a polar verdict
+ *        (unreachable for the Sun as far as testing and review can tell).
  * @note The root of (altitude - h₀) = 0 is found with `toolbox::newton_method`. Working on the
  *       altitude directly sidesteps two of the classic pitfalls: there is no hand-written
  *       dh/dH derivative to get wrong (the solver differentiates numerically), and no hour-angle
@@ -439,6 +443,9 @@ struct SunLocal {
   const double sign = is_sunrise ? -1.0 : 1.0;
 
   if (H0.has_value()) {
+    // The Sun's hour angle sweeps ~360.0°/day (mean solar rate), not the sidereal rate — the
+    // deliberate reuse of SIDEREAL_RATE overstates it by 0.27% (~1 min at H₀ ≈ 90°), which the
+    // ±72 min bracket absorbs; the estimate only centers the bracket, `straddles` decides.
     const double estimate = transit + sign * (H0->deg() / astro::toolbox::SIDEREAL_RATE_DEG_PER_DAY);
     const double lo = estimate - RISE_SET_BRACKET_HALF_WIDTH_DAYS;
     const double hi = estimate + RISE_SET_BRACKET_HALF_WIDTH_DAYS;
@@ -457,7 +464,13 @@ struct SunLocal {
   const double lo = is_sunrise ? culmination : transit;
   const double hi = is_sunrise ? transit : culmination;
   if (straddles(lo, hi)) {
-    return solve(lo, hi);
+    if (const auto root = solve(lo, hi); root.has_value()) {
+      return root;
+    }
+    // The straddle just proved a crossing exists, so a guard rejection here is a numerical
+    // failure, not a polar verdict — surface it loudly instead of returning nullopt, which
+    // `calculate` would compound into a wrong polar-day/night flag (per review).
+    throw std::runtime_error { "rise_set_jde: bracketed root failed to converge" };
   }
 
   return std::nullopt;

--- a/src/astro/sunrise_sunset.hpp
+++ b/src/astro/sunrise_sunset.hpp
@@ -1,0 +1,508 @@
+/*
+ * CelestialCalendar:
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ *
+ * Copyright (C) 2026 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <cmath>
+#include <format>
+#include <optional>
+#include <stdexcept>
+
+#include "toolbox.hpp"
+#include "datetime.hpp"
+#include "julian_day.hpp"
+#include "coord_transform.hpp"
+#include "sidereal_time.hpp"
+#include "sun.hpp"
+
+
+namespace astro::sunrise_sunset {
+
+#pragma region Constants
+
+/**
+ * @brief The standard altitude of the Sun's center at rise/set: -0°50' = -0.8333…°.
+ * @note Meeus Chapter 15: -34' of standard atmospheric refraction at the horizon,
+ *       plus -16' so that the event refers to the Sun's upper limb, not its center.
+ */
+inline constexpr auto STANDARD_ALTITUDE = astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>::from_arcmin(-50.0);
+
+/** @brief The Sun's altitude at civil twilight: -6°. */
+inline constexpr astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> CIVIL_TWILIGHT { -6.0 };
+
+/** @brief The Sun's altitude at nautical twilight: -12°. */
+inline constexpr astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> NAUTICAL_TWILIGHT { -12.0 };
+
+/** @brief The Sun's altitude at astronomical twilight: -18°. */
+inline constexpr astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> ASTRONOMICAL_TWILIGHT { -18.0 };
+
+/**
+ * @brief How far past ±1 cos(H₀) may land and still count as a grazing event rather than
+ *        a polar day/night verdict.
+ * @note Roundoff in `(sin h₀ - sin φ sin δ) / (cos φ cos δ)` is a few ulps (~1e-16); 1e-9 keeps
+ *       a wide margin over that while staying far below any physically meaningful excess.
+ */
+inline constexpr double COS_H0_CLAMP_TOLERANCE = 1e-9;
+
+/**
+ * @brief Below this |cos φ · cos δ| the hour-angle equation is treated as degenerate (observer at
+ *        a geographic pole, or the body at a celestial pole).
+ */
+inline constexpr double POLAR_DENOMINATOR_EPSILON = 1e-10;
+
+/**
+ * @brief The half-width of the root bracket around the transit estimate, in days.
+ * @note The estimate is local mean noon; the true transit deviates from it by the equation of
+ *       time only, |EoT| ≤ 16.5 min ≈ 0.0115 day — a 8.7x margin. The hour angle sweeps
+ *       ±36° across this bracket, well clear of the ±180° wrap.
+ */
+inline constexpr double TRANSIT_BRACKET_HALF_WIDTH_DAYS = 0.1;
+
+/**
+ * @brief The half-width of the first-try root bracket around the rise/set estimate, in days.
+ * @note The estimate extrapolates H₀ computed from the declination at transit; away from the
+ *       polar boundary the δ drift between transit and the event (≤ ~0.2°) moves the true root
+ *       by a few minutes at most, so ±72 min is a comfortable margin. Near the polar boundary
+ *       the extrapolation degrades without bound — which is why this bracket is only an
+ *       accelerator: the decider is the sign check at the bracket ends, with the
+ *       transit-to-lower-culmination bracket as fallback (see `rise_set_jde`).
+ */
+inline constexpr double RISE_SET_BRACKET_HALF_WIDTH_DAYS = 0.05;
+
+/**
+ * @brief The nominal half solar day, in days — the mean-time estimate of how far the lower
+ *        culmination sits from the transit. The apparent value deviates from 0.5 by up to
+ *        ~±15 s (the apparent solar day runs 24h ± ~30 s), which is why the fallback bracket
+ *        ends at the *solved* lower culmination, not at transit ± 0.5 (per review: a short
+ *        polar-boundary night centered on the lower culmination can lie entirely outside
+ *        an exact half-day window).
+ */
+inline constexpr double HALF_SOLAR_DAY_DAYS = 0.5;
+
+/**
+ * @brief The half-width of the root bracket around the lower-culmination estimate, in days.
+ * @note The estimate is transit ± `HALF_SOLAR_DAY_DAYS`; the true lower culmination deviates
+ *       by ≤ ~15 s ≈ 1.8e-4 day — a 500x margin. The unwrapped H−180° sweeps ±36° across
+ *       this bracket, well clear of its wrap (which sits at the upper culminations).
+ */
+inline constexpr double LOWER_CULMINATION_BRACKET_HALF_WIDTH_DAYS = 0.1;
+
+/**
+ * @brief The residual guard on a rise/set root, in degrees of altitude.
+ * @note Robustness only: after a directed sign check the bracketed Newton solve converges to
+ *       residuals ~1e-7° for the Sun; this guard (4 orders looser) exists so that a degenerate
+ *       solve — `newton_method` may return a best-effort iterate when f′ collapses — surfaces
+ *       as "no event" instead of a wrong instant, and to keep the contract honest if this
+ *       solver is ever reused for the Moon.
+ */
+inline constexpr double RISE_SET_RESIDUAL_GUARD_DEG = 1e-3;
+
+#pragma endregion
+
+
+#pragma region Types
+
+/**
+ * @brief An observer's location on the Earth.
+ * @note `longitude` is **positive east** of Greenwich (the modern/ISO 6709 convention),
+ *       in [-180°, 180°]. This is the opposite of Meeus's west-positive convention used by
+ *       `sidereal::local_apparent`; the negation happens inside this namespace, so callers
+ *       never deal with west-positive longitudes.
+ * @note +180° and -180° name the same meridian but are NOT interchangeable here: the date
+ *       input is a UT1 date, so they select transit-centered windows one day apart (local
+ *       mean noon at +180° is 0h UT of that date; at -180° it is 24h UT). Pick the sign
+ *       matching the intended UT window — deliberate, same behavior as other UT-date APIs.
+ */
+struct GeoLocation {
+  astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> latitude;  // North-positive, [-90°, 90°].
+  astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> longitude; // East-positive, [-180°, 180°].
+};
+
+/**
+ * @brief The result of a rise/transit/set calculation for one date.
+ * @note All instants are JDE, on the **TT** scale, like every other moment produced by this
+ *       library. Use `julian_day::jde_to_ut1` to read them as civil (UT1) datetimes.
+ * @note `is_polar_day`/`is_polar_night` are set only when neither rise nor set exists in the
+ *       transit-centered window; on the transition days around the polar seasons one of the two
+ *       events can exist alone, in which case both flags stay false.
+ */
+struct Result {
+  std::optional<double> sunrise_jde;  // The sunrise instant, or nullopt if the Sun never crosses h₀ upward.
+  std::optional<double> sunset_jde;   // The sunset instant, or nullopt if the Sun never crosses h₀ downward.
+  double transit_jde;                 // The upper-culmination instant. Exists even on polar days/nights.
+  bool is_polar_day;                  // The Sun stays above h₀ all day.
+  bool is_polar_night;                // The Sun stays below h₀ all day.
+};
+
+#pragma endregion
+
+
+namespace detail {
+
+/**
+ * @brief Validate an observer location, throwing on out-of-range or non-finite coordinates.
+ * @param location The location to validate.
+ * @throw std::invalid_argument If latitude ∉ [-90°, 90°] or longitude ∉ [-180°, 180°],
+ *        or either is not finite.
+ */
+inline void validate(const GeoLocation& location) {
+  const double lat = location.latitude.deg();
+  const double lon = location.longitude.deg();
+
+  if (not std::isfinite(lat) or lat < -90.0 or lat > 90.0) {
+    throw std::invalid_argument {
+      std::format("Argument `location.latitude` out of range [-90, 90], whose value is {}", lat)
+    };
+  }
+
+  if (not std::isfinite(lon) or lon < -180.0 or lon > 180.0) {
+    throw std::invalid_argument {
+      std::format("Argument `location.longitude` out of range [-180, 180], whose value is {}", lon)
+    };
+  }
+}
+
+/**
+ * @brief Convert a JDE (TT) to the JD (UT1) of the same instant.
+ * @param jde_tt The julian ephemeris day, on the **TT** scale.
+ * @return The julian day number, on the **UT1** scale.
+ */
+[[nodiscard]] inline auto jde_tt_to_jd_ut1(const double jde_tt) -> double {
+  return astro::julian_day::ut1_to_jd(astro::julian_day::jde_to_ut1(jde_tt));
+}
+
+/** @brief The Sun's local hour angle and equatorial position at one instant. */
+struct SunLocal {
+  double hour_angle_deg;                // The local hour angle H = θ(LAST) - α, unwrapped to [-180°, 180°).
+  astro::coords::EquatorialCoord eq;    // The Sun's apparent equatorial coordinates (α, δ).
+};
+
+/**
+ * @brief Compute the Sun's local hour angle and equatorial coordinates for an observer.
+ * @param jde_tt The instant, as a julian ephemeris day on the **TT** scale.
+ * @param location The observer's location.
+ * @return The hour angle (unwrapped to [-180°, 180°)) and the equatorial coordinates.
+ * @note The sidereal time is evaluated on the UT1 scale (pitfall: feeding TT would shift the
+ *       result by ΔT ≈ 69 s); the Sun's position and the nutation terms are evaluated on TT.
+ */
+[[nodiscard]] inline auto sun_local(const double jde_tt, const GeoLocation& location) -> SunLocal {
+  const double jd_ut1 = jde_tt_to_jd_ut1(jde_tt);
+  const auto eq = astro::sun::equatorial_coord::apparent(jde_tt);
+
+  // `local_apparent` wants Meeus's west-positive longitude; `GeoLocation` carries east-positive.
+  const auto θ = astro::sidereal::local_apparent(jd_ut1, jde_tt, -location.longitude);
+
+  return {
+    .hour_angle_deg = astro::toolbox::normalize_pm180((θ - eq.α).deg()),
+    .eq = eq,
+  };
+}
+
+/**
+ * @brief Compute the Sun's geometric altitude for an observer at one instant.
+ * @param jde_tt The instant, as a julian ephemeris day on the **TT** scale.
+ * @param location The observer's location.
+ * @return The Sun's altitude, in [-90°, 90°]. Purely geometric — refraction enters only through
+ *         the h₀ convention (e.g. `STANDARD_ALTITUDE`), not through this function.
+ */
+[[nodiscard]] inline auto sun_altitude(
+  const double jde_tt,
+  const GeoLocation& location
+) -> astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> {
+  using astro::toolbox::Angle;
+  using astro::toolbox::AngleUnit::DEG;
+
+  const auto local = sun_local(jde_tt, location);
+  const auto horizontal = astro::coords::equatorial_to_horizontal(
+    Angle<DEG> { local.hour_angle_deg }, local.eq.δ, location.latitude
+  );
+  return horizontal.h;
+}
+
+/**
+ * @brief Compute the Sun's lower culmination adjacent to a transit, before or after it.
+ * @param transit The upper-culmination instant (JDE, TT scale).
+ * @param before True for the lower culmination preceding the transit, false for the following one.
+ * @param location The observer's location.
+ * @return The lower-culmination instant (JDE, TT scale).
+ * @note Solves H = ±180° with the wrap moved onto the upper culminations: the residual
+ *       `normalize_pm180(H - 180°)` is smooth around the lower culmination, exactly as
+ *       the plain unwrapped H is smooth around the transit.
+ */
+[[nodiscard]] inline auto lower_culmination_jde(
+  const double transit,
+  const bool before,
+  const GeoLocation& location
+) -> double {
+  const auto f = [&location](const double jde) -> double {
+    return astro::toolbox::normalize_pm180(sun_local(jde, location).hour_angle_deg - 180.0);
+  };
+
+  const double estimate = before ? transit - HALF_SOLAR_DAY_DAYS : transit + HALF_SOLAR_DAY_DAYS;
+  return astro::toolbox::newton_method(
+    f,
+    estimate - LOWER_CULMINATION_BRACKET_HALF_WIDTH_DAYS,
+    estimate + LOWER_CULMINATION_BRACKET_HALF_WIDTH_DAYS,
+    astro::toolbox::SIDEREAL_RATE_DEG_PER_DAY
+  );
+}
+
+} // namespace detail
+
+
+/**
+ * @brief Compute the hour angle at which a body of declination δ reaches altitude h₀, as seen
+ *        from latitude φ.
+ * @param δ The body's declination.
+ * @param φ The observer's geographic latitude.
+ * @param h0 The target altitude.
+ * @return The (positive) hour angle H₀ ∈ [0°, 180°]; the body is at h₀ at hour angles ±H₀.
+ *         Returns `nullopt` when the altitude is never reached (polar day/night) or when the
+ *         equation degenerates (observer at a pole).
+ * @throw std::invalid_argument If any argument is not finite or lies outside [-90°, 90°]
+ *        (outside that domain sin/cos alias and (15.1) returns a physically meaningless H₀).
+ * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 15, Formula (15.1).
+ */
+[[nodiscard]] inline auto hour_angle_at_altitude(
+  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& δ,
+  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& φ,
+  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& h0
+) -> std::optional<astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>> {
+  using astro::toolbox::Angle;
+  using astro::toolbox::AngleUnit::DEG;
+  using astro::toolbox::rad_to_deg;
+
+  const auto reject_outside_pm90 = [](const char* name, const double deg) {
+    if (not std::isfinite(deg) or deg < -90.0 or deg > 90.0) {
+      throw std::invalid_argument {
+        std::format("Argument `{}` out of range [-90, 90], whose value is {}", name, deg)
+      };
+    }
+  };
+  reject_outside_pm90("δ", δ.deg());
+  reject_outside_pm90("φ", φ.deg());
+  reject_outside_pm90("h0", h0.deg());
+
+  const double denominator = std::cos(φ.rad()) * std::cos(δ.rad());
+  if (std::fabs(denominator) < POLAR_DENOMINATOR_EPSILON) [[unlikely]] {
+    return std::nullopt;
+  }
+
+  // Meeus (15.1): cos H₀ = (sin h₀ - sin φ sin δ) / (cos φ cos δ).
+  double cos_H0 = (std::sin(h0.rad()) - std::sin(φ.rad()) * std::sin(δ.rad())) / denominator;
+
+  // Roundoff can push a grazing event just past ±1, where acos would return NaN — clamp within
+  // the tolerance, and treat anything beyond it as a real polar day (< -1) or night (> +1).
+  if (cos_H0 < -1.0) {
+    if (cos_H0 < -1.0 - COS_H0_CLAMP_TOLERANCE) {
+      return std::nullopt;
+    }
+    cos_H0 = -1.0;
+  }
+  if (cos_H0 > 1.0) {
+    if (cos_H0 > 1.0 + COS_H0_CLAMP_TOLERANCE) {
+      return std::nullopt;
+    }
+    cos_H0 = 1.0;
+  }
+
+  return Angle<DEG> { rad_to_deg(std::acos(cos_H0)) };
+}
+
+
+/**
+ * @brief Compute the instant of the Sun's upper culmination (solar transit / solar noon) on a date.
+ * @param ymd The date, interpreted on the **UT1** scale (not local civil time — callers handle
+ *        time zones). The returned transit is the one nearest 12h local mean time on this date.
+ * @param location The observer's location.
+ * @return The transit instant, as a julian ephemeris day on the **TT** scale.
+ * @throw std::invalid_argument If `ymd` is invalid or `location` is out of range.
+ * @note The root of H = 0 is found with `toolbox::newton_method` on the unwrapped hour angle;
+ *       the initial bracket is local mean noon ± `TRANSIT_BRACKET_HALF_WIDTH_DAYS`, which the
+ *       equation of time can never escape (see the constant's note).
+ */
+[[nodiscard]] inline auto transit_jde(
+  const std::chrono::year_month_day& ymd,
+  const GeoLocation& location
+) -> double {
+  detail::validate(location);
+
+  // Local mean noon in UT1: 12h UT minus the east-positive longitude's worth of a day.
+  // The offset is applied in JDE arithmetic (not in the Datetime fraction) so longitudes near
+  // ±180° cannot push the fraction outside [0, 1).
+  const calendar::Datetime noon_ut1 { ymd, 0.5 };
+  const double estimate = astro::julian_day::ut1_to_jde(noon_ut1) - location.longitude.deg() / 360.0;
+
+  const auto f = [&location](const double jde) -> double {
+    return detail::sun_local(jde, location).hour_angle_deg;
+  };
+
+  return astro::toolbox::newton_method(
+    f,
+    estimate - TRANSIT_BRACKET_HALF_WIDTH_DAYS,
+    estimate + TRANSIT_BRACKET_HALF_WIDTH_DAYS,
+    astro::toolbox::SIDEREAL_RATE_DEG_PER_DAY
+  );
+}
+
+
+/**
+ * @brief Compute the instant at which the Sun crosses altitude h₀, before (sunrise) or after
+ *        (sunset) a given transit.
+ * @param transit The transit instant, as a julian ephemeris day on the **TT** scale
+ *        (from `transit_jde`).
+ * @param is_sunrise True for the upward crossing before transit, false for the downward
+ *        crossing after it.
+ * @param location The observer's location.
+ * @param h0 The crossing altitude. Defaults to `STANDARD_ALTITUDE`; pass a twilight constant
+ *        for dawn/dusk instants.
+ * @return The crossing instant (JDE, TT scale), or `nullopt` when the Sun does not cross h₀
+ *         between the transit and the adjacent lower culmination (polar day/night).
+ * @throw std::invalid_argument If `transit` is not finite, `location` is out of range, or `h0`
+ *        is not finite or outside [-90°, 90°].
+ * @note The root of (altitude - h₀) = 0 is found with `toolbox::newton_method`. Working on the
+ *       altitude directly sidesteps two of the classic pitfalls: there is no hand-written
+ *       dh/dH derivative to get wrong (the solver differentiates numerically), and no hour-angle
+ *       sign convention to enforce (the bracket side selects the event).
+ * @note Whether a crossing exists is decided by a directed sign check at the bracket ends — the
+ *       H₀-based estimate only accelerates the search, it never decides (#63's lesson: measure
+ *       the quantity that actually drives the behavior). When the tight bracket misses (polar
+ *       boundary, where extrapolating transit's δ degrades), the fallback bracket runs from the
+ *       transit to the *solved* adjacent lower culmination — not to transit ± 0.5, whose ~±15 s
+ *       error could swallow a short polar-boundary night whole (per review).
+ */
+[[nodiscard]] inline auto rise_set_jde(
+  const double transit,
+  const bool is_sunrise,
+  const GeoLocation& location,
+  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& h0 = STANDARD_ALTITUDE
+) -> std::optional<double> {
+  detail::validate(location);
+
+  if (not std::isfinite(transit)) {
+    throw std::invalid_argument {
+      std::format("Argument `transit` is not finite, whose value is {}", transit)
+    };
+  }
+  if (not std::isfinite(h0.deg()) or h0.deg() < -90.0 or h0.deg() > 90.0) {
+    throw std::invalid_argument {
+      std::format("Argument `h0` out of range [-90, 90], whose value is {}", h0.deg())
+    };
+  }
+
+  const auto f = [&location, &h0](const double jde) -> double {
+    return detail::sun_altitude(jde, location).deg() - h0.deg();
+  };
+
+  // Sunrise is an upward crossing (f goes - to +), sunset a downward one; requiring the right
+  // direction — not just a sign change — is what rejects brackets that contain no event.
+  const auto straddles = [&f, is_sunrise](const double lo, const double hi) -> bool {
+    const double f_lo = f(lo);
+    const double f_hi = f(hi);
+    return is_sunrise ? (f_lo < 0.0 and f_hi > 0.0) : (f_lo > 0.0 and f_hi < 0.0);
+  };
+
+  // The residual guard turns a degenerate solve into "no event" instead of a wrong instant;
+  // see `RISE_SET_RESIDUAL_GUARD_DEG` (robustness only, per review).
+  const auto solve = [&f](const double lo, const double hi) -> std::optional<double> {
+    const double root = astro::toolbox::newton_method(f, lo, hi, astro::toolbox::SIDEREAL_RATE_DEG_PER_DAY);
+    if (std::fabs(f(root)) > RISE_SET_RESIDUAL_GUARD_DEG) [[unlikely]] {
+      return std::nullopt;
+    }
+    return root;
+  };
+
+  // First try: a tight bracket around the mean-rate extrapolation of H₀ from transit's δ.
+  const auto eq_transit = astro::sun::equatorial_coord::apparent(transit);
+  const auto H0 = hour_angle_at_altitude(eq_transit.δ, location.latitude, h0);
+  const double sign = is_sunrise ? -1.0 : 1.0;
+
+  if (H0.has_value()) {
+    const double estimate = transit + sign * (H0->deg() / astro::toolbox::SIDEREAL_RATE_DEG_PER_DAY);
+    const double lo = estimate - RISE_SET_BRACKET_HALF_WIDTH_DAYS;
+    const double hi = estimate + RISE_SET_BRACKET_HALF_WIDTH_DAYS;
+    if (straddles(lo, hi)) {
+      // On a guard rejection fall THROUGH to the fallback rather than reporting "no event":
+      // the straddle proved a root exists, so the tight bracket must never be the last word.
+      if (const auto root = solve(lo, hi); root.has_value()) {
+        return root;
+      }
+    }
+  }
+
+  // Fallback: from the transit to the solved adjacent lower culmination, whose endpoint IS the
+  // Sun's altitude minimum — so the directed sign check there is the exact existence criterion.
+  const double culmination = detail::lower_culmination_jde(transit, is_sunrise, location);
+  const double lo = is_sunrise ? culmination : transit;
+  const double hi = is_sunrise ? transit : culmination;
+  if (straddles(lo, hi)) {
+    return solve(lo, hi);
+  }
+
+  return std::nullopt;
+}
+
+
+/**
+ * @brief Compute sunrise, transit, and sunset for a date and location.
+ * @param ymd The date, interpreted on the **UT1** scale (callers handle time zones).
+ * @param location The observer's location.
+ * @param h0 The event altitude. Defaults to `STANDARD_ALTITUDE`; pass a twilight constant to
+ *        compute dawn/dusk instead.
+ * @return The three instants (JDE, TT scale) and the polar-day/night flags; see `Result`'s notes
+ *         for the exact semantics.
+ * @throw std::invalid_argument If `ymd` is invalid, `location` is out of range, or `h0` is not
+ *        finite or outside [-90°, 90°].
+ * @note Consumer trap (deliberate semantics): because `ymd` is a UT1 date, for eastern
+ *       longitudes the returned sunrise can fall on the *previous* UT1 calendar day (e.g.
+ *       Beijing's sunrise is ~21-22h UT of `ymd - 1`); callers building a local calendar day
+ *       must convert with their time zone, not assume all three instants share `ymd`.
+ */
+[[nodiscard]] inline auto calculate(
+  const std::chrono::year_month_day& ymd,
+  const GeoLocation& location,
+  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& h0 = STANDARD_ALTITUDE
+) -> Result {
+  const double transit = transit_jde(ymd, location);
+
+  Result result {
+    .sunrise_jde = rise_set_jde(transit, true, location, h0),
+    .sunset_jde  = rise_set_jde(transit, false, location, h0),
+    .transit_jde = transit,
+    .is_polar_day = false,
+    .is_polar_night = false,
+  };
+
+  if (not result.sunrise_jde.has_value() and not result.sunset_jde.has_value()) {
+    // `>=`: an exact graze (the Sun's center touching h₀ at transit without crossing) counts as
+    // a polar day — the midnight-sun convention "never goes below" includes the touch.
+    const bool above = detail::sun_altitude(transit, location).deg() >= h0.deg();
+    result.is_polar_day = above;
+    result.is_polar_night = not above;
+  }
+
+  return result;
+}
+
+} // namespace astro::sunrise_sunset

--- a/src/astro/sunrise_sunset.hpp
+++ b/src/astro/sunrise_sunset.hpp
@@ -25,9 +25,11 @@
 
 #include <chrono>
 #include <cmath>
+#include <concepts>
 #include <format>
 #include <optional>
 #include <stdexcept>
+#include <type_traits>
 
 #include "toolbox.hpp"
 #include "datetime.hpp"
@@ -269,6 +271,73 @@ struct SunLocal {
   );
 }
 
+/**
+ * @brief Validate `rise_set_jde`'s inputs.
+ * @throw std::invalid_argument If `transit` is not finite, `location` is out of range, or `h0`
+ *        is not finite or outside [-90°, 90°].
+ */
+inline void validate_rise_set_inputs(
+  const double transit,
+  const GeoLocation& location,
+  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& h0
+) {
+  validate(location);
+
+  if (not std::isfinite(transit)) {
+    throw std::invalid_argument {
+      std::format("Argument `transit` is not finite, whose value is {}", transit)
+    };
+  }
+  if (not std::isfinite(h0.deg()) or h0.deg() < -90.0 or h0.deg() > 90.0) {
+    throw std::invalid_argument {
+      std::format("Argument `h0` out of range [-90, 90], whose value is {}", h0.deg())
+    };
+  }
+}
+
+/** @brief A refined crossing and the |altitude − h₀| residual it left, in degrees. */
+struct Solved {
+  double root_jde;
+  double residual_deg;
+};
+
+/**
+ * @brief Try to solve one altitude crossing inside a bracket.
+ * @param f The residual function (altitude − h₀), in degrees, over JDE (TT).
+ * @param lo_jde The left bracket end, inclusive.
+ * @param hi_jde The right bracket end, exclusive.
+ * @param rising True for an upward crossing (sunrise side), false for a downward one.
+ * @return `nullopt` when the bracket ends do not straddle a crossing in the required direction
+ *         (a plain sign change is not enough — direction is what rejects event-free brackets);
+ *         otherwise the refined root plus its residual. The residual verdict is the caller's:
+ *         a straddle proves a root exists, so what a rejection *means* depends on the bracket.
+ */
+// The `_jde` suffixes carry the contract at the call site.
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
+template <typename Func>
+requires std::invocable<Func, double>
+     and std::convertible_to<std::invoke_result_t<Func, double>, double>
+[[nodiscard]] inline auto crossing_in_bracket(
+  const Func& f,
+  const double lo_jde,
+  const double hi_jde,
+  const bool rising
+) -> std::optional<Solved> {
+  const double f_lo = f(lo_jde);
+  const double f_hi = f(hi_jde);
+
+  const bool straddles = rising ? (f_lo < 0.0 and f_hi > 0.0) : (f_lo > 0.0 and f_hi < 0.0);
+  if (not straddles) {
+    return std::nullopt;
+  }
+
+  const double root = astro::toolbox::newton_method(
+    f, lo_jde, hi_jde, astro::toolbox::SIDEREAL_RATE_DEG_PER_DAY
+  );
+  return Solved { .root_jde = root, .residual_deg = std::fabs(f(root)) };
+}
+// NOLINTEND(bugprone-easily-swappable-parameters)
+
 } // namespace detail
 
 
@@ -383,19 +452,13 @@ struct SunLocal {
  *         between the transit and the adjacent lower culmination (polar day/night).
  * @throw std::invalid_argument If `transit` is not finite, `location` is out of range, or `h0`
  *        is not finite or outside [-90°, 90°].
- * @throw std::runtime_error If a sign change proved a crossing exists but the solve failed the
- *        residual guard — a numerical failure that must not masquerade as a polar verdict
- *        (unreachable for the Sun as far as testing and review can tell).
- * @note The root of (altitude - h₀) = 0 is found with `toolbox::newton_method`. Working on the
- *       altitude directly sidesteps two of the classic pitfalls: there is no hand-written
- *       dh/dH derivative to get wrong (the solver differentiates numerically), and no hour-angle
- *       sign convention to enforce (the bracket side selects the event).
- * @note Whether a crossing exists is decided by a directed sign check at the bracket ends — the
- *       H₀-based estimate only accelerates the search, it never decides (#63's lesson: measure
- *       the quantity that actually drives the behavior). When the tight bracket misses (polar
- *       boundary, where extrapolating transit's δ degrades), the fallback bracket runs from the
- *       transit to the *solved* adjacent lower culmination — not to transit ± 0.5, whose ~±15 s
- *       error could swallow a short polar-boundary night whole (per review).
+ * @throw std::runtime_error If a directed sign change proved a crossing exists but the solve
+ *        failed the residual guard — a numerical failure must not read as a polar verdict.
+ * @note Solves (altitude − h₀) = 0 directly: no hand-written dh/dH derivative, no hour-angle
+ *       sign convention — the bracket side selects the event. Existence is decided by the
+ *       directed sign check inside `detail::crossing_in_bracket`; the H₀-based bracket only
+ *       accelerates, the bracket ending at the *solved* lower culmination (the altitude
+ *       minimum) is the authority.
  */
 [[nodiscard]] inline auto rise_set_jde(
   const double transit,
@@ -403,89 +466,57 @@ struct SunLocal {
   const GeoLocation& location,
   const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& h0 = STANDARD_ALTITUDE
 ) -> std::optional<double> {
-  detail::validate(location);
-
-  if (not std::isfinite(transit)) {
-    throw std::invalid_argument {
-      std::format("Argument `transit` is not finite, whose value is {}", transit)
-    };
-  }
-  if (not std::isfinite(h0.deg()) or h0.deg() < -90.0 or h0.deg() > 90.0) {
-    throw std::invalid_argument {
-      std::format("Argument `h0` out of range [-90, 90], whose value is {}", h0.deg())
-    };
-  }
+  detail::validate_rise_set_inputs(transit, location, h0);
 
   const auto f = [&location, &h0](const double jde) -> double {
     return detail::sun_altitude(jde, location).deg() - h0.deg();
   };
 
-  // Sunrise is an upward crossing (f goes - to +), sunset a downward one; requiring the right
-  // direction — not just a sign change — is what rejects brackets that contain no event.
-  const auto straddles = [&f, is_sunrise](const double lo, const double hi) -> bool {
-    const double f_lo = f(lo);
-    const double f_hi = f(hi);
-    return is_sunrise ? (f_lo < 0.0 and f_hi > 0.0) : (f_lo > 0.0 and f_hi < 0.0);
-  };
-
-  // The residual guard keeps a degenerate solve from shipping a wrong instant; see
-  // `RISE_SET_RESIDUAL_GUARD_DEG` (robustness only, per review). The residual is returned
-  // alongside the root so a guard rejection can be reported with context.
-  struct Solved {
-    double root;
-    double residual_deg;
-  };
-  const auto solve = [&f](const double lo, const double hi) -> Solved {
-    const double root = astro::toolbox::newton_method(f, lo, hi, astro::toolbox::SIDEREAL_RATE_DEG_PER_DAY);
-    return { .root = root, .residual_deg = std::fabs(f(root)) };
-  };
-
   // First try: a tight bracket around the mean-rate extrapolation of H₀ from transit's δ.
+  // (Reusing the sidereal rate overstates the Sun's ~360.0°/day sweep by 0.27% — ~1 min at
+  // H₀ ≈ 90°; the ±72 min bracket absorbs it, the sign check decides.)
   const auto eq_transit = astro::sun::equatorial_coord::apparent(transit);
   const auto H0 = hour_angle_at_altitude(eq_transit.δ, location.latitude, h0);
-  const double sign = is_sunrise ? -1.0 : 1.0;
 
   if (H0.has_value()) {
-    // The Sun's hour angle sweeps ~360.0°/day (mean solar rate), not the sidereal rate — the
-    // deliberate reuse of SIDEREAL_RATE overstates it by 0.27% (~1 min at H₀ ≈ 90°), which the
-    // ±72 min bracket absorbs; the estimate only centers the bracket, `straddles` decides.
+    const double sign = is_sunrise ? -1.0 : 1.0;
     const double estimate = transit + sign * (H0->deg() / astro::toolbox::SIDEREAL_RATE_DEG_PER_DAY);
-    const double lo = estimate - RISE_SET_BRACKET_HALF_WIDTH_DAYS;
-    const double hi = estimate + RISE_SET_BRACKET_HALF_WIDTH_DAYS;
-    if (straddles(lo, hi)) {
-      // On a guard rejection fall THROUGH to the fallback rather than reporting "no event":
-      // the straddle proved a root exists, so the tight bracket must never be the last word.
-      const auto solved = solve(lo, hi);
-      if (solved.residual_deg <= RISE_SET_RESIDUAL_GUARD_DEG) [[likely]] {
-        return solved.root;
-      }
+    const auto solved = detail::crossing_in_bracket(
+      f,
+      estimate - RISE_SET_BRACKET_HALF_WIDTH_DAYS,
+      estimate + RISE_SET_BRACKET_HALF_WIDTH_DAYS,
+      is_sunrise
+    );
+    if (solved.has_value() and solved->residual_deg <= RISE_SET_RESIDUAL_GUARD_DEG) [[likely]] {
+      return solved->root_jde;
     }
+    // A guard rejection falls through — the tight bracket must never be the last word.
   }
 
-  // Fallback: from the transit to the solved adjacent lower culmination, whose endpoint IS the
-  // Sun's altitude minimum — so the directed sign check there is the exact existence criterion.
+  // The authority: from the transit to the solved adjacent lower culmination, whose endpoint
+  // IS the altitude minimum — the directed sign check there is the exact existence criterion.
   const double culmination = detail::lower_culmination_jde(transit, is_sunrise, location);
   const double lo = is_sunrise ? culmination : transit;
   const double hi = is_sunrise ? transit : culmination;
-  if (straddles(lo, hi)) {
-    const auto solved = solve(lo, hi);
-    if (solved.residual_deg <= RISE_SET_RESIDUAL_GUARD_DEG) [[likely]] {
-      return solved.root;
-    }
-    // The straddle just proved a crossing exists, so a guard rejection here is a numerical
-    // failure, not a polar verdict — surface it loudly instead of returning nullopt, which
-    // `calculate` would compound into a wrong polar-day/night flag (per review).
-    throw std::runtime_error {
-      std::format(
-        "rise_set_jde: bracketed {} root failed to converge: |altitude - h0| = {} deg at jde {} "
-        "(bracket [{}, {}], guard {} deg)",
-        is_sunrise ? "sunrise" : "sunset",
-        solved.residual_deg, solved.root, lo, hi, RISE_SET_RESIDUAL_GUARD_DEG
-      )
-    };
+
+  const auto solved = detail::crossing_in_bracket(f, lo, hi, is_sunrise);
+  if (not solved.has_value()) {
+    return std::nullopt; // No directed crossing in the half arc: polar day/night.
+  }
+  if (solved->residual_deg <= RISE_SET_RESIDUAL_GUARD_DEG) [[likely]] {
+    return solved->root_jde;
   }
 
-  return std::nullopt;
+  // This straddle proved a crossing exists, so a guard rejection here is a numerical failure —
+  // surface it loudly instead of letting `calculate` turn it into a wrong polar-day/night flag.
+  throw std::runtime_error {
+    std::format(
+      "rise_set_jde: bracketed {} root failed to converge: |altitude - h0| = {} deg at jde {} "
+      "(bracket [{}, {}], guard {} deg)",
+      is_sunrise ? "sunrise" : "sunset",
+      solved->residual_deg, solved->root_jde, lo, hi, RISE_SET_RESIDUAL_GUARD_DEG
+    )
+  };
 }
 
 

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -398,8 +398,8 @@ inline auto newton_method(
     const double h = std::max(step, NEWTON_MIN_STEP_ULP * ulp(jde));
     const double f_prime = (f(jde + h) - f(jde - h)) / (2.0 * h);
 
-    // A shared solver has to tolerate an `f` that is not defined everywhere -- #43's rise/set `f`
-    // goes NaN where a body is circumpolar -- and a collapsed f' has no direction left to offer.
+    // A shared solver has to tolerate an `f` that may go non-finite somewhere in its bracket
+    // (#43 originally planned such an f), and a collapsed f' has no direction left to offer.
     if (not std::isfinite(f_prime) or f_prime == 0.0) {
       break;
     }

--- a/src/test/astro/sunrise_sunset_test.cpp
+++ b/src/test/astro/sunrise_sunset_test.cpp
@@ -23,6 +23,8 @@
 
 #include <chrono>
 #include <limits>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/src/test/astro/sunrise_sunset_test.cpp
+++ b/src/test/astro/sunrise_sunset_test.cpp
@@ -77,7 +77,7 @@ TEST(SunriseSunset, HourAngleAtAltitudeMatchesHorizontalAltitude) {
 
         for (const double sign : { 1.0, -1.0 }) {
           const auto horizontal = astro::coords::equatorial_to_horizontal(
-            *H0 * sign, Angle<DEG> { δ }, Angle<DEG> { φ }
+            H0.value() * sign, Angle<DEG> { δ }, Angle<DEG> { φ }
           );
           ASSERT_NEAR(horizontal.h.deg(), h0, 1e-9)
             << "δ=" << δ << " φ=" << φ << " h0=" << h0 << " sign=" << sign;
@@ -102,7 +102,7 @@ TEST(SunriseSunset, HourAngleAtAltitudePolarAndDegenerateCases) {
   // Equator, equinoctial Sun, geometric horizon: the diurnal arc is exactly a half turn.
   const auto H0 = hour_angle_at_altitude(Angle<DEG> { 0.0 }, Angle<DEG> { 0.0 }, Angle<DEG> { 0.0 });
   ASSERT_TRUE(H0.has_value());
-  ASSERT_NEAR(H0->deg(), 90.0, 1e-9);
+  ASSERT_NEAR(H0.value().deg(), 90.0, 1e-9);
 }
 
 TEST(SunriseSunset, AltitudeConstantsProvenance) {
@@ -195,8 +195,8 @@ TEST(SunriseSunset, RiseSetAltitudeIsH0) {
     ASSERT_TRUE(result.sunset_jde.has_value());
 
     // 0.001° ≈ 0.36". At typical crossing rates (~200°/day) that is ~0.4 s of time.
-    ASSERT_NEAR(detail::sun_altitude(*result.sunrise_jde, location).deg(), h0.deg(), 0.001);
-    ASSERT_NEAR(detail::sun_altitude(*result.sunset_jde, location).deg(), h0.deg(), 0.001);
+    ASSERT_NEAR(detail::sun_altitude(result.sunrise_jde.value(), location).deg(), h0.deg(), 0.001);
+    ASSERT_NEAR(detail::sun_altitude(result.sunset_jde.value(), location).deg(), h0.deg(), 0.001);
   }
 }
 
@@ -212,8 +212,8 @@ TEST(SunriseSunset, OrderIsCorrect) {
     const auto result = calculate(ymd, location);
     ASSERT_TRUE(result.sunrise_jde.has_value());
     ASSERT_TRUE(result.sunset_jde.has_value());
-    ASSERT_LT(*result.sunrise_jde, result.transit_jde);
-    ASSERT_LT(result.transit_jde, *result.sunset_jde);
+    ASSERT_LT(result.sunrise_jde.value(), result.transit_jde);
+    ASSERT_LT(result.transit_jde, result.sunset_jde.value());
     ASSERT_FALSE(result.is_polar_day);
     ASSERT_FALSE(result.is_polar_night);
   }
@@ -234,14 +234,14 @@ TEST(SunriseSunset, TwilightOrder) {
   }
 
   // Morning: astronomical dawn < nautical dawn < civil dawn < sunrise.
-  ASSERT_LT(*r_astro.sunrise_jde, *r_nautical.sunrise_jde);
-  ASSERT_LT(*r_nautical.sunrise_jde, *r_civil.sunrise_jde);
-  ASSERT_LT(*r_civil.sunrise_jde, *r_standard.sunrise_jde);
+  ASSERT_LT(r_astro.sunrise_jde.value(), r_nautical.sunrise_jde.value());
+  ASSERT_LT(r_nautical.sunrise_jde.value(), r_civil.sunrise_jde.value());
+  ASSERT_LT(r_civil.sunrise_jde.value(), r_standard.sunrise_jde.value());
 
   // Evening: sunset < civil dusk < nautical dusk < astronomical dusk.
-  ASSERT_LT(*r_standard.sunset_jde, *r_civil.sunset_jde);
-  ASSERT_LT(*r_civil.sunset_jde, *r_nautical.sunset_jde);
-  ASSERT_LT(*r_nautical.sunset_jde, *r_astro.sunset_jde);
+  ASSERT_LT(r_standard.sunset_jde.value(), r_civil.sunset_jde.value());
+  ASSERT_LT(r_civil.sunset_jde.value(), r_nautical.sunset_jde.value());
+  ASSERT_LT(r_nautical.sunset_jde.value(), r_astro.sunset_jde.value());
 }
 
 TEST(SunriseSunset, EquatorDayLength) {
@@ -253,7 +253,7 @@ TEST(SunriseSunset, EquatorDayLength) {
     ASSERT_TRUE(result.sunrise_jde.has_value());
     ASSERT_TRUE(result.sunset_jde.has_value());
 
-    const double day_length = *result.sunset_jde - *result.sunrise_jde;
+    const double day_length = result.sunset_jde.value() - result.sunrise_jde.value();
     ASSERT_NEAR(day_length, 0.5, 30.0 / (24.0 * 60.0)) << "month=" << month; // 12h ± 30 min.
   }
 }
@@ -265,8 +265,8 @@ TEST(SunriseSunset, RiseSetSymmetryAroundTransit) {
   ASSERT_TRUE(result.sunrise_jde.has_value());
   ASSERT_TRUE(result.sunset_jde.has_value());
 
-  const double morning = result.transit_jde - *result.sunrise_jde;
-  const double evening = *result.sunset_jde - result.transit_jde;
+  const double morning = result.transit_jde - result.sunrise_jde.value();
+  const double evening = result.sunset_jde.value() - result.transit_jde;
   ASSERT_NEAR(morning, evening, 0.01);
 }
 
@@ -315,8 +315,8 @@ TEST(SunriseSunset, PolarNightOnsetWeekIsCoherent) {
       ASSERT_FALSE(result.is_polar_night) << "day=" << day;
       ASSERT_FALSE(seen_polar_night) << "day=" << day; // No coming back out of the night in this window.
       if (events == 2) {
-        ASSERT_LT(*result.sunrise_jde, result.transit_jde);
-        ASSERT_LT(result.transit_jde, *result.sunset_jde);
+        ASSERT_LT(result.sunrise_jde.value(), result.transit_jde);
+        ASSERT_LT(result.transit_jde, result.sunset_jde.value());
       }
     }
   }
@@ -344,8 +344,8 @@ TEST(SunriseSunset, MidnightSunOnsetWeekIsCoherent) {
       ASSERT_FALSE(result.is_polar_day) << "day=" << day;
       ASSERT_FALSE(result.is_polar_night) << "day=" << day;
       if (events == 2) {
-        ASSERT_LT(*result.sunrise_jde, result.transit_jde);
-        ASSERT_LT(result.transit_jde, *result.sunset_jde);
+        ASSERT_LT(result.sunrise_jde.value(), result.transit_jde);
+        ASSERT_LT(result.transit_jde, result.sunset_jde.value());
       }
     }
   }

--- a/src/test/astro/sunrise_sunset_test.cpp
+++ b/src/test/astro/sunrise_sunset_test.cpp
@@ -23,6 +23,8 @@
 
 #include <chrono>
 #include <limits>
+#include <optional>
+#include <stdexcept>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -59,6 +61,19 @@ auto local_mean_noon_jde(const std::chrono::year_month_day& ymd, const GeoLocati
   return astro::julian_day::ut1_to_jde(noon_ut1) - location.longitude.deg() / 360.0;
 }
 
+/**
+ * @brief Checked unwrap for assertions. clang-tidy's bugprone-unchecked-optional-access cannot
+ *        see through gtest's ASSERT_TRUE, so tests unwrap through this provably-guarded helper
+ *        rather than NOLINT-ing every access.
+ */
+template <typename T>
+auto req(const std::optional<T>& opt) -> const T& {
+  if (not opt.has_value()) {
+    throw std::logic_error { "expected optional to hold a value" };
+  }
+  return *opt;
+}
+
 } // anonymous namespace
 
 
@@ -79,7 +94,7 @@ TEST(SunriseSunset, HourAngleAtAltitudeMatchesHorizontalAltitude) {
 
         for (const double sign : { 1.0, -1.0 }) {
           const auto horizontal = astro::coords::equatorial_to_horizontal(
-            H0.value() * sign, Angle<DEG> { δ }, Angle<DEG> { φ }
+            req(H0) * sign, Angle<DEG> { δ }, Angle<DEG> { φ }
           );
           ASSERT_NEAR(horizontal.h.deg(), h0, 1e-9)
             << "δ=" << δ << " φ=" << φ << " h0=" << h0 << " sign=" << sign;
@@ -104,7 +119,7 @@ TEST(SunriseSunset, HourAngleAtAltitudePolarAndDegenerateCases) {
   // Equator, equinoctial Sun, geometric horizon: the diurnal arc is exactly a half turn.
   const auto H0 = hour_angle_at_altitude(Angle<DEG> { 0.0 }, Angle<DEG> { 0.0 }, Angle<DEG> { 0.0 });
   ASSERT_TRUE(H0.has_value());
-  ASSERT_NEAR(H0.value().deg(), 90.0, 1e-9);
+  ASSERT_NEAR(req(H0).deg(), 90.0, 1e-9);
 }
 
 TEST(SunriseSunset, AltitudeConstantsProvenance) {
@@ -197,8 +212,8 @@ TEST(SunriseSunset, RiseSetAltitudeIsH0) {
     ASSERT_TRUE(result.sunset_jde.has_value());
 
     // 0.001° ≈ 0.36". At typical crossing rates (~200°/day) that is ~0.4 s of time.
-    ASSERT_NEAR(detail::sun_altitude(result.sunrise_jde.value(), location).deg(), h0.deg(), 0.001);
-    ASSERT_NEAR(detail::sun_altitude(result.sunset_jde.value(), location).deg(), h0.deg(), 0.001);
+    ASSERT_NEAR(detail::sun_altitude(req(result.sunrise_jde), location).deg(), h0.deg(), 0.001);
+    ASSERT_NEAR(detail::sun_altitude(req(result.sunset_jde), location).deg(), h0.deg(), 0.001);
   }
 }
 
@@ -214,8 +229,8 @@ TEST(SunriseSunset, OrderIsCorrect) {
     const auto result = calculate(ymd, location);
     ASSERT_TRUE(result.sunrise_jde.has_value());
     ASSERT_TRUE(result.sunset_jde.has_value());
-    ASSERT_LT(result.sunrise_jde.value(), result.transit_jde);
-    ASSERT_LT(result.transit_jde, result.sunset_jde.value());
+    ASSERT_LT(req(result.sunrise_jde), result.transit_jde);
+    ASSERT_LT(result.transit_jde, req(result.sunset_jde));
     ASSERT_FALSE(result.is_polar_day);
     ASSERT_FALSE(result.is_polar_night);
   }
@@ -236,14 +251,14 @@ TEST(SunriseSunset, TwilightOrder) {
   }
 
   // Morning: astronomical dawn < nautical dawn < civil dawn < sunrise.
-  ASSERT_LT(r_astro.sunrise_jde.value(), r_nautical.sunrise_jde.value());
-  ASSERT_LT(r_nautical.sunrise_jde.value(), r_civil.sunrise_jde.value());
-  ASSERT_LT(r_civil.sunrise_jde.value(), r_standard.sunrise_jde.value());
+  ASSERT_LT(req(r_astro.sunrise_jde), req(r_nautical.sunrise_jde));
+  ASSERT_LT(req(r_nautical.sunrise_jde), req(r_civil.sunrise_jde));
+  ASSERT_LT(req(r_civil.sunrise_jde), req(r_standard.sunrise_jde));
 
   // Evening: sunset < civil dusk < nautical dusk < astronomical dusk.
-  ASSERT_LT(r_standard.sunset_jde.value(), r_civil.sunset_jde.value());
-  ASSERT_LT(r_civil.sunset_jde.value(), r_nautical.sunset_jde.value());
-  ASSERT_LT(r_nautical.sunset_jde.value(), r_astro.sunset_jde.value());
+  ASSERT_LT(req(r_standard.sunset_jde), req(r_civil.sunset_jde));
+  ASSERT_LT(req(r_civil.sunset_jde), req(r_nautical.sunset_jde));
+  ASSERT_LT(req(r_nautical.sunset_jde), req(r_astro.sunset_jde));
 }
 
 TEST(SunriseSunset, EquatorDayLength) {
@@ -255,7 +270,7 @@ TEST(SunriseSunset, EquatorDayLength) {
     ASSERT_TRUE(result.sunrise_jde.has_value());
     ASSERT_TRUE(result.sunset_jde.has_value());
 
-    const double day_length = result.sunset_jde.value() - result.sunrise_jde.value();
+    const double day_length = req(result.sunset_jde) - req(result.sunrise_jde);
     ASSERT_NEAR(day_length, 0.5, 30.0 / (24.0 * 60.0)) << "month=" << month; // 12h ± 30 min.
   }
 }
@@ -267,8 +282,8 @@ TEST(SunriseSunset, RiseSetSymmetryAroundTransit) {
   ASSERT_TRUE(result.sunrise_jde.has_value());
   ASSERT_TRUE(result.sunset_jde.has_value());
 
-  const double morning = result.transit_jde - result.sunrise_jde.value();
-  const double evening = result.sunset_jde.value() - result.transit_jde;
+  const double morning = result.transit_jde - req(result.sunrise_jde);
+  const double evening = req(result.sunset_jde) - result.transit_jde;
   ASSERT_NEAR(morning, evening, 0.01);
 }
 
@@ -317,8 +332,8 @@ TEST(SunriseSunset, PolarNightOnsetWeekIsCoherent) {
       ASSERT_FALSE(result.is_polar_night) << "day=" << day;
       ASSERT_FALSE(seen_polar_night) << "day=" << day; // No coming back out of the night in this window.
       if (events == 2) {
-        ASSERT_LT(result.sunrise_jde.value(), result.transit_jde);
-        ASSERT_LT(result.transit_jde, result.sunset_jde.value());
+        ASSERT_LT(req(result.sunrise_jde), result.transit_jde);
+        ASSERT_LT(result.transit_jde, req(result.sunset_jde));
       }
     }
   }
@@ -346,8 +361,8 @@ TEST(SunriseSunset, MidnightSunOnsetWeekIsCoherent) {
       ASSERT_FALSE(result.is_polar_day) << "day=" << day;
       ASSERT_FALSE(result.is_polar_night) << "day=" << day;
       if (events == 2) {
-        ASSERT_LT(result.sunrise_jde.value(), result.transit_jde);
-        ASSERT_LT(result.transit_jde, result.sunset_jde.value());
+        ASSERT_LT(req(result.sunrise_jde), result.transit_jde);
+        ASSERT_LT(result.transit_jde, req(result.sunset_jde));
       }
     }
   }

--- a/src/test/astro/sunrise_sunset_test.cpp
+++ b/src/test/astro/sunrise_sunset_test.cpp
@@ -1,0 +1,384 @@
+/*
+ * CelestialCalendar:
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ *
+ * Copyright (C) 2026 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <chrono>
+#include <limits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "util.hpp"
+#include "sunrise_sunset.hpp"
+
+namespace astro::sunrise_sunset::test {
+
+using namespace astro::sunrise_sunset;
+using astro::toolbox::Angle;
+using astro::toolbox::AngleUnit::DEG;
+
+namespace {
+
+constexpr auto loc(const double lat_deg, const double lon_deg) -> GeoLocation {
+  return { .latitude = Angle<DEG> { lat_deg }, .longitude = Angle<DEG> { lon_deg } };
+}
+
+// East-positive longitudes, per `GeoLocation`'s convention.
+const GeoLocation EQUATOR   = loc(  0.0,      0.0);
+const GeoLocation LONDON    = loc( 51.5074,  -0.1278);
+const GeoLocation NEW_YORK  = loc( 40.7128, -74.0060);
+const GeoLocation BEIJING   = loc( 39.9042, 116.4074);
+const GeoLocation SYDNEY    = loc(-33.8688, 151.2093);
+const GeoLocation TROMSO    = loc( 69.65,    18.96);
+const GeoLocation MIDLAT_0E = loc( 40.0,      0.0);
+
+/** @brief The estimate `transit_jde` starts from: local mean noon of the UT1 date, as a JDE. */
+auto local_mean_noon_jde(const std::chrono::year_month_day& ymd, const GeoLocation& location) -> double {
+  const calendar::Datetime noon_ut1 { ymd, 0.5 };
+  return astro::julian_day::ut1_to_jde(noon_ut1) - location.longitude.deg() / 360.0;
+}
+
+} // anonymous namespace
+
+
+TEST(SunriseSunset, HourAngleAtAltitudeMatchesHorizontalAltitude) {
+  // Meeus (15.1) inverts (13.6); feeding H₀ back through `equatorial_to_horizontal` must
+  // reproduce h₀ (and at -H₀ too, by the symmetry of the diurnal arc).
+  const std::vector<double> declinations { -23.44, -10.0, 0.0, 10.0, 23.44 };
+  const std::vector<double> latitudes    { -55.0, -30.0, 0.0, 30.0, 51.5, 65.0 };
+  const std::vector<double> altitudes    { -18.0, -12.0, -6.0, -0.8333, 0.0 };
+
+  for (const double δ : declinations) {
+    for (const double φ : latitudes) {
+      for (const double h0 : altitudes) {
+        const auto H0 = hour_angle_at_altitude(Angle<DEG> { δ }, Angle<DEG> { φ }, Angle<DEG> { h0 });
+        if (not H0.has_value()) {
+          continue; // Polar cases are covered by their own test.
+        }
+
+        for (const double sign : { 1.0, -1.0 }) {
+          const auto horizontal = astro::coords::equatorial_to_horizontal(
+            *H0 * sign, Angle<DEG> { δ }, Angle<DEG> { φ }
+          );
+          ASSERT_NEAR(horizontal.h.deg(), h0, 1e-9)
+            << "δ=" << δ << " φ=" << φ << " h0=" << h0 << " sign=" << sign;
+        }
+      }
+    }
+  }
+}
+
+TEST(SunriseSunset, HourAngleAtAltitudePolarAndDegenerateCases) {
+  const Angle<DEG> h0_standard { -0.8333 };
+
+  // Midnight sun at 80°N in northern summer: the Sun's minimum altitude is ~+13.4°, far above h₀.
+  ASSERT_FALSE(hour_angle_at_altitude(Angle<DEG> { 23.44 }, Angle<DEG> { 80.0 }, h0_standard).has_value());
+
+  // Polar night at 80°N in northern winter: the maximum altitude is ~-13.4°, below h₀.
+  ASSERT_FALSE(hour_angle_at_altitude(Angle<DEG> { -23.44 }, Angle<DEG> { 80.0 }, h0_standard).has_value());
+
+  // The equation degenerates at the geographic pole (cos φ = 0).
+  ASSERT_FALSE(hour_angle_at_altitude(Angle<DEG> { 10.0 }, Angle<DEG> { 90.0 }, h0_standard).has_value());
+
+  // Equator, equinoctial Sun, geometric horizon: the diurnal arc is exactly a half turn.
+  const auto H0 = hour_angle_at_altitude(Angle<DEG> { 0.0 }, Angle<DEG> { 0.0 }, Angle<DEG> { 0.0 });
+  ASSERT_TRUE(H0.has_value());
+  ASSERT_NEAR(H0->deg(), 90.0, 1e-9);
+}
+
+TEST(SunriseSunset, AltitudeConstantsProvenance) {
+  // Pin the externally-meaningful constants to their literature values (Meeus Ch.15's
+  // -34' refraction - 16' upper limb; the standard civil/nautical/astronomical twilight
+  // definitions). The solver tests are parametric in h₀ and would stay green with a silently
+  // wrong constant — e.g. even h₀ = 0° keeps EquatorDayLength inside its ±30 min (per review).
+  ASSERT_NEAR(STANDARD_ALTITUDE.deg(), -50.0 / 60.0, 1e-12);
+  ASSERT_NEAR(CIVIL_TWILIGHT.deg(), -6.0, 1e-12);
+  ASSERT_NEAR(NAUTICAL_TWILIGHT.deg(), -12.0, 1e-12);
+  ASSERT_NEAR(ASTRONOMICAL_TWILIGHT.deg(), -18.0, 1e-12);
+}
+
+TEST(SunriseSunset, TransitHourAngleIsZero) {
+  const std::vector<std::pair<std::chrono::year_month_day, GeoLocation>> cases {
+    { util::to_ymd(2024, 6, 21), NEW_YORK },
+    { util::to_ymd(2024, 6, 21), BEIJING  },
+    { util::to_ymd(2024, 3, 20), LONDON   },
+    { util::to_ymd(2024, 12, 21), SYDNEY  },
+  };
+
+  for (const auto& [ymd, location] : cases) {
+    const double transit = transit_jde(ymd, location);
+    const double H = detail::sun_local(transit, location).hour_angle_deg;
+    // 0.001° of hour angle ≈ 0.24 s of time. Self-consistency only: solver and checker share
+    // `detail::sun_local`, so a systematic error (e.g. a UT1/TT mixup) cancels out here — the
+    // Meeus 28.a anchor below is the absolute guard (mutation-verified).
+    ASSERT_NEAR(H, 0.0, 0.001);
+  }
+}
+
+TEST(SunriseSunset, TransitNearLocalMeanNoon) {
+  // The transit deviates from local mean noon by the equation of time only (|EoT| ≤ 16.5 min
+  // ≈ 0.0115 day). A sign flip in `sun_local`'s longitude negation moves the H = 0 root ~0.65
+  // day off Beijing's bracket — 32x this tolerance — so this pins that negation. (It does NOT
+  // pin the estimate formula itself: the `local_mean_noon_jde` helper mirrors it by construction.)
+  const std::vector<std::pair<std::chrono::year_month_day, GeoLocation>> cases {
+    { util::to_ymd(2024, 2, 11), BEIJING  }, // Near the EoT minimum (~-14.2 min).
+    { util::to_ymd(2024, 11, 3), NEW_YORK }, // Near the EoT maximum (~+16.5 min).
+    { util::to_ymd(2024, 6, 21), TROMSO   }, // Transit exists even on a polar day.
+  };
+
+  for (const auto& [ymd, location] : cases) {
+    const double transit = transit_jde(ymd, location);
+    ASSERT_NEAR(transit, local_mean_noon_jde(ymd, location), 0.02);
+  }
+}
+
+TEST(SunriseSunset, TransitAnchoredToMeeusEquationOfTime) {
+  // Meeus Example 28.a: 1992 October 13, 0h TD — E = +3°.427351 = +13.70940 min. E > 0 means
+  // the true Sun crosses the meridian before the mean sun, so at Greenwich the transit falls
+  // at ≈ 12h − E of mean time (= UT). This is the one assertion in this file tied to a value
+  // from OUTSIDE the computation chain: the self-consistency tests (H(transit) ≈ 0 etc.) run
+  // solver and checker through the same `detail::sun_local`, so a systematic error — e.g.
+  // feeding TT to the sidereal-time step — cancels out of them, but not out of this one.
+  // Tolerance ±20 s: E drifts only a few seconds between 0h TD and the ~11h46m transit, and
+  // the model differences are ~1 s; a UT1/TT mixup would shift the transit by ΔT ≈ 59 s
+  // (epoch 1992), i.e. ~3x this tolerance.
+  const auto ymd = util::to_ymd(1992, 10, 13);
+  const double transit = transit_jde(ymd, loc(51.4769, 0.0)); // Greenwich; latitude does not move the transit.
+
+  const auto ut1 = astro::julian_day::jde_to_ut1(transit);
+  ASSERT_EQ(ut1.ymd, ymd);
+
+  const double expected_fraction = 0.5 - (13.70940 / (24.0 * 60.0));
+  ASSERT_NEAR(ut1.fraction(), expected_fraction, 20.0 / 86400.0);
+}
+
+TEST(SunriseSunset, TransitIsUpperCulmination) {
+  const auto ymd = util::to_ymd(2024, 9, 22);
+  const double transit = transit_jde(ymd, LONDON);
+
+  const double h_transit = detail::sun_altitude(transit, LONDON).deg();
+  ASSERT_GT(h_transit, detail::sun_altitude(transit - 2.0 / 24.0, LONDON).deg());
+  ASSERT_GT(h_transit, detail::sun_altitude(transit + 2.0 / 24.0, LONDON).deg());
+}
+
+TEST(SunriseSunset, RiseSetAltitudeIsH0) {
+  const std::vector<std::tuple<std::chrono::year_month_day, GeoLocation, Angle<DEG>>> cases {
+    { util::to_ymd(2024, 3, 20), LONDON,  STANDARD_ALTITUDE },
+    { util::to_ymd(2024, 6, 21), BEIJING, STANDARD_ALTITUDE },
+    { util::to_ymd(2024, 12, 21), SYDNEY, STANDARD_ALTITUDE },
+    { util::to_ymd(2024, 3, 20), LONDON,  CIVIL_TWILIGHT    },
+    { util::to_ymd(2024, 3, 20), LONDON,  ASTRONOMICAL_TWILIGHT },
+  };
+
+  for (const auto& [ymd, location, h0] : cases) {
+    const auto result = calculate(ymd, location, h0);
+    ASSERT_TRUE(result.sunrise_jde.has_value());
+    ASSERT_TRUE(result.sunset_jde.has_value());
+
+    // 0.001° ≈ 0.36". At typical crossing rates (~200°/day) that is ~0.4 s of time.
+    ASSERT_NEAR(detail::sun_altitude(*result.sunrise_jde, location).deg(), h0.deg(), 0.001);
+    ASSERT_NEAR(detail::sun_altitude(*result.sunset_jde, location).deg(), h0.deg(), 0.001);
+  }
+}
+
+TEST(SunriseSunset, OrderIsCorrect) {
+  const std::vector<std::pair<std::chrono::year_month_day, GeoLocation>> cases {
+    { util::to_ymd(2024, 6, 21), BEIJING },
+    { util::to_ymd(2024, 12, 21), BEIJING },
+    { util::to_ymd(2024, 6, 21), SYDNEY },
+    { util::to_ymd(2024, 9, 22), EQUATOR },
+  };
+
+  for (const auto& [ymd, location] : cases) {
+    const auto result = calculate(ymd, location);
+    ASSERT_TRUE(result.sunrise_jde.has_value());
+    ASSERT_TRUE(result.sunset_jde.has_value());
+    ASSERT_LT(*result.sunrise_jde, result.transit_jde);
+    ASSERT_LT(result.transit_jde, *result.sunset_jde);
+    ASSERT_FALSE(result.is_polar_day);
+    ASSERT_FALSE(result.is_polar_night);
+  }
+}
+
+TEST(SunriseSunset, TwilightOrder) {
+  // At 40°N the midsummer Sun still dips to ~-26.6°, so all three twilights exist.
+  const auto ymd = util::to_ymd(2024, 6, 21);
+
+  const auto r_standard = calculate(ymd, MIDLAT_0E, STANDARD_ALTITUDE);
+  const auto r_civil    = calculate(ymd, MIDLAT_0E, CIVIL_TWILIGHT);
+  const auto r_nautical = calculate(ymd, MIDLAT_0E, NAUTICAL_TWILIGHT);
+  const auto r_astro    = calculate(ymd, MIDLAT_0E, ASTRONOMICAL_TWILIGHT);
+
+  for (const auto& r : { r_standard, r_civil, r_nautical, r_astro }) {
+    ASSERT_TRUE(r.sunrise_jde.has_value());
+    ASSERT_TRUE(r.sunset_jde.has_value());
+  }
+
+  // Morning: astronomical dawn < nautical dawn < civil dawn < sunrise.
+  ASSERT_LT(*r_astro.sunrise_jde, *r_nautical.sunrise_jde);
+  ASSERT_LT(*r_nautical.sunrise_jde, *r_civil.sunrise_jde);
+  ASSERT_LT(*r_civil.sunrise_jde, *r_standard.sunrise_jde);
+
+  // Evening: sunset < civil dusk < nautical dusk < astronomical dusk.
+  ASSERT_LT(*r_standard.sunset_jde, *r_civil.sunset_jde);
+  ASSERT_LT(*r_civil.sunset_jde, *r_nautical.sunset_jde);
+  ASSERT_LT(*r_nautical.sunset_jde, *r_astro.sunset_jde);
+}
+
+TEST(SunriseSunset, EquatorDayLength) {
+  // At the equator the day is close to 12h all year; h₀ = -50' stretches it by a few minutes.
+  for (int month = 1; month <= 12; ++month) {
+    const auto ymd = util::to_ymd(2024, month, 15);
+    const auto result = calculate(ymd, EQUATOR);
+
+    ASSERT_TRUE(result.sunrise_jde.has_value());
+    ASSERT_TRUE(result.sunset_jde.has_value());
+
+    const double day_length = *result.sunset_jde - *result.sunrise_jde;
+    ASSERT_NEAR(day_length, 0.5, 30.0 / (24.0 * 60.0)) << "month=" << month; // 12h ± 30 min.
+  }
+}
+
+TEST(SunriseSunset, RiseSetSymmetryAroundTransit) {
+  // δ drifts slowly, so morning and afternoon half-arcs agree to well under a minute — but
+  // assert only a loose bound to keep the test about symmetry, not about δ's exact rate.
+  const auto result = calculate(util::to_ymd(2024, 9, 22), EQUATOR);
+  ASSERT_TRUE(result.sunrise_jde.has_value());
+  ASSERT_TRUE(result.sunset_jde.has_value());
+
+  const double morning = result.transit_jde - *result.sunrise_jde;
+  const double evening = *result.sunset_jde - result.transit_jde;
+  ASSERT_NEAR(morning, evening, 0.01);
+}
+
+TEST(SunriseSunset, PolarDayAndPolarNight) {
+  // Tromsø (69.65°N) is inside the Arctic Circle: midnight sun in June, polar night in December.
+  const auto summer = calculate(util::to_ymd(2024, 6, 21), TROMSO);
+  ASSERT_FALSE(summer.sunrise_jde.has_value());
+  ASSERT_FALSE(summer.sunset_jde.has_value());
+  ASSERT_TRUE(summer.is_polar_day);
+  ASSERT_FALSE(summer.is_polar_night);
+
+  const auto winter = calculate(util::to_ymd(2024, 12, 21), TROMSO);
+  ASSERT_FALSE(winter.sunrise_jde.has_value());
+  ASSERT_FALSE(winter.sunset_jde.has_value());
+  ASSERT_FALSE(winter.is_polar_day);
+  ASSERT_TRUE(winter.is_polar_night);
+
+  // In the December polar night the Sun still culminates at ~-3.1°, above the civil-twilight
+  // altitude — so civil dawn/dusk exist even though sunrise/sunset do not.
+  const auto winter_civil = calculate(util::to_ymd(2024, 12, 21), TROMSO, CIVIL_TWILIGHT);
+  ASSERT_TRUE(winter_civil.sunrise_jde.has_value());
+  ASSERT_TRUE(winter_civil.sunset_jde.has_value());
+  ASSERT_FALSE(winter_civil.is_polar_day);
+  ASSERT_FALSE(winter_civil.is_polar_night);
+}
+
+TEST(SunriseSunset, PolarNightOnsetWeekIsCoherent) {
+  // Tromsø's polar night (h₀ = -50') begins in the last days of November. Scan the onset
+  // window: every day must be exactly one of {both events; one event + no flags; no events +
+  // the night flag}, and once polar night starts it must persist through the window. This
+  // exercises the fallback bracket (transit → solved lower culmination) in the regime the
+  // review flagged: short nights centered near the lower culmination.
+  bool seen_polar_night = false;
+
+  for (int day = 20; day <= 30; ++day) {
+    const auto result = calculate(util::to_ymd(2024, 11, day), TROMSO);
+    const int events = static_cast<int>(result.sunrise_jde.has_value())
+                     + static_cast<int>(result.sunset_jde.has_value());
+
+    if (events == 0) {
+      ASSERT_TRUE(result.is_polar_night) << "day=" << day; // November at 69.65°N: night, never day.
+      ASSERT_FALSE(result.is_polar_day) << "day=" << day;
+      seen_polar_night = true;
+    } else {
+      ASSERT_FALSE(result.is_polar_day) << "day=" << day;
+      ASSERT_FALSE(result.is_polar_night) << "day=" << day;
+      ASSERT_FALSE(seen_polar_night) << "day=" << day; // No coming back out of the night in this window.
+      if (events == 2) {
+        ASSERT_LT(*result.sunrise_jde, result.transit_jde);
+        ASSERT_LT(result.transit_jde, *result.sunset_jde);
+      }
+    }
+  }
+
+  ASSERT_TRUE(seen_polar_night); // The onset falls inside the scanned window.
+}
+
+TEST(SunriseSunset, MidnightSunOnsetWeekIsCoherent) {
+  // The mirror window: Tromsø's midnight sun begins in mid-May. This is the only regime where
+  // one-sided days (a rise or set alone, both flags false) can occur — the nights collapse one
+  // side at a time around the lower culminations — so the scan exercises that branch when the
+  // year's alignment produces one, and the polar-day onset in any case.
+  bool seen_polar_day = false;
+
+  for (int day = 12; day <= 24; ++day) {
+    const auto result = calculate(util::to_ymd(2024, 5, day), TROMSO);
+    const int events = static_cast<int>(result.sunrise_jde.has_value())
+                     + static_cast<int>(result.sunset_jde.has_value());
+
+    if (events == 0) {
+      ASSERT_TRUE(result.is_polar_day) << "day=" << day; // May at 69.65°N: day, never night.
+      ASSERT_FALSE(result.is_polar_night) << "day=" << day;
+      seen_polar_day = true;
+    } else {
+      ASSERT_FALSE(result.is_polar_day) << "day=" << day;
+      ASSERT_FALSE(result.is_polar_night) << "day=" << day;
+      if (events == 2) {
+        ASSERT_LT(*result.sunrise_jde, result.transit_jde);
+        ASSERT_LT(result.transit_jde, *result.sunset_jde);
+      }
+    }
+  }
+
+  ASSERT_TRUE(seen_polar_day); // The onset falls inside the scanned window.
+}
+
+TEST(SunriseSunset, InvalidInputsThrow) {
+  const auto ymd = util::to_ymd(2024, 6, 21);
+  constexpr double NAN_D = std::numeric_limits<double>::quiet_NaN();
+
+  ASSERT_THROW((void) transit_jde(ymd, loc(90.5, 0.0)), std::invalid_argument);
+  ASSERT_THROW((void) transit_jde(ymd, loc(0.0, 180.5)), std::invalid_argument);
+  ASSERT_THROW((void) transit_jde(ymd, loc(NAN_D, 0.0)), std::invalid_argument);
+  ASSERT_THROW((void) transit_jde(ymd, loc(0.0, NAN_D)), std::invalid_argument);
+
+  // An invalid gregorian date is rejected by `Datetime`'s constructor.
+  ASSERT_THROW((void) transit_jde(util::to_ymd(2024, 2, 30), EQUATOR), std::invalid_argument);
+
+  const double transit = transit_jde(ymd, EQUATOR);
+  ASSERT_THROW((void) rise_set_jde(NAN_D, true, EQUATOR), std::invalid_argument);
+  ASSERT_THROW((void) rise_set_jde(transit, true, EQUATOR, Angle<DEG> { NAN_D }), std::invalid_argument);
+  ASSERT_THROW((void) rise_set_jde(transit, true, EQUATOR, Angle<DEG> { 100.0 }), std::invalid_argument);
+  ASSERT_THROW((void) rise_set_jde(transit, true, loc(-91.0, 0.0)), std::invalid_argument);
+
+  // hour_angle_at_altitude is public API too: out-of-domain angles alias through sin/cos into
+  // physically meaningless H₀ values, so they are rejected rather than returned (per review).
+  ASSERT_THROW((void) hour_angle_at_altitude(Angle<DEG> { NAN_D }, Angle<DEG> { 0.0 }, Angle<DEG> { 0.0 }),
+               std::invalid_argument);
+  ASSERT_THROW((void) hour_angle_at_altitude(Angle<DEG> { 0.0 }, Angle<DEG> { 95.0 }, Angle<DEG> { 0.0 }),
+               std::invalid_argument);
+  ASSERT_THROW((void) hour_angle_at_altitude(Angle<DEG> { 0.0 }, Angle<DEG> { 0.0 }, Angle<DEG> { 100.0 }),
+               std::invalid_argument);
+}
+
+} // namespace astro::sunrise_sunset::test


### PR DESCRIPTION
Closes #43 (Phase 5 of milestone v0.3.0).

## 内容

新建 `src/astro/sunrise_sunset.hpp`:日出日落/中天核心。

- `GeoLocation`(东经为正,ISO 6709;与 `sidereal::local_apparent` 的 Meeus 西经为正约定的转换封装在内部,带 ±180° 语义说明)/ `Result{sunrise/sunset/transit_jde, is_polar_day/night}`(全部 JDE/TT 输出,与库内其它时刻一致)
- `hour_angle_at_altitude`(Meeus 15.1,cos H₀ 越界 ±1e-9 clamp、超出判极昼极夜、极点退化 nullopt;入参域校验走 #77 throw 契约)
- `transit_jde` / `rise_set_jde` / `calculate`:求根全部复用 #76 合入 `astro::toolbox` 的 `newton_method`(其注释本就预留了 #43)。rise/set 的 f 取「高度角 − h₀」形式——spec §7.2 陷阱(手写导数漏 `/cos h`)从构造上不存在,时角符号约定也无需处理(括号侧向选择事件)
- 存在性判定 = 括号端点**定向符号检查**(H₀ 外推只当加速器,不作裁决);fallback 括号到**解出的下中天**(`H∓180°` 求根,wrap 挪到上中天)而非 transit±0.5——精确覆盖极圈边界短夜(review 发现)
- 残差守卫(1e-3°,robustness-only):守卫拒绝时落入 fallback,不直接判无事件(review 发现)
- 常量:`STANDARD_ALTITUDE`(−50′)+ civil/nautical/astronomical twilight(issue 评论的显式验收项)

`astro.hpp` 聚合头补挂新头、补缺失的 `#pragma once`(#71 范围内的一行 drive-by)及 coord_transform/sidereal_time 两行;`toolbox.hpp` 修一条过时注释(原文描述已废弃的 NaN-f 设计)。

## Spec 与漂移

Spec = Notion「日出日落计算功能完整开发路线图」§Phase 5/§五/§七(已核对 merged 现状:namespace 实为 `astro::sidereal`/`astro::coords`;`local_apparent` 西经为正——本实现按 spec 公开 API 的东经为正语义封装)。

## 验证

- **152/152 测试全绿**(136 既有 + 16 新增),MSVC 本地;Linux CI 为 linter 权威门禁(本地 clang-tidy 18.1.8 × MSVC 14.40 头文件为已知环境性崩溃,HEAD 基线同样复现,两侧零真告警)
- **检出率协议**(突变注入实测):TT/UT1 混用 → 被 Meeus Example 28.a 均时差绝对锚点检出(书值已对扫描原著逐字核对:1992-10-13 0h TD,E=+13m42.6s;±20 s 容差 vs ~59 s 突变量);经度符号翻转 → 4/16 检出。第一版性质测试对 TT 混用检出率为 0(solver/checker 共享 `sun_local` 自洽相消)——绝对锚点即为此补
- **本地双审两轮**(kimi + grok;codex 未参与):Round 1 无 P0/P1,2×P2 + 若干 P3 全部处置(fallback 括号精确化、h₀ 域校验、常量出处钉子、残差守卫、两处过时注释、擦边判据文档化);Round 2 双家 **FIXES VERIFIED**,新增 1 LOW(守卫跳过 fallback)已修
- **极地过渡覆盖**:Tromsø 极夜入夜周(11月)+ 极昼入昼周(5月)双镜像扫描,逐日穷举状态断言

## 已知余量(明示不做)

- rise/set 时刻的外部 golden 对照(NOAA/USNO)= **Phase 6 (#44) 的全部内容**,本 PR 不预支;transit 有 Meeus 28.a 绝对锚点
- 下中天求根无独立残差守卫(±0.1 d 括号 500× 余量,失败模式仅影响 straddle 端点;review 判 low risk)
- 双侧守卫同时拒绝→极昼误标的理论路径(需在已验证 straddle 上的病理性 Newton 失败;review 判 theoretical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)