### PR TITLE
test(astro): 日出日落 golden 数据集 USNO/NOAA/Skyfield 多源对照 ±2min;版本 0.3.0 (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 * Conversions between Gregorian, Lunar, and Ganzhi dates (公历、阴历、干支历之间的转换)
 * Accurate Jieqi moment queries (查询某一年的某节气的具体时刻)
+* Sunrise, sunset, transit, twilight, and polar day/night queries, within ±2 min of external references (USNO / NOAA / JPL DE) (日出日落、中天、曙暮光、极昼极夜)
 
 ## 2. Requirements
 

--- a/project.py
+++ b/project.py
@@ -32,7 +32,7 @@ from automation import (
 )
 
 
-BUILD_VERSION: Final[str] = "0.2.0"
+BUILD_VERSION: Final[str] = "0.3.0"
 
 def parse_args() -> argparse.Namespace:
   """Parse the command line arguments."""

--- a/src/test/astro/sunrise_sunset_golden_test.cpp
+++ b/src/test/astro/sunrise_sunset_golden_test.cpp
@@ -1,0 +1,251 @@
+/*
+ * CelestialCalendar:
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ *
+ * Copyright (C) 2026 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <cmath>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "util.hpp"
+#include "sunrise_sunset.hpp"
+
+// End-to-end golden dataset for sunrise/sunset/twilight (#44), collected 2026-07-27 by
+// `statistics/sunrise_golden_crawler.py`:
+// - Rise / upper transit / set / civil twilight: USNO rstt/oneday API (apiversion 4.0.1),
+//   queried per site at the fixed standard-time offset in the `tz` column (no DST), minute
+//   precision. Cross-checked against NOAA solcalc `table.php` (independent implementation,
+//   DST unwound via IANA zones): worst disagreement 1.0 min over all 42 shared values.
+// - Nautical/astronomical twilight: Skyfield 1.54 + JPL DE421, second precision. Skyfield was
+//   validated against USNO on every shared quantity of the full matrix first (worst 0.52 min),
+//   and its −12°/−18° rows agree with sunrise-sunset.org to ≤ 0.2 min. (That site's own
+//   rise/set column is a ~2–3 min outlier vs USNO+NOAA and was rejected as a source.)
+// - Empty cell = the source states the event does not occur that day (polar day/night, or the
+//   Sun never reaching −18° at London's June solstice). USNO omits the transit time during
+//   polar night, so that single cell has no golden value and is skipped.
+// Tolerance: ±2 min is the v0.3.0 accuracy contract (#44). Sources are minute-rounded
+// (±0.5 min quantization) and agree pairwise within 1 min; this library's measured worst
+// residual over all 143 golden time values is 0.55 min (2026-07-27), a 3.6× margin.
+// A TT/UT1 mixup (~69 s) is inside this tolerance by design — that axis is pinned by the
+// Meeus Example 28.a anchor (±20 s) in sunrise_sunset_test.cpp, not here.
+
+namespace astro::sunrise_sunset::test {
+
+using namespace astro::sunrise_sunset;
+using astro::toolbox::Angle;
+using astro::toolbox::AngleUnit::DEG;
+
+namespace {
+
+constexpr double TOL_MIN = 2.0;
+
+constexpr auto loc(const double lat_deg, const double lon_deg) -> GeoLocation {
+  return { .latitude = Angle<DEG> { lat_deg }, .longitude = Angle<DEG> { lon_deg } };
+}
+
+/** @brief Parse "HH:MM" / "HH:MM:SS" into minutes-of-day; blank cell → `nullopt`. */
+auto cell_minutes(const std::string_view cell) -> std::optional<double> {
+  const auto first = cell.find_first_not_of(' ');
+  if (first == std::string_view::npos) {
+    return std::nullopt;
+  }
+  if (cell.size() - first < 5 or cell[first + 2] != ':') {
+    throw std::invalid_argument { "malformed golden cell: " + std::string { cell } };
+  }
+  const auto digits = [&](const size_t pos) { return 10.0 * (cell[pos] - '0') + (cell[pos + 1] - '0'); };
+  double minutes = 60.0 * digits(first) + digits(first + 3);
+  const auto second_colon = cell.find(':', first + 3);
+  if (second_colon != std::string_view::npos) {
+    if (second_colon != first + 5 or cell.size() - first < 8) {
+      throw std::invalid_argument { "malformed golden cell: " + std::string { cell } };
+    }
+    minutes += digits(first + 6) / 60.0;
+  }
+  return minutes;
+}
+
+// NOLINTBEGIN(bugprone-easily-swappable-parameters): tiny comparison helpers.
+
+/** @brief Our JDE(TT) result as minutes-of-day on the site's standard-time clock. */
+auto jde_to_local_minutes(const double jde, const int tz_hours) -> double {
+  const calendar::Datetime ut1 = astro::julian_day::jde_to_ut1(jde);
+  return std::fmod(ut1.fraction() * 1440.0 + (tz_hours * 60.0) + 1440.0, 1440.0);
+}
+
+/** @brief |a − b| in minutes on the 24h circle, so a source's day and ours may differ. */
+auto clock_diff(const double a, const double b) -> double {
+  const double diff = std::fabs(a - b);
+  return std::min(diff, 1440.0 - diff);
+}
+
+// NOLINTEND(bugprone-easily-swappable-parameters)
+
+void expect_event(
+  const std::optional<double>& event_jde, const std::string_view cell,
+  const int tz, const std::string_view what
+) {
+  const auto golden = cell_minutes(cell);
+  ASSERT_EQ(event_jde.has_value(), golden.has_value()) << what;
+  if (golden.has_value()) {
+    ASSERT_LE(clock_diff(jde_to_local_minutes(*event_jde, tz), *golden), TOL_MIN) << what;
+  }
+}
+
+struct GoldenRow {
+  int month;
+  int day;
+  double lat;
+  double lon;
+  int tz;                       // fixed standard-time offset, hours east of UT
+  std::string_view civil_dawn;  // "Begin Civil Twilight"
+  std::string_view rise;
+  std::string_view transit;    // "Upper Transit"
+  std::string_view set;
+  std::string_view civil_dusk;  // "End Civil Twilight"
+  bool polar_day;
+  bool polar_night;
+};
+
+// USNO rows, local standard time (see file header for provenance).
+const std::vector<GoldenRow> USNO_ROWS {
+  {  3, 20,   -0.22,   -78.51,  -5, "05:57", "06:18", "12:21", "18:25", "18:45", false, false },  // Quito
+  {  6, 21,   -0.22,   -78.51,  -5, "05:50", "06:13", "12:16", "18:19", "18:42", false, false },  // Quito
+  {  9, 23,   -0.22,   -78.51,  -5, "05:42", "06:03", "12:06", "18:10", "18:30", false, false },  // Quito
+  { 12, 21,   -0.22,   -78.51,  -5, "05:46", "06:08", "12:12", "18:16", "18:39", false, false },  // Quito
+  {  3, 20,    1.35,   103.82,   8, "06:48", "07:09", "13:12", "19:15", "19:36", false, false },  // Singapore
+  {  6, 21,    1.35,   103.82,   8, "06:38", "07:00", "13:06", "19:12", "19:35", false, false },  // Singapore
+  {  9, 23,    1.35,   103.82,   8, "06:33", "06:54", "12:57", "19:00", "19:21", false, false },  // Singapore
+  { 12, 21,    1.35,   103.82,   8, "06:39", "07:01", "13:03", "19:04", "19:27", false, false },  // Singapore
+  {  3, 20,   51.50,    -0.13,   0, "05:30", "06:03", "12:08", "18:13", "18:47", false, false },  // London
+  {  6, 21,   51.50,    -0.13,   0, "02:55", "03:43", "12:02", "20:21", "21:09", false, false },  // London
+  {  9, 23,   51.50,    -0.13,   0, "05:15", "05:48", "11:53", "17:57", "18:30", false, false },  // London
+  { 12, 21,   51.50,    -0.13,   0, "07:23", "08:04", "11:59", "15:53", "16:34", false, false },  // London
+  {  3, 20,   39.90,   116.41,   8, "05:52", "06:19", "12:22", "18:26", "18:53", false, false },  // Beijing
+  {  6, 21,   39.90,   116.41,   8, "04:13", "04:46", "12:16", "19:46", "20:19", false, false },  // Beijing
+  {  9, 23,   39.90,   116.41,   8, "05:36", "06:02", "12:07", "18:11", "18:37", false, false },  // Beijing
+  { 12, 21,   39.90,   116.41,   8, "07:02", "07:32", "12:12", "16:52", "17:23", false, false },  // Beijing
+  {  3, 20,   40.71,   -74.01,  -5, "05:32", "05:59", "12:03", "18:08", "18:36", false, false },  // NewYork
+  {  6, 21,   40.71,   -74.01,  -5, "03:52", "04:25", "11:58", "19:31", "20:04", false, false },  // NewYork
+  {  9, 23,   40.71,   -74.01,  -5, "05:17", "05:45", "11:48", "17:51", "18:19", false, false },  // NewYork
+  { 12, 21,   40.71,   -74.01,  -5, "06:46", "07:17", "11:54", "16:32", "17:03", false, false },  // NewYork
+  {  3, 20,  -33.87,   151.21,  10, "05:33", "05:58", "12:03", "18:07", "18:32", false, false },  // Sydney
+  {  6, 21,  -33.87,   151.21,  10, "06:32", "07:00", "11:57", "16:54", "17:22", false, false },  // Sydney
+  {  9, 23,  -33.87,   151.21,  10, "05:19", "05:44", "11:48", "17:52", "18:17", false, false },  // Sydney
+  { 12, 21,  -33.87,   151.21,  10, "04:11", "04:41", "11:53", "19:05", "19:35", false, false },  // Sydney
+  {  3, 20,   69.65,    18.96,   1, "04:44", "05:44", "11:52", "18:01", "19:02", false, false },  // Tromso
+  {  6, 21,   69.65,    18.96,   1, "     ", "     ", "11:46", "     ", "     ", true , false },  // Tromso
+  {  9, 23,   69.65,    18.96,   1, "04:27", "05:28", "11:37", "17:43", "18:43", false, false },  // Tromso
+  { 12, 21,   69.65,    18.96,   1, "09:31", "     ", "     ", "     ", "13:53", false, true  },  // Tromso
+};
+
+struct TwilightRow {
+  int month;
+  int day;
+  double lat;
+  double lon;
+  int tz;
+  std::string_view nautical_dawn;
+  std::string_view nautical_dusk;
+  std::string_view astronomical_dawn;
+  std::string_view astronomical_dusk;
+};
+
+// Skyfield rows, local standard time (see file header for provenance).
+const std::vector<TwilightRow> TWILIGHT_ROWS {
+  {  6, 21,   51.50,    -0.13,   0, "01:40:47", "22:23:51", "        ", "        " },  // London
+  { 12, 21,   51.50,    -0.13,   0, "06:40:11", "17:16:58", "05:59:22", "17:57:46" },  // London
+  { 12, 21,   69.65,    18.96,   1, "07:46:42", "15:37:40", "06:28:18", "16:56:03" },  // Tromso
+};
+
+}  // namespace
+
+
+TEST(SunriseSunsetGolden, UsnoRiseTransitSet) {
+  for (const auto& row : USNO_ROWS) {
+    const auto ymd = util::to_ymd(2026, row.month, row.day);
+    const Result result = calculate(ymd, loc(row.lat, row.lon));
+    const auto tag = std::to_string(row.month) + "-" + std::to_string(row.day)
+                   + " @ " + std::to_string(row.lat);
+
+    ASSERT_EQ(result.is_polar_day, row.polar_day) << tag;
+    ASSERT_EQ(result.is_polar_night, row.polar_night) << tag;
+    expect_event(result.sunrise_jde, row.rise, row.tz, tag + " rise");
+    expect_event(result.sunset_jde, row.set, row.tz, tag + " set");
+    if (cell_minutes(row.transit).has_value()) {
+      expect_event(result.transit_jde, row.transit, row.tz, tag + " transit");
+    }
+
+    // Pin the day axis: `clock_diff` alone is day-blind, and consecutive-day transits differ
+    // only by the equation-of-time drift (≪ tolerance). The transit is ~local noon, so its
+    // local-standard date must be the queried date on every row.
+    const double jd_local = detail::jde_tt_to_jd_ut1(result.transit_jde) + row.tz / 24.0;
+    ASSERT_EQ(astro::julian_day::jd_to_ut1(jd_local).ymd, ymd) << tag << " transit date";
+  }
+}
+
+TEST(SunriseSunsetGolden, UsnoCivilTwilight) {
+  for (const auto& row : USNO_ROWS) {
+    const auto ymd = util::to_ymd(2026, row.month, row.day);
+    const Result result = calculate(ymd, loc(row.lat, row.lon), CIVIL_TWILIGHT);
+    const auto tag = std::to_string(row.month) + "-" + std::to_string(row.day)
+                   + " @ " + std::to_string(row.lat) + " civil";
+
+    // Expected −6° flags follow from the cells, not the horizon flags: no civil crossings
+    // means the Sun stayed on one side of −6° all day — below it only if the day is already
+    // a polar night at the horizon, above it otherwise (midnight sun like Tromsø June, or a
+    // future "white night" row whose sun sets but never reaches −6°). A polar night at the
+    // horizon with crossings (Tromsø December) is no polar anything at −6°.
+    const bool has_civil = cell_minutes(row.civil_dawn).has_value()
+                        or cell_minutes(row.civil_dusk).has_value();
+    ASSERT_EQ(result.is_polar_day, not has_civil and not row.polar_night) << tag;
+    ASSERT_EQ(result.is_polar_night, not has_civil and row.polar_night) << tag;
+    expect_event(result.sunrise_jde, row.civil_dawn, row.tz, tag + " dawn");
+    expect_event(result.sunset_jde, row.civil_dusk, row.tz, tag + " dusk");
+  }
+}
+
+TEST(SunriseSunsetGolden, SkyfieldDeepTwilights) {
+  for (const auto& row : TWILIGHT_ROWS) {
+    const auto ymd = util::to_ymd(2026, row.month, row.day);
+    const auto tag = std::to_string(row.month) + "-" + std::to_string(row.day)
+                   + " @ " + std::to_string(row.lat);
+
+    const Result nautical = calculate(ymd, loc(row.lat, row.lon), NAUTICAL_TWILIGHT);
+    expect_event(nautical.sunrise_jde, row.nautical_dawn, row.tz, tag + " nautical dawn");
+    expect_event(nautical.sunset_jde, row.nautical_dusk, row.tz, tag + " nautical dusk");
+
+    const Result astronomical = calculate(ymd, loc(row.lat, row.lon), ASTRONOMICAL_TWILIGHT);
+    expect_event(astronomical.sunrise_jde, row.astronomical_dawn, row.tz, tag + " astronomical dawn");
+    expect_event(astronomical.sunset_jde, row.astronomical_dusk, row.tz, tag + " astronomical dusk");
+    // London's June solstice Sun never reaches −18°: "polar day" at that altitude. All rows
+    // here keep the transit-time Sun above −18°, so empty cells always mean polar day; a
+    // future polar-night-at-−18° row would need a flag column like `GoldenRow`'s.
+    ASSERT_EQ(astronomical.is_polar_day, not cell_minutes(row.astronomical_dawn).has_value()) << tag;
+    ASSERT_FALSE(astronomical.is_polar_night) << tag;
+  }
+}
+
+}  // namespace astro::sunrise_sunset::test

--- a/src/test/astro/sunrise_sunset_golden_test.cpp
+++ b/src/test/astro/sunrise_sunset_golden_test.cpp
@@ -109,9 +109,12 @@ void expect_event(
 ) {
   const auto golden = cell_minutes(cell);
   ASSERT_EQ(event_jde.has_value(), golden.has_value()) << what;
-  if (golden.has_value()) {
-    ASSERT_LE(clock_diff(jde_to_local_minutes(*event_jde, tz), *golden), TOL_MIN) << what;
+  // Explicit guard (not just the ASSERT above): clang-tidy's unchecked-optional-access
+  // cannot see through gtest macros (#110's lesson).
+  if (not event_jde.has_value() or not golden.has_value()) {
+    return;
   }
+  ASSERT_LE(clock_diff(jde_to_local_minutes(*event_jde, tz), *golden), TOL_MIN) << what;
 }
 
 struct GoldenRow {

--- a/statistics/sunrise_golden_crawler.py
+++ b/statistics/sunrise_golden_crawler.py
@@ -1,0 +1,206 @@
+# This file is used to download the golden dataset for sunrise/sunset tests (#44):
+# - Primary source: USNO "Complete Sun and Moon Data for One Day" API (aa.usno.navy.mil/api/rstt/oneday),
+#   queried per site at its fixed standard-time offset (no DST), so each response lists the
+#   events of one local civil day — matching `astro::sunrise_sunset::calculate`'s local-day semantics.
+# - Cross-check source: NOAA solcalc yearly tables (gml.noaa.gov/grad/solcalc/table.php),
+#   which render sunrise/sunset/solar-noon in the site's IANA zone (DST applied per date);
+#   zoneinfo converts them to the site's fixed standard offset before comparison.
+# - Nautical/astronomical twilight golden values come from Skyfield (JPL DE421), validated here
+#   against USNO on every overlapping quantity (rise/set/civil twilight) before its -12/-18
+#   values are accepted; sunrise-sunset.org is a third cross-check for the twilight rows only
+#   (its rise/set column is a documented ~2-3 min outlier vs USNO+NOAA and is not used).
+# The script prints the agreement reports and emits the column-aligned C++ dataset rows to
+# paste into src/test/astro/sunrise_sunset_golden_test.cpp.
+#
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+
+
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import requests
+
+
+# (name, lat, lon, standard-time UTC offset in hours, IANA zone for the NOAA cross-check).
+# Coordinates are city centroids rounded to 0.01° — they only need to be identical across
+# sources and the C++ dataset, not to match any authority's database.
+SITES = [
+  ("Quito",     -0.22,  -78.51, -5, "America/Guayaquil"),
+  ("Singapore",  1.35,  103.82,  8, "Asia/Singapore"),
+  ("London",    51.50,   -0.13,  0, "Europe/London"),
+  ("Beijing",   39.90,  116.41,  8, "Asia/Shanghai"),
+  ("NewYork",   40.71,  -74.01, -5, "America/New_York"),
+  ("Sydney",   -33.87,  151.21, 10, "Australia/Sydney"),
+  ("Tromso",    69.65,   18.96,  1, "Europe/Oslo"),
+]
+
+# 2026 equinoxes / solstices (sample dates; the exact instants are irrelevant here).
+DATES = [(2026, 3, 20), (2026, 6, 21), (2026, 9, 23), (2026, 12, 21)]
+
+PHEN_KEYS = ["Begin Civil Twilight", "Rise", "Upper Transit", "Set", "End Civil Twilight"]
+
+
+def fetch_usno(lat: float, lon: float, y: int, m: int, d: int, tz: int) -> dict:
+  url = "https://aa.usno.navy.mil/api/rstt/oneday"
+  params = {"date": f"{y:04d}-{m:02d}-{d:02d}", "coords": f"{lat},{lon}", "tz": str(tz)}
+  resp = requests.get(url, params=params, timeout=30)
+  resp.raise_for_status()
+  payload = resp.json()
+  print(f"USNO apiversion={payload.get('apiversion')}", file=sys.stderr)
+  sundata = payload["properties"]["data"]["sundata"]
+  return {entry["phen"]: entry["time"] for entry in sundata}
+
+
+def fetch_noaa_tables(lat: float, lon: float, year: int) -> list[list[list[str]]]:
+  url = "https://gml.noaa.gov/grad/solcalc/table.php"
+  resp = requests.get(url, params={"lat": lat, "lon": lon, "year": year}, timeout=30)
+  resp.raise_for_status()
+  tables = re.findall(r"<table class='table table-bordered'>(.*?)</table>", resp.text, re.S)
+  assert len(tables) == 3, "expected sunrise / sunset / solar-noon tables"
+  parsed = []
+  for tbl in tables:
+    rows = re.findall(r"<tr[^>]*>(.*?)</tr>", tbl, re.S)
+    parsed.append([
+      [re.sub(r"<[^>]+>", "", c).strip() for c in re.findall(r"<t[dh][^>]*>(.*?)</t[dh]>", r, re.S)]
+      for r in rows
+    ])
+  return parsed
+
+
+def noaa_local_to_std(cell: str, y: int, m: int, d: int, zone: str, tz_std: int) -> float | None:
+  """NOAA cell ("HH:MM" or "HH:MM:SS", local wall clock w/ DST) -> minutes-of-day in standard time."""
+  if not cell or not re.fullmatch(r"\d{2}:\d{2}(:\d{2})?", cell):
+    return None
+  parts = [int(p) for p in cell.split(":")]
+  h, mi, s = parts[0], parts[1], parts[2] if len(parts) == 3 else 0
+  local = datetime(y, m, d, h, mi, s, tzinfo=ZoneInfo(zone))
+  std = local.astimezone(timezone(timedelta(hours=tz_std)))
+  return std.hour * 60 + std.minute + std.second / 60.0
+
+
+def hm_to_min(t: str | None) -> float | None:
+  if t is None:
+    return None
+  parts = [int(p) for p in t.split(":")]
+  return parts[0] * 60 + parts[1] + (parts[2] / 60.0 if len(parts) > 2 else 0.0)
+
+
+# (site name, year, month, day) rows for the nautical/astronomical twilight golden set.
+TWILIGHT_CASES = [("London", 2026, 6, 21), ("London", 2026, 12, 21), ("Tromso", 2026, 12, 21)]
+
+
+def skyfield_boundaries(lat: float, lon: float, tz: int, y: int, m: int, d: int) -> dict:
+  """All dark_twilight_day boundary crossings within the local standard day, keyed by
+  (from-state, to-state) using state indices 0..4 = night/astro/nautical/civil/day."""
+  import tempfile
+  from skyfield import api, almanac
+  load = api.Loader(tempfile.gettempdir() + "/skyfield-cache")
+  eph = load("de421.bsp")
+  ts = load.timescale()
+  f = almanac.dark_twilight_day(eph, api.wgs84.latlon(lat, lon))
+  t0 = ts.utc(y, m, d, -tz, 0, 0)
+  t1 = ts.utc(y, m, d, 24 - tz, 0, 0)
+  times, events = almanac.find_discrete(t0, t1, f)
+  out, prev = {}, f(t0).item()
+  for t, e in zip(times, events, strict=True):
+    utc = t.utc_datetime()
+    minutes = (utc.hour * 60 + utc.minute + utc.second / 60.0 + tz * 60) % 1440
+    out[(prev, e.item())] = minutes
+    prev = e.item()
+  return out
+
+
+def min_to_hms(minutes: float | None) -> str:
+  if minutes is None:
+    return ""
+  total = round(minutes * 60)
+  return f"{total // 3600:02d}:{(total // 60) % 60:02d}:{total % 60:02d}"
+
+
+def skyfield_report(usno: dict) -> None:
+  import skyfield
+  print(f"skyfield version {skyfield.__version__}", file=sys.stderr)
+  worst = 0.0
+  for (name, lat, lon, tz, _zone) in SITES:
+    for (y, m, d) in DATES:
+      bounds = skyfield_boundaries(lat, lon, tz, y, m, d)
+      pairs = [
+        ("Begin Civil Twilight", (2, 3)), ("Rise", (3, 4)),
+        ("Set", (4, 3)), ("End Civil Twilight", (3, 2)),
+      ]
+      for phen, key in pairs:
+        u, s = hm_to_min(usno[(name, m, d)].get(phen)), bounds.get(key)
+        if u is None or s is None:
+          if (u is None) != (s is None):
+            print(f"MISMATCH presence {name} {m:02d}-{d:02d} {phen}: usno={u} skyfield={s}")
+          continue
+        delta = abs(u - s)
+        delta = min(delta, 1440 - delta)
+        worst = max(worst, delta)
+        flag = "  <-- CHECK" if delta > 2.0 else ""
+        print(f"{name:10s} {m:02d}-{d:02d} {phen:19s} usno={u:7.1f} skyfield={s:7.2f} d={delta:4.2f}min{flag}")
+  print(f"\nworst |USNO - Skyfield| = {worst:.2f} min")
+
+  print("\n// --- C++ twilight rows (nautical / astronomical, HH:MM:SS local standard) ---")
+  site_by_name = {s[0]: s for s in SITES}
+  for (name, y, m, d) in TWILIGHT_CASES:
+    _, lat, lon, tz, _zone = site_by_name[name]
+    b = skyfield_boundaries(lat, lon, tz, y, m, d)
+    cells = ", ".join(
+      f'"{min_to_hms(b.get(key)):8s}"'
+      for key in [(1, 2), (2, 1), (0, 1), (1, 0)]  # naut begin/end, astro begin/end
+    )
+    print(f"  {{ {m:2d}, {d:2d}, {lat:7.2f}, {lon:8.2f}, {tz:3d}, {cells} }},  // {name}")
+
+
+def main() -> None:
+  usno: dict[tuple, dict] = {}
+  for (name, lat, lon, tz, _zone) in SITES:
+    for (y, m, d) in DATES:
+      usno[(name, m, d)] = fetch_usno(lat, lon, y, m, d, tz)
+      print(f"USNO {name} {y}-{m:02d}-{d:02d}: {usno[(name, m, d)]}", file=sys.stderr)
+
+  # Cross-check against NOAA (sunrise / sunset / solar noon).
+  worst = 0.0
+  for (name, lat, lon, tz, zone) in SITES:
+    tables = fetch_noaa_tables(lat, lon, DATES[0][0])
+    for (y, m, d) in DATES:
+      noaa_cells = []
+      for rows in tables:  # sunrise, sunset, solar noon
+        cell = next((r[m] for r in rows if r and r[0] == str(d)), "")
+        noaa_cells.append(noaa_local_to_std(cell, y, m, d, zone, tz))
+      pairs = [("Rise", noaa_cells[0]), ("Set", noaa_cells[1]), ("Upper Transit", noaa_cells[2])]
+      for phen, noaa_min in pairs:
+        usno_min = hm_to_min(usno[(name, m, d)].get(phen))
+        if usno_min is None or noaa_min is None:
+          if (usno_min is None) != (noaa_min is None):
+            print(f"MISMATCH presence {name} {m:02d}-{d:02d} {phen}: usno={usno_min} noaa={noaa_min}")
+          continue
+        delta = abs(usno_min - noaa_min)
+        delta = min(delta, 1440 - delta)
+        worst = max(worst, delta)
+        flag = "  <-- CHECK" if delta > 2.0 else ""
+        print(f"{name:10s} {m:02d}-{d:02d} {phen:14s} "
+              f"usno={usno_min:7.1f} noaa={noaa_min:7.1f} d={delta:4.1f}min{flag}")
+  print(f"\nworst |USNO - NOAA| = {worst:.2f} min")
+
+  # Emit C++ dataset rows (local standard time "HH:MM"; "" = event absent that day).
+  print("\n// --- C++ rows ---")
+  for (name, lat, lon, tz, _zone) in SITES:
+    for (_y, m, d) in DATES:
+      rec = usno[(name, m, d)]
+      cells = ", ".join(f'"{rec.get(k) or "":5s}"' for k in PHEN_KEYS)
+      above = "Object continuously above the Horizon" in rec
+      below = "Object continuously below the Horizon" in rec
+      flags = f"{str(above).lower():5s}, {str(below).lower():5s}"
+      print(f"  {{ {m:2d}, {d:2d}, {lat:7.2f}, {lon:8.2f}, {tz:3d}, {cells}, {flags} }},  // {name}")
+
+  skyfield_report(usno)
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
Closes #44. Phase 6/6 of the sunrise/sunset milestone: end-to-end golden dataset against external authorities, closing out v0.3.0.

## What

- **`src/test/astro/sunrise_sunset_golden_test.cpp`** (new): 3 tests, 140 golden values.
  - `UsnoRiseTransitSet` + `UsnoCivilTwilight`: 28 rows = 7 sites (Quito, Singapore, London, Beijing, New York, Sydney, Tromsø — equator/mid-lat/polar, east/west/zero longitudes, both hemispheres) × 4 dates (2026 equinoxes/solstices). Rise / upper transit / set / civil dawn / civil dusk, plus Tromsø polar-day (Jun 21) and polar-night (Dec 21) flag rows.
  - `SkyfieldDeepTwilights`: nautical + astronomical twilight for London Jun/Dec and Tromsø Dec — including London Jun 21 where the Sun never reaches −18° (asserted as `is_polar_day` at that altitude) and Tromsø's polar-night twilights.
- **`statistics/sunrise_golden_crawler.py`** (new): reproducible collection + validation script (prints the cross-check reports and emits the C++ rows verbatim).
- **README**: sunrise/sunset feature line (per #44's definition of done). **`project.py`**: `BUILD_VERSION` 0.2.0 → 0.3.0 (tag after merge).

## Sources & provenance (#68 / #94 rules)

- **Primary (rise/transit/set/civil twilight)**: USNO `api/rstt/oneday` (apiversion 4.0.1), collected 2026-07-27, queried per site at a **fixed standard-time offset** (`tz` column, no DST) so each response lists one local civil day — matching `calculate()`'s local-day anchor. Minute precision.
- **Cross-check**: NOAA solcalc `table.php` (independent implementation; DST unwound via IANA zoneinfo): **worst disagreement 1.0 min over 42 shared values**. NOAA's polar-day placeholder cells and its polar-night solar-noon are the only presence differences (explained in the script output).
- **Nautical/astro twilight**: Skyfield 1.54 + JPL DE421 (a genuinely independent chain per #94's candidate table), **validated against USNO first**: worst 0.52 min over every shared quantity of the full matrix, zero presence mismatches. Its −12°/−18° rows agree with sunrise-sunset.org to ≤0.2 min.
- **Rejected source**: sunrise-sunset.org's rise/set column is a systematic ~2–3 min outlier vs USNO+NOAA (its depression-angle events are fine) — documented in the test header, not used.

## Tolerance & detection power

- ±2 min = the #44 v0.3.0 contract. Sources are minute-rounded (±0.5 min quantization) and agree pairwise ≤1 min.
- Measured worst residual of this library over all 140 golden values: **0.55 min** (3.6× margin). Distribution is rounding-dominated.
- Mutation check (per the detection-rate methodology): longitude-sign flip, `STANDARD_ALTITUDE` −50′→−34′, nautical/astronomical constant swap — **3/3 caught** by the golden suite (the Phase 5 property suite also catches them via its constant pins; the golden set's unique coverage is the end-to-end absolute anchor across latitudes/seasons that #66/#94 flagged as missing).
- A TT/UT1 mixup (~69 s) fits inside ±2 min by design — that axis stays pinned by the Meeus Example 28.a anchor (±20 s) in `sunrise_sunset_test.cpp`.

## Local review (pre-PR gate)

kimi + grok (codex unavailable), two rounds each. R1: no P1; both independently flagged the same P2 (the golden comparison was day-blind — `clock_diff` works mod 1440 and consecutive-day transits differ by ≪ tolerance) → fixed with a per-row assertion that the transit's local-standard date equals the queried date. grok's white-night footgun (civil polar flag was reused from the horizon flag) → civil −6° flags now derived from the cells + `row.polar_night`, correct for future white-night/civil-polar-night rows too. P3 batch: malformed-cell parsing now throws, header count corrected to 143 values, crawler namespace/wording fixes, USNO `apiversion` + skyfield version printed into the audit trail, README wording de-overclaimed. Declined with rationale: CHANGELOG entry (tracked in #90, raised at tag time), freezing raw USNO JSON, skyfield in Requirements.txt (repo precedent). R2: both reviewers returned **FIXES VERIFIED / no new findings** (kimi additionally re-derived the 143-value count, the −6° flag matrix, and the date-pin float-safety; grok re-checked the polar-night transit path).

## Verification

- Build + full ctest: 155/155 (152 existing + 3 new), re-verified after review fixes.
- ruff clean; clang-tidy clean on the new TU locally (Linux CI authoritative).
- Crawler re-run end-to-end after edits: emitted rows byte-identical, cross-check numbers unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)