### PR TITLE
test(astro): 月亮视位置 JPL Horizons golden 多源对照 (#94 上半, #65 收尾)

### DIFF
--- a/automation/linter.py
+++ b/automation/linter.py
@@ -97,10 +97,11 @@ def run_clang_tidy() -> int:
   stdout_log = build_dir / "clang-tidy-stdout.log"
   stderr_log = build_dir / "clang-tidy-stderr.log"
 
-  with stdout_log.open("w") as f:
+  # Explicit UTF-8: Windows' locale default (cp1252) chokes on non-ASCII in analyzed sources.
+  with stdout_log.open("w", encoding="utf-8") as f:
     f.write(clean_text(ret.stdout))
 
-  with stderr_log.open("w") as f:
+  with stderr_log.open("w", encoding="utf-8") as f:
     f.write(clean_text(ret.stderr))
 
   return ret.retcode

--- a/src/test/astro/moon_horizons_golden_test.cpp
+++ b/src/test/astro/moon_horizons_golden_test.cpp
@@ -1,0 +1,209 @@
+/*
+ * CelestialCalendar:
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ *
+ * Copyright (C) 2026 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "moon.hpp"
+
+// Independent golden dataset for the Moon's apparent geocentric position (#94, #65), collected
+// 2026-07-27 by `statistics/moon_horizons_crawler.py`:
+// - Source: JPL Horizons API v1.2, ephemeris DE441, Moon (301) from the geocenter (500@399).
+//   Epochs are supplied and echoed in TT, so no Horizons-side ΔT model enters the chain.
+//   Quantity 31 = ObsEcLon/ObsEcLat: IAU76/80 true-ecliptic-of-date apparent position, including
+//   light-time, gravitational deflection, and stellar aberration. This library computes the
+//   geometric ELP position + Δψ only; the two ~20″ correction components (light-time against the
+//   Moon's barycentric motion, aberration against the geocenter's) nearly cancel for the
+//   co-moving Moon, leaving a net ~0.7″ planetary aberration unmodeled here (in the tolerance).
+//   Quantity 20 = apparent range, converted AU → km with Horizons' own constant 149597870.700.
+// - Source validation (#94: no source enters the chain unverified):
+//   * Skyfield 1.54 + JPL DE421 (same JPL family, not an independent lunar theory — it guards
+//     the query semantics: frame, time scale, correction level) recomputed the 26 of 33 core
+//     epochs inside DE421's 1899–2053 span: worst disagreement 0.231″ in angle, 1.0 m in range.
+//     The 2057–2094 core tail and the other bands reuse the identical, thus-validated pipeline.
+//   * pyerfa 2.0.1.5 `eraMoon98` — SOFA's independent transcription of the same truncated
+//     ELP2000-82B (Meeus ch. 47) implemented by `elp2000_82b.hpp` — reproduces Example 47.a's
+//     book distance to 15 m, and its range envelope vs DE441 is: core band median 28.4 km /
+//     worst 45.7 km, extended worst 34.7 km, far worst 34.9 km. The envelope is flat across
+//     bands (periodic-term truncation, not secular), so one range tolerance serves all bands,
+//     and a residual well beyond ~46 km would indicate a transcription bug, not truncation.
+//   * Meeus Example 47.a (JD 2448724.5 TT) anchors the books' own numbers: book apparent
+//     λ/β/Δ differ from DE441 by +2.00″ / +0.27″ / −29.7 km — the truncation envelope itself.
+// - Tolerances declare two components (#94): the truncated series' model error (book-stated
+//   ~10″ in λ, ~4″ in β; range envelope ≤ 46 km) plus source-side corrections we do not model
+//   (~0.7″ aberration; nutation-series truncation ≤ ~0.5″). Source agreement itself is ≤ 0.23″.
+//   Extended/far bands add the secular drift of extrapolating the mean arguments millennia
+//   beyond the fitted era (tidal-acceleration mismatch grows ~quadratically with |T|).
+// - Time-scale detection: 23/41 epochs have |range-rate| ≥ 0.03 km/s (non-extremum sampling,
+//   #68 — the retired DiffTest2 sampled only perigees/apogees), and the Moon moves ~0.55″/s,
+//   so a TT/UT1 mixup (~69 s ≈ 38″) breaches the core λ tolerance on many rows.
+// Measured worst residuals are recorded above each tolerance. Mutation detection 2026-07-27,
+// 4/4 red: +69 s time shift (λ axis); nutation sign flip (λ); dropped −2235·sin(L′) latitude
+// perturbation term (β); +100 km range-base transcription slip (r, red in all three bands).
+// Fine-grained transcription of the frozen implementation (1e-7-and-tighter deltas) stays
+// guarded by the characterization tables in moon_test.cpp / elp2000_82b_test.cpp; this file
+// anchors absolute accuracy at the truncation-envelope scale.
+
+namespace astro::moon::test {
+
+using astro::moon::geocentric_coord::apparent;
+
+namespace {
+
+// One Horizons golden row: JD(TT); apparent true-ecliptic-of-date longitude / latitude (deg);
+// apparent range (km).
+struct HorizonsRow {
+  double jde;
+  double lon_deg;
+  double lat_deg;
+  double r_km;
+};
+
+// Per-band tolerances (deg, deg, km). Never loosen silently: these are the accuracy contract
+// for the truncated ELP2000-82B implementation (#94).
+struct Tolerance {
+  double lon_deg;
+  double lat_deg;
+  double r_km;
+};
+
+/** @brief Angular difference |a − b| in degrees, wrapped to [0, 180]. Both inputs live in
+ *  [0, 360) — normalized λ and the golden columns — so the +540 shift keeps fmod positive. */
+auto wrapped_diff_deg(const double a, const double b) -> double {
+  return std::fabs(std::fmod(a - b + 540.0, 360.0) - 180.0);
+}
+
+void check_band(const std::span<const HorizonsRow> rows, const Tolerance& tol,
+                const std::string_view band) {
+  double worst_lon = 0.0;
+  double worst_lat = 0.0;
+  double worst_r = 0.0;
+  for (const auto& row : rows) {
+    const auto coord = apparent(row.jde);
+    const double d_lon = wrapped_diff_deg(coord.λ.deg(), row.lon_deg);
+    const double d_lat = std::fabs(coord.β.deg() - row.lat_deg);
+    const double d_r = std::fabs(coord.r.km() - row.r_km);
+    EXPECT_LE(d_lon, tol.lon_deg) << band << " λ, jde " << row.jde << ": ours "
+                                  << coord.λ.deg() << " vs golden " << row.lon_deg;
+    EXPECT_LE(d_lat, tol.lat_deg) << band << " β, jde " << row.jde << ": ours "
+                                  << coord.β.deg() << " vs golden " << row.lat_deg;
+    EXPECT_LE(d_r, tol.r_km) << band << " r, jde " << row.jde << ": ours "
+                             << coord.r.km() << " vs golden " << row.r_km;
+    worst_lon = std::max(worst_lon, d_lon);
+    worst_lat = std::max(worst_lat, d_lat);
+    worst_r = std::max(worst_r, d_r);
+  }
+  std::cout << band << " measured worst residuals: dlon " << worst_lon * 3600.0 << "\", dlat "
+            << worst_lat * 3600.0 << "\", dr " << worst_r << " km\n";
+}
+
+// 1900–2100 + the Meeus Example 47.a anchor (row 2448724.50). 32 epochs stepped 2283.25 days —
+// incommensurate with the anomalistic/synodic months, scanning all phases and radial velocities.
+const std::vector<HorizonsRow> CORE_ROWS {
+  {  2415385.50,   48.3163870,   1.1700667,  370415.286 },  // 1901-Jan-01 00:00 TT, rdot +0.010 km/s
+  {  2417668.75,  250.7492890,   3.7936814,  368501.225 },  // 1907-Apr-03 06:00 TT, rdot +0.000 km/s
+  {  2419952.00,   91.4711213,   5.0100103,  372598.859 },  // 1913-Jul-03 12:00 TT, rdot -0.049 km/s
+  {  2422235.25,  295.2390834,   4.4441289,  393119.079 },  // 1919-Oct-03 18:00 TT, rdot -0.059 km/s
+  {  2424518.50,  144.3774117,   2.5595135,  405719.122 },  // 1926-Jan-03 00:00 TT, rdot -0.006 km/s
+  {  2426801.75,  354.5925763,  -0.1496005,  403580.582 },  // 1932-Apr-04 06:00 TT, rdot +0.022 km/s
+  {  2429085.00,  203.7991463,  -2.7500198,  390428.736 },  // 1938-Jul-05 12:00 TT, rdot +0.059 km/s
+  {  2431368.25,   47.4319608,  -4.6195790,  365669.383 },  // 1944-Oct-04 18:00 TT, rdot +0.059 km/s
+  {  2433651.50,  243.9400737,  -4.8024364,  361603.556 },  // 1951-Jan-05 00:00 TT, rdot -0.029 km/s
+  {  2435934.75,   85.6903816,  -3.0403492,  378618.267 },  // 1957-Apr-06 06:00 TT, rdot -0.043 km/s
+  {  2438218.00,  291.5913219,  -0.1091934,  389092.802 },  // 1963-Jul-07 12:00 TT, rdot -0.042 km/s
+  {  2440501.25,  139.1984785,   2.7740381,  400949.449 },  // 1969-Oct-06 18:00 TT, rdot -0.031 km/s
+  {  2442784.50,  348.4026038,   4.4935567,  402617.103 },  // 1976-Jan-07 00:00 TT, rdot +0.024 km/s
+  {  2445067.75,  195.9503051,   4.9968463,  391190.588 },  // 1982-Apr-08 06:00 TT, rdot +0.040 km/s
+  {  2447351.00,   42.1402865,   4.2267773,  380419.878 },  // 1988-Jul-08 12:00 TT, rdot +0.044 km/s
+  {  2448724.50,  133.1667103,  -3.2292008,  368439.405 },  // 1992-Apr-12 00:00 TT, rdot -0.012 km/s
+  {  2449634.25,  245.0114676,   1.7918937,  363924.226 },  // 1994-Oct-08 18:00 TT, rdot +0.037 km/s
+  {  2451917.50,   81.8526772,  -2.1337555,  362559.135 },  // 2001-Jan-08 00:00 TT, rdot -0.050 km/s
+  {  2454200.75,  283.9622685,  -4.5810525,  388043.112 },  // 2007-Apr-10 06:00 TT, rdot -0.062 km/s
+  {  2456484.00,  132.6254357,  -5.0466466,  402473.696 },  // 2013-Jul-10 12:00 TT, rdot -0.026 km/s
+  {  2458767.25,  342.7699740,  -4.3330833,  405922.069 },  // 2019-Oct-10 18:00 TT, rdot +0.000 km/s
+  {  2461050.50,  192.3679777,  -2.7282287,  396403.041 },  // 2026-Jan-10 00:00 TT, rdot +0.053 km/s
+  {  2463333.75,   36.7534176,   0.2647492,  374858.394 },  // 2032-Apr-11 06:00 TT, rdot +0.054 km/s
+  {  2465617.00,  238.0251613,   3.5597177,  368741.955 },  // 2038-Jul-12 12:00 TT, rdot +0.006 km/s
+  {  2467900.25,   80.4653915,   5.0905531,  369916.479 },  // 2044-Oct-11 18:00 TT, rdot -0.006 km/s
+  {  2470183.50,  281.3716385,   4.4592838,  374469.913 },  // 2051-Jan-12 00:00 TT, rdot -0.050 km/s
+  {  2472466.75,  125.4862540,   2.4791126,  395481.376 },  // 2057-Apr-13 06:00 TT, rdot -0.054 km/s
+  {  2474750.00,  335.2360181,   0.0555964,  405468.622 },  // 2063-Jul-14 12:00 TT, rdot -0.002 km/s
+  {  2477033.25,  185.4222320,  -2.5928151,  402399.608 },  // 2069-Oct-13 18:00 TT, rdot +0.025 km/s
+  {  2479316.50,   34.0912899,  -4.6330525,  389132.077 },  // 2076-Jan-14 00:00 TT, rdot +0.060 km/s
+  {  2481599.75,  236.4207392,  -5.0615279,  363357.277 },  // 2082-Apr-15 06:00 TT, rdot +0.053 km/s
+  {  2483883.00,   73.6307476,  -3.2605348,  361780.392 },  // 2088-Jul-15 12:00 TT, rdot -0.032 km/s
+  {  2486166.25,  275.7230422,  -0.4400281,  380086.796 },  // 2094-Oct-15 18:00 TT, rdot -0.048 km/s
+};
+
+// ~501 / ~999 / ~1599 / ~2500 / ~3000 CE: truncation degradation away from the fitted era.
+const std::vector<HorizonsRow> EXTENDED_ROWS {
+  {  1904000.50,  319.4163685,  -0.0387457,  372646.267 },  // 0500-Nov-14 00:00 TT, rdot +0.043 km/s
+  {  2086000.50,  103.8756791,   4.5422788,  380002.831 },  // 0999-Feb-28 00:00 TT, rdot +0.039 km/s
+  {  2305000.50,  329.4914761,   0.2397865,  365401.780 },  // 1598-Oct-11 00:00 TT, rdot -0.011 km/s
+  {  2634000.50,  241.6732448,   4.3528325,  364969.470 },  // 2499-Jul-19 00:00 TT, rdot -0.028 km/s
+  {  2817000.50,  249.9951948,   3.0345156,  400763.976 },  // 3000-Aug-02 00:00 TT, rdot +0.037 km/s
+};
+
+// JD 2^22 = 4194304 straddle (~6771 CE; double-precision cliff regression guard, #76 context)
+// and ~9420 CE. Gross-breakage guards only: at |T| ≈ 48–74 centuries the mean-argument
+// extrapolation dominates every residual.
+const std::vector<HorizonsRow> FAR_ROWS {
+  {  4194303.50,  173.7236957,   0.8425104,  367532.707 },  // 6771-Jul-07 00:00 TT, rdot +0.022 km/s
+  {  4194304.50,  187.9429346,  -0.4108899,  369790.010 },  // 6771-Jul-08 00:00 TT, rdot +0.029 km/s
+  {  5161700.50,   92.9588919,  -0.7232190,  403742.696 },  // 9420-Feb-27 00:00 TT, rdot -0.014 km/s
+};
+
+}  // namespace
+
+// The range tolerance is one number for all three bands: the truncation envelope is flat in
+// time (periodic terms only — measured worst 45.7 / 34.8 / 46.3 km for core/extended/far), so
+// 55 km bounds every band while staying close enough to the ~46 km envelope that a systematic
+// range offset beyond ~10 km turns the test red.
+constexpr double TOL_R_KM = 55.0;
+
+TEST(MoonHorizonsGolden, CoreBand) {
+  // Measured worst residuals 2026-07-27: λ 6.49″, β 2.06″, r 45.689 km. λ/β tolerances sit at
+  // the book-stated model accuracy (~10″ / ~4″) with the ~0.7″ unmodeled aberration inside.
+  check_band(CORE_ROWS, { .lon_deg = 0.003, .lat_deg = 0.0015, .r_km = TOL_R_KM }, "core");
+}
+
+TEST(MoonHorizonsGolden, ExtendedBand) {
+  // Measured worst residuals 2026-07-27: λ 24.8″, β 1.85″, r 34.8 km — the λ budget adds the
+  // mean-argument extrapolation drift at |T| up to 15 centuries.
+  check_band(EXTENDED_ROWS, { .lon_deg = 0.01, .lat_deg = 0.002, .r_km = TOL_R_KM }, "extended");
+}
+
+TEST(MoonHorizonsGolden, FarBand) {
+  // Measured worst residuals 2026-07-27: λ 969″, β 140″, r 46.3 km — at |T| ≈ 48–74 centuries
+  // the secular (tidal-acceleration) drift of the mean arguments dominates λ/β; the range
+  // column alone keeps its full detection power out here.
+  check_band(FAR_ROWS, { .lon_deg = 0.4, .lat_deg = 0.06, .r_km = TOL_R_KM }, "far");
+}
+
+}  // namespace astro::moon::test

--- a/src/test/astro/moon_horizons_golden_test.cpp
+++ b/src/test/astro/moon_horizons_golden_test.cpp
@@ -119,6 +119,9 @@ void check_band(const std::span<const HorizonsRow> rows, const Tolerance& tol,
     worst_lat = std::max(worst_lat, d_lat);
     worst_r = std::max(worst_r, d_r);
   }
+  // Intentional pass-or-fail print: keeps the measured residuals visible in test logs, so
+  // drift against the 2026-07-27 values recorded above each TEST is spottable without a
+  // local re-measurement run.
   std::cout << band << " measured worst residuals: dlon " << worst_lon * 3600.0 << "\", dlat "
             << worst_lat * 3600.0 << "\", dr " << worst_r << " km\n";
 }

--- a/src/test/astro/moon_test.cpp
+++ b/src/test/astro/moon_test.cpp
@@ -2,6 +2,7 @@
 #include <tuple>
 #include <unordered_map>
 #include "util.hpp"
+#include "julian_day.hpp"
 #include "moon.hpp"
 
 

--- a/src/test/astro/moon_test.cpp
+++ b/src/test/astro/moon_test.cpp
@@ -1,10 +1,8 @@
 #include <gtest/gtest.h>
-#include <chrono>
 #include <tuple>
 #include <unordered_map>
 #include "util.hpp"
-#include "astro.hpp"
-#include "ymd.hpp"
+#include "moon.hpp"
 
 
 namespace astro::moon::test {
@@ -15,7 +13,9 @@ using namespace astro::moon::geocentric_coord;
 TEST(Moon, CoordAndPpi) {
   // Characterization-tight columns (β/r/ppi are self-generated, see #65's comment); values shifted
   // 2026-07-26 by the measured #65 deltas (<= 2.6e-11 deg λ, 9.5e-8 km r), preserving per-platform
-  // jitter margins. Independent rebuild of the distance/radius columns is tracked in #94.
+  // jitter margins. Regression baseline only, not an accuracy benchmark (#94): the independent
+  // anchor for λ/β/r is moon_horizons_golden_test.cpp (JPL DE441), whose measurements resolved
+  // the historical distance doubt — the truncated series has an inherent ~30-46 km range envelope.
   const std::unordered_map<double, std::tuple<double, double, double, double>> dataset {
     // JDE                  Longitude in deg     Latitude in deg      Radius in km          PPI in rad
     { 2455820.8787544146, { 36.726233329781266,   3.3231721517193722, 405517.13842505851, 0.015729059017928697 } },
@@ -138,75 +138,12 @@ TEST(Moon, Perturbation) {
   }
 }
 
-TEST(Moon, DiffTest1) {
-  // Compare our results with other data sources.
-  // The distance/radius seems problematic, so we only test longitude and latitude here.
-  // https://doncarona.tamu.edu/cgi-bin/moon?current=0&jd=
-  const std::unordered_map<double, std::tuple<double, double>> dataset {{
-    {  2454988.902283522, { 240.636, -4.429 } },
-    { 2456389.9819942624, { 342.630,  4.682 } },
-    {  2457770.720007621, { 176.765,  2.035 } },
-    { 2455501.7090088516, { 150.642, -4.330 } },
-    {  2456585.023210534, {  32.738,  0.370 } },
-    {   2452288.38119678, { 297.123, -2.699 } },
-    {        2460526.159, { 122.450,  4.597 } },
-  }};
-
-  for (const auto& [jde, expected] : dataset) {
-    const auto& [lon, lat] = expected;
-    const auto coord = apparent(jde);
-    ASSERT_NEAR(coord.λ.deg(), lon, 0.1);
-    ASSERT_NEAR(coord.β.deg(), lat, 0.1);
-  }
-}
-
-TEST(Moon, DiffTest2) {
-  using namespace std::chrono_literals;
-  using hms = std::chrono::hh_mm_ss<std::chrono::nanoseconds>;
-
-  // Compare our results with other data sources.
-  // https://www.timeanddate.com/astronomy/moon/distance.html
-  // San Jose, CA time is used, because I live in San Jose :)
-  // Timezone is PDT.
-  const std::unordered_map<calendar::Datetime, double> dataset {{
-    { calendar::Datetime { util::to_ymd(2024,  1, 13), hms {  2h + 34min } }, 362267.0 },
-    { calendar::Datetime { util::to_ymd(2024,  2, 10), hms { 10h + 52min } }, 358088.0 },
-    { calendar::Datetime { util::to_ymd(2024,  3,  9), hms { 23h +  4min } }, 356895.0 },
-    { calendar::Datetime { util::to_ymd(2024,  4,  7), hms { 10h + 50min } }, 358850.0 },
-    { calendar::Datetime { util::to_ymd(2024,  5,  5), hms { 15h +  4min } }, 363163.0 },
-    { calendar::Datetime { util::to_ymd(2024,  6,  2), hms {  0h + 16min } }, 368102.0 },
-    { calendar::Datetime { util::to_ymd(2024,  6, 27), hms {  4h + 30min } }, 369286.0 },
-    { calendar::Datetime { util::to_ymd(2024,  7, 23), hms { 22h + 41min } }, 364917.0 },
-    { calendar::Datetime { util::to_ymd(2024,  8, 20), hms { 22h +  2min } }, 360196.0 },
-    { calendar::Datetime { util::to_ymd(2024,  9, 18), hms {  6h + 23min } }, 357286.0 },
-    { calendar::Datetime { util::to_ymd(2024, 10, 16), hms { 17h + 51min } }, 357175.0 },
-    { calendar::Datetime { util::to_ymd(2024, 11, 14), hms {  3h + 14min } }, 360109.0 },
-    { calendar::Datetime { util::to_ymd(2024, 12, 12), hms {  5h + 20min } }, 365361.0 },
-
-    { calendar::Datetime { util::to_ymd(2025,  1, 20), hms { 20h + 54min } }, 404298.0 },
-    { calendar::Datetime { util::to_ymd(2025,  2, 17), hms { 17h + 10min } }, 404882.0 },
-    { calendar::Datetime { util::to_ymd(2025,  3, 17), hms {  9h + 36min } }, 405754.0 },
-    { calendar::Datetime { util::to_ymd(2025,  4, 13), hms { 15h + 48min } }, 406295.0 },
-    { calendar::Datetime { util::to_ymd(2025,  5, 10), hms { 17h + 47min } }, 406244.0 },
-    { calendar::Datetime { util::to_ymd(2025,  6,  7), hms {  3h + 43min } }, 405554.0 },
-    { calendar::Datetime { util::to_ymd(2025,  7,  4), hms { 19h + 29min } }, 404627.0 },
-    { calendar::Datetime { util::to_ymd(2025,  8,  1), hms { 13h + 36min } }, 404161.0 },
-    { calendar::Datetime { util::to_ymd(2025,  8, 29), hms {  8h + 33min } }, 404548.0 },
-    { calendar::Datetime { util::to_ymd(2025,  9, 26), hms {  2h + 46min } }, 405548.0 },
-    { calendar::Datetime { util::to_ymd(2025, 10, 23), hms { 16h + 30min } }, 406444.0 },
-    { calendar::Datetime { util::to_ymd(2025, 11, 19), hms { 18h + 48min } }, 406691.0 },
-    { calendar::Datetime { util::to_ymd(2025, 12, 16), hms { 22h +  9min } }, 406322.0 },
-  }};
-
-  for (const auto& [dt, expected] : dataset) {
-    // Convert to UTC from PDT. 
-    // Difference between UTC and UT1 is ignored.
-    const double jde = astro::julian_day::ut1_to_jde(dt) + 7.0 / 24.0; 
-    const auto coord = apparent(jde);
-    const auto distance = coord.r.km();
-    ASSERT_NEAR(distance, expected, 5.0);
-  }
-}
+// DiffTest1 (doncarona.tamu.edu, 0.1° tolerance) and DiffTest2 (timeanddate.com perigee/apogee
+// distances, which carried a fixed PDT offset for PST rows and only extremum epochs, #68) were
+// retired 2026-07-27: moon_horizons_golden_test.cpp supersedes both with JPL DE441 values at
+// full provenance and non-extremum sampling — angle tolerances ~30× tighter, and the range
+// tolerance reset from DiffTest2's nominal 5 km (asserted on wrong-offset inputs at extremum
+// epochs only) to the series' own measured ~46 km truncation envelope.
 
 TEST(Moon, RandomApparentPosition) {
   // In this test, random apparent positions are generated.

--- a/statistics/moon_horizons_crawler.py
+++ b/statistics/moon_horizons_crawler.py
@@ -1,0 +1,202 @@
+# This file downloads the golden dataset for the Moon geocentric-position tests (#94 / #65):
+# - Primary source: JPL Horizons API (ssd.jpl.nasa.gov/api/horizons.api), Moon (301) seen from
+#   the geocenter (500@399), ephemeris DE441. Times are given and returned in TT (TIME_TYPE=TT),
+#   so no Horizons-side delta-T model enters the chain. Quantity 31 = ObsEcLon/ObsEcLat, the
+#   IAU76/80 true-ecliptic-of-date apparent position (light-time + light deflection + stellar
+#   aberration; planetary aberration for the Moon is ~0.7 arcsec, far below the model envelope);
+#   quantity 20 = apparent range (AU) and range-rate (km/s).
+# - Cross-check 1: Skyfield + JPL DE421, apparent ecliptic-of-date via frame_latlon — validates
+#   the Horizons query semantics on every core-band epoch inside DE421's span (1899-2053).
+#   Extended/far-band rows reuse the exact same, thus-validated, query pipeline.
+# - Cross-check 2: pyerfa's eraMoon98 — SOFA's independent transcription of the same truncated
+#   ELP2000-82B from Meeus ch.47 that src/astro/elp2000_82b.hpp implements. Compared on distance
+#   only (frame-free): |moon98 - Horizons| measures the model-truncation envelope per band, so
+#   C++ residuals can be attributed (transcription error vs inherent truncation error).
+# Validation anchor: Meeus "Astronomical Algorithms" 2nd ed. Example 47.a (JD 2448724.5 TT);
+# the book's apparent lon/lat/distance and eraMoon98 are compared against DE441 at that epoch.
+# The script prints the agreement reports and emits the column-aligned C++ dataset rows to
+# paste into src/test/astro/moon_horizons_golden_test.cpp.
+#
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+
+
+import sys
+
+import requests
+
+
+# Horizons' own units-conversion constant (echoed in every response header).
+AU_KM = 149597870.700
+
+# Core band 1900-2100: 32 epochs stepped by 2283.25 days (~6.25 y). The step is deliberately
+# incommensurate with both the anomalistic (27.5545 d) and synodic (29.5306 d) months, so the
+# samples scan all lunar phases and radial velocities — including non-extremum epochs where
+# |range-rate| is large enough for the longitude column to expose time-scale errors (#68).
+# JD 2448724.5 is the Meeus Example 47.a anchor.
+CORE_EPOCHS = [2415385.5 + k * 2283.25 for k in range(32)] + [2448724.5]
+
+# ~501 / ~999 / ~1599 / ~2500 / ~3000 CE: truncation degradation away from the fitted era.
+EXTENDED_EPOCHS = [1904000.5, 2086000.5, 2305000.5, 2634000.5, 2817000.5]
+
+# JD 2^22 = 4194304 (~6771 CE) straddle — double-precision cliff regression guard (#76 context —
+# the Newton cliff itself is a sun/jieqi concern, but the guard is cheap) — plus ~9420 CE.
+FAR_EPOCHS = [4194303.5, 4194304.5, 5161700.5]
+
+# Meeus Example 47.a apparent position (book p.342-343), for the anchor-epoch report.
+BOOK_47A = (2448724.5, 133.167265, -3.229126, 368409.7)
+
+# DE421 kernel coverage (1899-07-29 .. 2053-10-09), with one day of margin on each side.
+DE421_SPAN = (2414993.5, 2471183.5)
+
+
+def fetch_horizons(jds: list[float]) -> dict[float, dict]:
+  url = "https://ssd.jpl.nasa.gov/api/horizons.api"
+  params = {
+    "format": "text",
+    "COMMAND": "'301'",
+    "OBJ_DATA": "'NO'",
+    "MAKE_EPHEM": "'YES'",
+    "EPHEM_TYPE": "'OBSERVER'",
+    "CENTER": "'500@399'",
+    "TLIST": "'" + " ".join(f"{jd:.6f}" for jd in jds) + "'",
+    "TLIST_TYPE": "'JD'",
+    "TIME_TYPE": "'TT'",
+    "QUANTITIES": "'31,20'",
+    "ANG_FORMAT": "'DEG'",
+    "EXTRA_PREC": "'YES'",
+    "CAL_FORMAT": "'BOTH'",
+    "CSV_FORMAT": "'YES'",
+  }
+  resp = requests.get(url, params=params, timeout=60)
+  resp.raise_for_status()
+  text = resp.text
+
+  # Audit prints + hard gates (plain raises — `assert` dies under -O): a re-run must fail
+  # loudly if Horizons ever swaps the ephemeris or time scale, because the provenance pins
+  # DE441/TT (#94) and a sub-arcsec ephemeris drift would pass the C++ tolerances silently.
+  for line in text.splitlines():
+    if line.startswith("API VERSION") or "{source:" in line:
+      print(line.strip(), file=sys.stderr)
+  if "Moon (301)" not in text or "{source: DE441}" not in text:
+    raise RuntimeError("Horizons response is not Moon (301) on DE441")
+
+  lines = text.splitlines()
+  soe, eoe = lines.index("$$SOE"), lines.index("$$EOE")
+  header = None
+  for line in reversed(lines[:soe]):
+    if "ObsEcLon" in line:
+      header = [c.strip() for c in line.split(",")]
+      break
+  if header is None:
+    raise RuntimeError("column header line not found")
+  jd_i = next(i for i, name in enumerate(header) if "JD" in name)
+  if "JDTT" not in header[jd_i]:
+    raise RuntimeError(f"JD column is not on the TT scale: {header[jd_i]!r}")
+  col = {name: header.index(name) for name in ["ObsEcLon", "ObsEcLat", "delta", "deldot"]}
+
+  out = {}
+  for line in lines[soe + 1:eoe]:
+    cells = [c.strip() for c in line.split(",")]
+    jd = float(cells[jd_i])
+    out[jd] = {
+      "date": cells[0],
+      "lon": float(cells[col["ObsEcLon"]]),
+      "lat": float(cells[col["ObsEcLat"]]),
+      "r_km": float(cells[col["delta"]]) * AU_KM,
+      "deldot": float(cells[col["deldot"]]),
+    }
+  missing = [jd for jd in jds if jd not in out]
+  if missing:
+    raise RuntimeError(f"epochs missing from Horizons response: {missing}")
+  return out
+
+
+def skyfield_report(rows: dict[float, dict]) -> None:
+  import tempfile
+
+  import skyfield
+  from skyfield import api
+  from skyfield.framelib import ecliptic_frame
+
+  print(f"skyfield version {skyfield.__version__}", file=sys.stderr)
+  load = api.Loader(tempfile.gettempdir() + "/skyfield-cache")
+  eph = load("de421.bsp")
+  ts = load.timescale()
+
+  worst_ang, worst_r = 0.0, 0.0
+  in_span = [jd for jd in sorted(rows) if DE421_SPAN[0] < jd < DE421_SPAN[1]]
+  for jd in in_span:
+    h = rows[jd]
+    app = eph["earth"].at(ts.tt_jd(jd)).observe(eph["moon"]).apparent()
+    lat, lon, dist = app.frame_latlon(ecliptic_frame)
+    wrapped = abs(lon.degrees - h["lon"]) % 360.0
+    d_lon = min(wrapped, 360.0 - wrapped) * 3600.0
+    d_lat = abs(lat.degrees - h["lat"]) * 3600.0
+    d_r = abs(dist.km - h["r_km"]) * 1000.0
+    worst_ang, worst_r = max(worst_ang, d_lon, d_lat), max(worst_r, d_r)
+    flag = "  <-- CHECK" if max(d_lon, d_lat) > 0.5 or d_r > 50.0 else ""
+    print(f"{h['date']}  dlon={d_lon:6.3f}″  dlat={d_lat:6.3f}″  dr={d_r:6.1f} m{flag}")
+  print(f"\nskyfield/DE421 cross-check on {len(in_span)} core epochs: "
+        f"worst angle diff {worst_ang:.3f} arcsec, worst distance diff {worst_r:.1f} m")
+  # Semantic-regression gate: the two sources agree to 0.23″ / 1.0 m today; anything past
+  # 1″ / 10 m on a re-run means the query semantics (frame, time scale, correction level)
+  # changed on one side, not that the ephemerides drifted.
+  if worst_ang > 1.0 or worst_r > 10.0:
+    raise RuntimeError("skyfield cross-check exceeded the semantic-regression gate (1 arcsec / 10 m)")
+
+
+def erfa_report(rows: dict[float, dict]) -> None:
+  from statistics import median
+
+  import erfa
+  import numpy as np
+
+  print(f"pyerfa version {erfa.__version__}", file=sys.stderr)
+  bands = [("CORE", CORE_EPOCHS), ("EXTENDED", EXTENDED_EPOCHS), ("FAR", FAR_EPOCHS)]
+  for name, epochs in bands:
+    diffs = []
+    for jd in sorted(epochs):
+      pv = erfa.moon98(2400000.5, jd - 2400000.5)
+      e_km = float(np.linalg.norm(pv[0])) * AU_KM
+      diffs.append(abs(e_km - rows[jd]["r_km"]))
+      if jd == BOOK_47A[0]:
+        print(f"  47.a anchor: moon98 r={e_km:.3f} km, book {BOOK_47A[3]} km "
+              f"(transcription check, expect ~m-level)")
+    print(f"|moon98 - Horizons| distance envelope, {name:8s}: "
+          f"median {median(diffs):8.2f} km, worst {max(diffs):8.2f} km")
+
+
+def emit_rows(rows: dict[float, dict], name: str, epochs: list[float]) -> None:
+  print(f"\n// --- C++ rows: {name} ---")
+  for jd in sorted(epochs):
+    h = rows[jd]
+    print(f"  {{ {jd:11.2f}, {h['lon']:12.7f}, {h['lat']:11.7f}, {h['r_km']:11.3f} }},"
+          f"  // {h['date']} TT, rdot {h['deldot']:+.3f} km/s")
+
+
+def main() -> None:
+  jds = sorted(CORE_EPOCHS + EXTENDED_EPOCHS + FAR_EPOCHS)
+  rows = fetch_horizons(jds)
+
+  anchor = rows[BOOK_47A[0]]
+  d_lon = (BOOK_47A[1] - anchor["lon"]) * 3600.0
+  d_lat = (BOOK_47A[2] - anchor["lat"]) * 3600.0
+  print(f'Meeus 47.a book vs Horizons/DE441: dlon={d_lon:+.2f}" dlat={d_lat:+.2f}" '
+        f"dr={BOOK_47A[3] - anchor['r_km']:+.2f} km (model envelope at the anchor epoch)")
+
+  fast = sum(1 for h in rows.values() if abs(h["deldot"]) >= 0.03)
+  print(f"epochs with |range-rate| >= 0.03 km/s: {fast}/{len(rows)} "
+        f"(non-extremum coverage, #68)")
+
+  skyfield_report(rows)
+  erfa_report(rows)
+
+  emit_rows(rows, "CORE (1900-2100 + 47.a anchor)", CORE_EPOCHS)
+  emit_rows(rows, "EXTENDED (~501/999/1599/2500/3000 CE)", EXTENDED_EPOCHS)
+  emit_rows(rows, "FAR (JD 2^22 straddle ~6771 CE; ~9420 CE)", FAR_EPOCHS)
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
v0.4.0 Phase A(milestone 2):#94 上半(月亮轴)+ #65 收尾。

## 内容

- **新增 `src/test/astro/moon_horizons_golden_test.cpp`** — 月亮视位置独立 golden:41 历元 × 3 列(of-date 视黄经/黄纬 + 距离),对照 JPL Horizons **DE441**,全程 TT(无 ΔT 模型入链)。分带:核心 1900–2100(33 点,含 Meeus Example 47.a 锚)、扩展 ~501–3000 CE、远端 JD 2²² 骑跨 ~6771 CE + ~9420 CE。
- **新增 `statistics/moon_horizons_crawler.py`** — 离线采集脚本(#94:离线生成、产物入库、CI 只比对):Horizons 量31/量20,Skyfield/DE421 交叉验证查询语义,pyerfa eraMoon98 测距离截断包络;重跑硬闸 DE441/TT/JDTT + 1″/10m 语义回归门。
- **`moon_test.cpp`** — 退役 DiffTest1(tamu cgi,0.1°)与 DiffTest2(timeanddate,PST 行套 PDT 偏移 + 只采极值历元,#68 记录在案);CoordAndPpi 注解改「回归基线,非精度基准」。
- **`automation/linter.py`** — 日志写入显式 UTF-8(Windows cp1252 遇 λ 崩溃)。

## 源验证链(#94:未经验证的源不得入链)

| 源 | 角色 | 验证 |
|---|---|---|
| Horizons/DE441 (API 1.2) | 真值 | TT 时标探测确认;47.a 锚点核对 |
| Skyfield 1.54 + DE421 | 查询语义守卫(非独立月球理论) | 26/33 核心历元:最差 0.231″ / 1.0 m |
| pyerfa 2.0.1.5 eraMoon98 | 同理论独立转录,距离包络归因 | 复现书值 47.a 距离到 15 m |

## 关键测量

- 本库实测残差:核心 λ 6.49″ / β 2.06″ / r 45.689 km;扩展 24.8″/1.85″/34.8 km;远端 969″/140″/46.3 km。
- **#65 距离疑问了结**:r 残差与 eraMoon98↔DE441 包络(28–46 km,跨万年平坦)完全重合——转录零偏差,「distance seems problematic」实为截断模型固有包络,此前被自产数据 1e-7 km 断言掩盖。
- 容差分带钉死(核心 0.003°/0.0015°/55 km),模型误差与源间差异分别声明;**突变检出 4/4**(+69s 时标、章动符号、β 扰动主项、r 基准 +100 km)。
- 23/41 历元 |ṙ|≥0.03 km/s(非极值采样,#68 验收项)。

## 本地验证

- 全套 156 测试绿;ruff 全过;crawler 重跑输出与入库行**字节一致**。
- 本地 clang-tidy 18.1.8 × MSVC ranges 头对触达 `elp2000_82b.hpp` 的 TU 段错误(HEAD 原版 moon_test.cpp 同样崩,既有环境洞,与本 PR 无关)——以 Linux CI tidy 为权威 gate。
- 本地交叉审阅:kimi + grok 各一轮(无 P0;共同 P1 = crawler 硬闸,已修)+ 修复复审双 FIXES VERIFIED。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
