### PR TITLE
feat(time): 闰秒感知 UTC 时标;UTC 年界/月界 (#84)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,16 @@ is intentional. Keep it. That buys a discipline:
 - `const`-correct; modern C++ (`<ranges>`, `<span>`, `std::array`).
 - 2-space indentation. Compiler flags: `-Wall -Wextra -Werror -Wpedantic -Wnull-dereference
   -Wunreachable-code -O2`.
+- **Multi-line call layout**: when an argument is itself a call, or the call grows long, put
+  each argument on its own line and the closing `);` on its own line at the call's
+  indentation — matching the existing `upper_bound` / `Datetime`-construction sites:
+  ```cpp
+  calendar::add_seconds(
+    tt_dt,
+    -tt_minus_utc(tt_dt.ymd)
+  );
+  ```
+  Trivial short calls stay on one line.
 - Doxygen `/** @brief / @param / @return / @note / @ref */` on public functions; inline `//`
   comments explain the physics, not the syntax — with order-of-magnitude arguments
   ("ΔT ≈ 69 s ≈ 0.29° of rotation"), not bare claims ("this is accurate"). `@ref` cites the

--- a/src/astro/delta_t.hpp
+++ b/src/astro/delta_t.hpp
@@ -496,27 +496,8 @@ constexpr auto compute(const calendar::Datetime& ut1_dt) -> double {
  * @return The datetime in TT.
  */
 constexpr auto ut1_to_tt(const calendar::Datetime& ut1_dt) -> calendar::Datetime {
-  using namespace util::ymd_operator;
-  using namespace std::chrono;
-
-  // Calculate the delta T.
-  const double delta_t = compute(ut1_dt);
-
   // As per the formula, TT = UT1 + ΔT.
-  // Calculate the day fraction in TT, using the above ΔT.
-  const double tt_day_fraction = ut1_dt.fraction()                          // UT1 day fraction
-                               + (delta_t / calendar::in_a_day<seconds>()); // Fraction of ΔT in a day.
-
-  // After adjustment, `tt_day_fraction` can be out of the range of [0.0, 1.0).
-
-  // Find out how many days to add or substract. `days` can be either positive or negative.
-  const auto days = static_cast<int32_t>(std::floor(tt_day_fraction));
-  
-  // Correct the fraction to be in the range of [0.0, 1.0).
-  const double real_fraction = tt_day_fraction - days;
-
-  // Finally return the result.
-  return calendar::Datetime { ut1_dt.ymd + days, real_fraction };
+  return calendar::add_seconds(ut1_dt, compute(ut1_dt));
 }
 
 
@@ -526,27 +507,8 @@ constexpr auto ut1_to_tt(const calendar::Datetime& ut1_dt) -> calendar::Datetime
  * @return The datetime in UT1.
  */
 constexpr auto tt_to_ut1(const calendar::Datetime& tt_dt) -> calendar::Datetime {
-  using namespace util::ymd_operator;
-  using namespace std::chrono;
-
-  // Calculate the delta T.
-  const double delta_t = compute(tt_dt);
-
   // As per the formula, UT1 = TT - ΔT.
-  // Calculate the day fraction in UT1, using the above ΔT.
-  const double ut1_day_fraction = tt_dt.fraction()                           // TT day fraction
-                                - (delta_t / calendar::in_a_day<seconds>()); // Fraction of ΔT in a day.
-
-  // After adjustment, `ut1_day_fraction` can be out of the range of [0.0, 1.0).
-
-  // Find out how many days to add or substract. `days` can be either positive or negative.
-  const auto days = static_cast<int32_t>(std::floor(ut1_day_fraction));
-  
-  // Correct the fraction to be in the range of [0.0, 1.0).
-  const double real_fraction = ut1_day_fraction - days;
-
-  // Finally return the result.
-  return calendar::Datetime { tt_dt.ymd + days, real_fraction };
+  return calendar::add_seconds(tt_dt, -compute(tt_dt));
 }
 
 } // namespace astro::delta_t

--- a/src/astro/julian_day.hpp
+++ b/src/astro/julian_day.hpp
@@ -29,6 +29,7 @@
 #include <stdexcept>
 
 #include "delta_t.hpp"
+#include "leap_second.hpp"
 
 #include "ymd.hpp"
 #include "datetime.hpp"
@@ -227,6 +228,28 @@ inline auto jde_to_ut1(const double jde) -> calendar::Datetime {
 inline auto ut1_to_jde(const calendar::Datetime& ut1_dt) -> double {
   const auto tt_dt = astro::delta_t::ut1_to_tt(ut1_dt);
   return tt_to_jde(tt_dt);
+}
+
+
+/**
+ * @brief Converts a julian ephemeris day number to UTC datetime.
+ * @param jde The julian ephemeris day number, which is based on TT.
+ * @return The date and time, in UTC.
+ * @note Before modern UTC (1972-01-01) this degrades to UT1; see `astro::leap_second::tt_to_utc`.
+ */
+inline auto jde_to_utc(const double jde) -> calendar::Datetime {
+  return astro::leap_second::tt_to_utc(jde_to_tt(jde));
+}
+
+
+/**
+ * @brief Converts a UTC datetime to julian ephemeris day number.
+ * @param utc_dt The date and time, in UTC.
+ * @return The julian ephemeris day number, which is based on TT.
+ * @note Before modern UTC (1972-01-01) this degrades to UT1; see `astro::leap_second::utc_to_tt`.
+ */
+inline auto utc_to_jde(const calendar::Datetime& utc_dt) -> double {
+  return tt_to_jde(astro::leap_second::utc_to_tt(utc_dt));
 }
 
 

--- a/src/astro/leap_second.hpp
+++ b/src/astro/leap_second.hpp
@@ -114,11 +114,10 @@ constexpr auto tai_minus_utc(const std::chrono::year_month_day& utc_ymd) -> doub
     };
   }
 
-  // Find the last entry whose start is on or before the date.
-  const auto after = std::ranges::upper_bound(
-    LEAP_SECOND_TABLE, utc_ymd, {}, &LeapSecondEntry::start_utc
-  );
-  return std::prev(after)->tai_minus_utc;
+  // The last entry whose start is on or before the date.
+  return std::prev(
+    std::ranges::upper_bound(LEAP_SECOND_TABLE, utc_ymd, {}, &LeapSecondEntry::start_utc)
+  )->tai_minus_utc;
 }
 
 

--- a/src/astro/leap_second.hpp
+++ b/src/astro/leap_second.hpp
@@ -147,7 +147,10 @@ constexpr auto utc_to_tt(const calendar::Datetime& utc_dt) -> calendar::Datetime
   if (utc_dt.ymd < MODERN_UTC_START) {
     return delta_t::ut1_to_tt(utc_dt);
   }
-  return calendar::add_seconds(utc_dt, tt_minus_utc(utc_dt.ymd));
+  return calendar::add_seconds(
+    utc_dt,
+    tt_minus_utc(utc_dt.ymd)
+  );
 }
 
 
@@ -171,14 +174,20 @@ constexpr auto tt_to_utc(const calendar::Datetime& tt_dt) -> calendar::Datetime 
     return delta_t::tt_to_ut1(tt_dt);
   }
 
-  const auto guessed_utc = calendar::add_seconds(tt_dt, -tt_minus_utc(tt_dt.ymd));
+  const auto guessed_utc = calendar::add_seconds(
+    tt_dt,
+    -tt_minus_utc(tt_dt.ymd)
+  );
 
   // The first ~42.184 s of 1972-01-01 (TT) still map below the table start.
   if (guessed_utc.ymd < MODERN_UTC_START) {
     return delta_t::tt_to_ut1(tt_dt);
   }
 
-  return calendar::add_seconds(tt_dt, -tt_minus_utc(guessed_utc.ymd));
+  return calendar::add_seconds(
+    tt_dt,
+    -tt_minus_utc(guessed_utc.ymd)
+  );
 }
 
 } // namespace astro::leap_second

--- a/src/astro/leap_second.hpp
+++ b/src/astro/leap_second.hpp
@@ -1,0 +1,185 @@
+/*
+ * CelestialCalendar:
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ *
+ * Copyright (C) 2026 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <array>
+#include <chrono>
+#include <format>
+#include <iterator>
+#include <algorithm>
+#include <stdexcept>
+
+#include "delta_t.hpp"
+
+#include "ymd.hpp"
+#include "datetime.hpp"
+
+namespace astro::leap_second {
+
+// UTC differs from the uniform atomic scale TAI by an integer number of leap seconds (ΔAT),
+// stepped by IERS so that |UTC - UT1| stays under 0.9 s. TT is defined as TAI + 32.184 s.
+// So TT - UTC = ΔAT + 32.184 s exactly — no model involved, unlike ΔT = TT - UT1.
+
+/**
+ * @brief TT − TAI in seconds. Exact by definition: TT = TAI + 32.184 s.
+ * @ref IAU 1991 Resolution A4.
+ */
+inline constexpr double TT_MINUS_TAI_SEC = 32.184;
+
+
+/** @brief One step of the ΔAT table: from `start_utc` (inclusive), TAI − UTC is `tai_minus_utc` seconds. */
+struct LeapSecondEntry {
+  std::chrono::year_month_day start_utc;
+  double tai_minus_utc;
+};
+
+/**
+ * @brief The ΔAT (TAI − UTC) step table, from the start of modern UTC (1972-01-01) onwards.
+ *        Each new entry is one inserted leap second.
+ * @details No leap second has been announced since 2017, and CGPM Resolution 4 (2022) decided
+ *          to discontinue them by 2035 — past the last entry, ΔAT is held at its final value.
+ * @ref IERS Bulletin C; the transcription is pinned by `LeapSecond.TableMatchesIERS`.
+ */
+inline constexpr std::array<LeapSecondEntry, 28> LEAP_SECOND_TABLE {{
+  { util::to_ymd(1972, 1, 1), 10.0 },
+  { util::to_ymd(1972, 7, 1), 11.0 },
+  { util::to_ymd(1973, 1, 1), 12.0 },
+  { util::to_ymd(1974, 1, 1), 13.0 },
+  { util::to_ymd(1975, 1, 1), 14.0 },
+  { util::to_ymd(1976, 1, 1), 15.0 },
+  { util::to_ymd(1977, 1, 1), 16.0 },
+  { util::to_ymd(1978, 1, 1), 17.0 },
+  { util::to_ymd(1979, 1, 1), 18.0 },
+  { util::to_ymd(1980, 1, 1), 19.0 },
+  { util::to_ymd(1981, 7, 1), 20.0 },
+  { util::to_ymd(1982, 7, 1), 21.0 },
+  { util::to_ymd(1983, 7, 1), 22.0 },
+  { util::to_ymd(1985, 7, 1), 23.0 },
+  { util::to_ymd(1988, 1, 1), 24.0 },
+  { util::to_ymd(1990, 1, 1), 25.0 },
+  { util::to_ymd(1991, 1, 1), 26.0 },
+  { util::to_ymd(1992, 7, 1), 27.0 },
+  { util::to_ymd(1993, 7, 1), 28.0 },
+  { util::to_ymd(1994, 7, 1), 29.0 },
+  { util::to_ymd(1996, 1, 1), 30.0 },
+  { util::to_ymd(1997, 7, 1), 31.0 },
+  { util::to_ymd(1999, 1, 1), 32.0 },
+  { util::to_ymd(2006, 1, 1), 33.0 },
+  { util::to_ymd(2009, 1, 1), 34.0 },
+  { util::to_ymd(2012, 7, 1), 35.0 },
+  { util::to_ymd(2015, 7, 1), 36.0 },
+  { util::to_ymd(2017, 1, 1), 37.0 },
+}};
+
+
+/**
+ * @brief The first day of modern UTC. Before it this project has no UTC to model: civil
+ *        datetimes are treated as UT1 and converted through ΔT instead.
+ */
+inline constexpr std::chrono::year_month_day MODERN_UTC_START = LEAP_SECOND_TABLE.front().start_utc;
+
+
+/**
+ * @brief Look up ΔAT = TAI − UTC for the given UTC calendar date.
+ * @param utc_ymd The UTC calendar date.
+ * @return ΔAT, in seconds.
+ * @throw std::invalid_argument if the date predates modern UTC (1972-01-01).
+ */
+constexpr auto tai_minus_utc(const std::chrono::year_month_day& utc_ymd) -> double {
+  if (utc_ymd < MODERN_UTC_START) {
+    throw std::invalid_argument {
+      std::vformat("ΔAT is undefined before modern UTC (1972-01-01), got {}",
+                   std::make_format_args(utc_ymd))
+    };
+  }
+
+  // Find the last entry whose start is on or before the date.
+  const auto after = std::ranges::upper_bound(
+    LEAP_SECOND_TABLE, utc_ymd, {}, &LeapSecondEntry::start_utc
+  );
+  return std::prev(after)->tai_minus_utc;
+}
+
+
+/**
+ * @brief TT − UTC in seconds for the given UTC calendar date: ΔAT + 32.184 s, exact by definition.
+ * @param utc_ymd The UTC calendar date.
+ * @return TT − UTC, in seconds.
+ * @throw std::invalid_argument if the date predates modern UTC (1972-01-01).
+ */
+constexpr auto tt_minus_utc(const std::chrono::year_month_day& utc_ymd) -> double {
+  return TT_MINUS_TAI_SEC + tai_minus_utc(utc_ymd);
+}
+
+
+/**
+ * @brief Convert a `calendar::Datetime` in UTC to a new `calendar::Datetime` in TT.
+ * @param utc_dt The datetime in UTC.
+ * @return The datetime in TT.
+ * @details TT = UTC + ΔAT + 32.184 s. Before modern UTC (1972-01-01) the input is treated
+ *          as UT1 and converted through ΔT instead — the rubber-second UTC of 1960-1971 is
+ *          not modelled. The seam at 1972-01-01 is ΔT(1972.0) − 42.184 s, well under a second.
+ *          Past the table's last entry ΔAT is held at 37 s (see `LEAP_SECOND_TABLE`).
+ * @note A `Datetime` cannot carry an inserted second 23:59:60 itself; the conversion is
+ *       defined on the representable instants around it.
+ */
+constexpr auto utc_to_tt(const calendar::Datetime& utc_dt) -> calendar::Datetime {
+  if (utc_dt.ymd < MODERN_UTC_START) {
+    return delta_t::ut1_to_tt(utc_dt);
+  }
+  return calendar::add_seconds(utc_dt, tt_minus_utc(utc_dt.ymd));
+}
+
+
+/**
+ * @brief Convert a `calendar::Datetime` in TT to a new `calendar::Datetime` in UTC.
+ * @param tt_dt The datetime in TT.
+ * @return The datetime in UTC.
+ * @details ΔAT steps on the UTC date, which is only known once the conversion is done — so
+ *          guess with the TT date, then refine once with the resulting UTC date. One
+ *          refinement settles any step crossing: consecutive steps are at least half a year
+ *          apart, while TT − UTC is under two minutes. Before modern UTC (1972-01-01) this
+ *          falls back to UT1 through ΔT, mirroring `utc_to_tt`; past the table's last entry
+ *          ΔAT is held at 37 s (see `LEAP_SECOND_TABLE`).
+ * @note Instants inside an inserted leap second (the unrepresentable 23:59:60) land in the
+ *       first second of the following UTC day, duplicating it — on that 1 s TT interval the
+ *       conversion is not invertible, and `utc_to_tt(tt_to_utc(tt))` returns `tt` plus one
+ *       second.
+ */
+constexpr auto tt_to_utc(const calendar::Datetime& tt_dt) -> calendar::Datetime {
+  if (tt_dt.ymd < MODERN_UTC_START) {
+    return delta_t::tt_to_ut1(tt_dt);
+  }
+
+  const auto guessed_utc = calendar::add_seconds(tt_dt, -tt_minus_utc(tt_dt.ymd));
+
+  // The first ~42.184 s of 1972-01-01 (TT) still map below the table start.
+  if (guessed_utc.ymd < MODERN_UTC_START) {
+    return delta_t::tt_to_ut1(tt_dt);
+  }
+
+  return calendar::add_seconds(tt_dt, -tt_minus_utc(guessed_utc.ymd));
+}
+
+} // namespace astro::leap_second

--- a/src/astro/moon_phase.hpp
+++ b/src/astro/moon_phase.hpp
@@ -214,27 +214,28 @@ public:
           计算某一个公历年中日月合朔的时刻。
  * @param year The Gregorian year.
  * @return The vector of the conjunction moments, in JDE (Julian Ephemeris Day).
- * @details The Sun's position is calculated using VSOP87D, 
+ * @note The year runs from Jan 1 to Jan 1 in UTC; before 1972 the bounds degrade to UT1.
+ * @details The Sun's position is calculated using VSOP87D,
  * @details The Moon's position is calculated using truncated ELP2000-82B.
  * @see VSOP87D, ELP2000-82B, and Astronomical Algorithms, Jean Meeus, 1998.
  */
 inline auto moments(const int32_t year) -> std::vector<double> {
   // The first moment of the year, inclusive.
-  const calendar::Datetime start_moment {
+  const calendar::Datetime start_moment_utc {
     util::to_ymd(year, 1, 1),
     0.0,
   };
 
   // The last moment of the year, exclusive.
-  const calendar::Datetime end_moment {
+  const calendar::Datetime end_moment_utc {
     util::to_ymd(year + 1, 1, 1),
     0.0,
   };
 
-  // Convert to JDEs.
-  // TODO: Use `utc_to_jde` when supported.
-  const auto start_jde = astro::julian_day::ut1_to_jde(start_moment);
-  const auto end_jde = astro::julian_day::ut1_to_jde(end_moment);
+  // #84: the bounds are UTC, not UT1 — a conjunction between the two midnights used to be
+  // attributed to the neighbouring year.
+  const auto start_jde = astro::julian_day::utc_to_jde(start_moment_utc);
+  const auto end_jde = astro::julian_day::utc_to_jde(end_moment_utc);
 
   RootGenerator gen(start_jde);
   std::vector<double> roots;

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <chrono>
 #include <format>
 #include <cassert>
@@ -110,7 +111,7 @@ constexpr auto from_fraction(const double fraction) -> hh_mm_ss<nanoseconds> {
  * @note The precision of the `time_of_day` field is `std::chrono::nanoseconds`.
  * @note The `time_of_day` field (i.e. `hh_mm_ss`) is positive and less than 24:00:00.0 (i.e. 1 day).
  * @note No time zone is assumed.
- * @details This struct is used to represent UT1 and UTC time in this project.
+ * @details This struct is used to represent UT1, UTC, and TT time in this project.
  */
 struct Datetime {
   year_month_day ymd;
@@ -266,6 +267,40 @@ struct Datetime {
     return time_of_day.to_duration() <=> other.time_of_day.to_duration();
   };
 };
+
+
+/**
+ * @brief Returns `dt` shifted by `offset_sec` seconds, carrying whole days into the date part.
+ * @param dt The datetime to shift.
+ * @param offset_sec The offset in seconds. Can be negative, and is not limited to one day.
+ * @return The shifted datetime.
+ * @throw std::invalid_argument if `offset_sec` is not finite or beyond the day-carry range,
+ *        or if the shifted date is not a valid gregorian date.
+ */
+constexpr auto add_seconds(const Datetime& dt, const double offset_sec) -> Datetime {
+  using namespace util::ymd_operator;
+
+  // Beyond ±2e9 days the day carry below overflows `int32_t`; NaN fails the comparison too.
+  if (not (std::fabs(offset_sec) < 2.0e9 * in_a_day<seconds>())) {
+    throw std::invalid_argument {
+      std::format("The offset {} seconds is not finite or beyond the day-carry range.", offset_sec)
+    };
+  }
+
+  const double fraction = dt.fraction() + (offset_sec / in_a_day<seconds>());
+
+  // The shift can leave [0.0, 1.0); carry the whole days into the date part.
+  const auto day_carry = static_cast<int32_t>(std::floor(fraction));
+  const double remainder = fraction - day_carry;
+
+  // A shift landing exactly on midnight can round `remainder` up to 1.0 (the sum comes out a
+  // half-ulp below a whole day); carry it, or the constructor rejects the fraction.
+  if (remainder >= 1.0) {
+    return Datetime { dt.ymd + day_carry + 1, 0.0 };
+  }
+
+  return Datetime { dt.ymd + day_carry, remainder };
+}
 
 } // namespace calendar
 

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -274,12 +274,10 @@ struct Datetime {
  * @param dt The datetime to shift.
  * @param offset_sec The offset in seconds. Can be negative, and is not limited to one day.
  * @return The shifted datetime.
- * @throw std::invalid_argument if `offset_sec` is not finite or beyond the day-carry range,
- *        or if the shifted date is not a valid gregorian date.
+ * @throw std::invalid_argument if `offset_sec` is not finite, or if the shifted date leaves
+ *        `std::chrono::year_month_day`'s representable years.
  */
 constexpr auto add_seconds(const Datetime& dt, const double offset_sec) -> Datetime {
-  using namespace util::ymd_operator;
-
   // Beyond ±2e9 days the day carry below overflows `int32_t`; NaN fails the comparison too.
   if (not (std::fabs(offset_sec) < 2.0e9 * in_a_day<seconds>())) {
     throw std::invalid_argument {
@@ -289,17 +287,25 @@ constexpr auto add_seconds(const Datetime& dt, const double offset_sec) -> Datet
 
   const double fraction = dt.fraction() + (offset_sec / in_a_day<seconds>());
 
-  // The shift can leave [0.0, 1.0); carry the whole days into the date part.
-  const auto day_carry = static_cast<int32_t>(std::floor(fraction));
-  const double remainder = fraction - day_carry;
+  // The shift can leave [0.0, 1.0); carry the whole days into the date part. A shift landing
+  // exactly on midnight can round the remainder up to 1.0 (the sum comes out a half-ulp below
+  // a whole day) — carry that too, or the constructor rejects the fraction.
+  const auto floor_carry = static_cast<int32_t>(std::floor(fraction));
+  const bool midnight_carry = (fraction - floor_carry) >= 1.0;
+  const auto day_carry = floor_carry + (midnight_carry ? 1 : 0);
+  const double remainder = midnight_carry ? 0.0 : fraction - floor_carry;
 
-  // A shift landing exactly on midnight can round `remainder` up to 1.0 (the sum comes out a
-  // half-ulp below a whole day); carry it, or the constructor rejects the fraction.
-  if (remainder >= 1.0) {
-    return Datetime { dt.ymd + day_carry + 1, 0.0 };
+  // `std::chrono::year` stores an unspecified value beyond ±32767 (`ok()` cannot be trusted
+  // on a wrapped date) — bound the shifted date while it is still a day count.
+  const auto shifted = std::chrono::sys_days { dt.ymd } + std::chrono::days { day_carry };
+  if (shifted < std::chrono::sys_days { util::to_ymd(-32767, 1, 1) }
+      or shifted > std::chrono::sys_days { util::to_ymd(32767, 12, 31) }) {
+    throw std::invalid_argument {
+      std::format("The offset {} seconds shifts the date beyond the representable years.", offset_sec)
+    };
   }
 
-  return Datetime { dt.ymd + day_carry, remainder };
+  return Datetime { std::chrono::year_month_day { shifted }, remainder };
 }
 
 } // namespace calendar

--- a/src/calendar/jieqi.hpp
+++ b/src/calendar/jieqi.hpp
@@ -163,6 +163,8 @@ const inline auto jieqi_jde = util::cache::cache_func(calc_jieqi_jde);
  * @param jq The jieqi.
  * @return The UT1 (Universal Time 1).
  * @details This is just a thin wrapper around `jieqi_jde`.
+ * @note UT1, not UTC — the lunar-calendar rules render civil moments through the
+ *       leap-second-aware path instead (#84).
  */
 inline auto jieqi_ut1_moment(const int32_t year, const Jieqi jq) -> calendar::Datetime {
   return astro::julian_day::jde_to_ut1(jieqi_jde(year, jq));

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -40,6 +40,20 @@ using namespace calendar::jieqi;
 using calendar::lunar::common::LunarYear;
 
 
+/**
+ * @brief Convert a JDE moment to UTC+8, the civil scale the lunar-calendar rules are defined in.
+ * @param jde The julian ephemeris day number, which is based on TT.
+ * @return The datetime in UTC+8.
+ * @note Leap-second aware (#84): rendering through UT1 sat model ΔT − (ΔAT + 32.184 s) off
+ *       UTC — enough to flip the civil date near midnight.
+ * @note Leap seconds step at UTC midnight, i.e. 08:00 in UTC+8 — the non-invertible second of
+ *       `leap_second::tt_to_utc` never lands on a civil-day boundary here.
+ */
+inline auto jde_to_utc8(const double jde) -> calendar::Datetime {
+  return calendar::add_seconds(astro::julian_day::jde_to_utc(jde), 8.0 * 3600.0);
+}
+
+
 /** @brief The metadata of a lunar month. */
 struct LunarMonth {
   // Start of the month, inclusive.
@@ -117,26 +131,25 @@ private:
     put_back_new_moon(end_jde);
 
     // As per the rules, we convert the JDEs to UTC+8.
-    // TODO: Currently we regard UT1 as UTC, which is a bit inaccurate. Use `jde_to_utc` when available.
-    const auto start_moment = astro::julian_day::jde_to_ut1(start_jde + 8.0 / 24.0);
-    const auto end_moment = astro::julian_day::jde_to_ut1(end_jde + 8.0 / 24.0);
+    const auto start_moment_utc8 = jde_to_utc8(start_jde);
+    const auto end_moment_utc8 = jde_to_utc8(end_jde);
 
     // Get the Jieqis that fall in this lunar month.
     std::vector<JieqiGenerator::JieqiPair> jieqis;
     while (true) {
       const auto jieqi = next_jieqi();
-      const auto jieqi_moment_ut1_8 = astro::julian_day::jde_to_ut1(jieqi.jde + 8.0 / 24.0);
+      const auto jieqi_moment_utc8 = jde_to_utc8(jieqi.jde);
 
       // If the Jieqi is in next month, stop.
       // Note that the comparison is at date time level, as per the rules.
-      if (jieqi_moment_ut1_8.ymd >= end_moment.ymd) {
+      if (jieqi_moment_utc8.ymd >= end_moment_utc8.ymd) {
         put_back_jieqi(jieqi);
         break;
       }
 
       // If the Jieqi is not in this month, continue going.
       // Note that the comparison is at date time level, as per the rules.
-      if (jieqi_moment_ut1_8.ymd < start_moment.ymd) {
+      if (jieqi_moment_utc8.ymd < start_moment_utc8.ymd) {
         continue;
       }
 
@@ -144,8 +157,8 @@ private:
     }
 
     return {
-      .start_moment_utc8 = start_moment,
-      .end_moment_utc8   = end_moment,
+      .start_moment_utc8 = start_moment_utc8,
+      .end_moment_utc8   = end_moment_utc8,
       .contained_jieqis  = jieqis
     };
   }

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -50,7 +50,10 @@ using calendar::lunar::common::LunarYear;
  *       `leap_second::tt_to_utc` never lands on a civil-day boundary here.
  */
 inline auto jde_to_utc8(const double jde) -> calendar::Datetime {
-  return calendar::add_seconds(astro::julian_day::jde_to_utc(jde), 8.0 * 3600.0);
+  return calendar::add_seconds(
+    astro::julian_day::jde_to_utc(jde),
+    8.0 * 3600.0
+  );
 }
 
 

--- a/src/test/astro/julian_day_test.cpp
+++ b/src/test/astro/julian_day_test.cpp
@@ -7,6 +7,9 @@
 
 namespace astro::julian_day::test {
 
+// The UTC family (`utc_to_jde` / `jde_to_utc`) is exercised in `leap_second_test.cpp`,
+// alongside the ΔAT machinery it composes.
+
 using namespace astro::julian_day;
 
 using namespace util;

--- a/src/test/astro/leap_second_test.cpp
+++ b/src/test/astro/leap_second_test.cpp
@@ -1,0 +1,236 @@
+#include <gtest/gtest.h>
+#include <chrono>
+#include <cstdlib>
+#include <random>
+#include <vector>
+
+#include "util.hpp"
+#include "ymd.hpp"
+#include "datetime.hpp"
+#include "leap_second.hpp"
+#include "julian_day.hpp"
+
+namespace astro::leap_second::test {
+
+using namespace astro::leap_second;
+using namespace util;
+using namespace util::ymd_operator;
+using namespace std::chrono_literals;
+using calendar::Datetime;
+
+
+/** @brief Signed difference `a - b`, in nanoseconds. */
+inline auto diff_ns(
+  const Datetime& a,
+  const Datetime& b // NOLINT(bugprone-easily-swappable-parameters) the sign convention is the point
+) -> int64_t {
+  const auto day_gap = std::chrono::sys_days { a.ymd } - std::chrono::sys_days { b.ymd };
+  const auto time_gap = a.time_of_day.to_duration() - b.time_of_day.to_duration();
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(day_gap + time_gap).count();
+}
+
+
+TEST(LeapSecond, TableMatchesIERS) {
+  // Transcription guard for `LEAP_SECOND_TABLE` (#65).
+  // Columns: year, month (day is always 1), ΔAT = TAI − UTC in seconds.
+  // Source: IERS Bulletin C, dumped via pyerfa 2.0.1 `erfa.dat` over 1972-2026 (2026-07-28).
+  struct Row { int32_t y; uint32_t m; double dat; };
+  const std::vector<Row> expected {
+    { 1972,  1, 10.0 }, { 1972,  7, 11.0 }, { 1973,  1, 12.0 }, { 1974,  1, 13.0 },
+    { 1975,  1, 14.0 }, { 1976,  1, 15.0 }, { 1977,  1, 16.0 }, { 1978,  1, 17.0 },
+    { 1979,  1, 18.0 }, { 1980,  1, 19.0 }, { 1981,  7, 20.0 }, { 1982,  7, 21.0 },
+    { 1983,  7, 22.0 }, { 1985,  7, 23.0 }, { 1988,  1, 24.0 }, { 1990,  1, 25.0 },
+    { 1991,  1, 26.0 }, { 1992,  7, 27.0 }, { 1993,  7, 28.0 }, { 1994,  7, 29.0 },
+    { 1996,  1, 30.0 }, { 1997,  7, 31.0 }, { 1999,  1, 32.0 }, { 2006,  1, 33.0 },
+    { 2009,  1, 34.0 }, { 2012,  7, 35.0 }, { 2015,  7, 36.0 }, { 2017,  1, 37.0 },
+  };
+
+  ASSERT_EQ(LEAP_SECOND_TABLE.size(), expected.size());
+  for (std::size_t i = 0; i < expected.size(); ++i) {
+    ASSERT_EQ(LEAP_SECOND_TABLE[i].start_utc, to_ymd(expected[i].y, expected[i].m, 1));
+    ASSERT_EQ(LEAP_SECOND_TABLE[i].tai_minus_utc, expected[i].dat);
+  }
+
+  // Structure: dates strictly increase, and every step inserts exactly one second.
+  for (std::size_t i = 1; i < LEAP_SECOND_TABLE.size(); ++i) {
+    ASSERT_LT(LEAP_SECOND_TABLE[i - 1].start_utc, LEAP_SECOND_TABLE[i].start_utc);
+    ASSERT_EQ(LEAP_SECOND_TABLE[i].tai_minus_utc - LEAP_SECOND_TABLE[i - 1].tai_minus_utc, 1.0);
+  }
+}
+
+
+TEST(LeapSecond, TaiMinusUtcLookup) {
+  ASSERT_EQ(tai_minus_utc(to_ymd(1972,  1,  1)), 10.0);
+  ASSERT_EQ(tai_minus_utc(to_ymd(1972,  6, 30)), 10.0);
+  ASSERT_EQ(tai_minus_utc(to_ymd(1972,  7,  1)), 11.0);
+  ASSERT_EQ(tai_minus_utc(to_ymd(2016, 12, 31)), 36.0);
+  ASSERT_EQ(tai_minus_utc(to_ymd(2017,  1,  1)), 37.0);
+  ASSERT_EQ(tai_minus_utc(to_ymd(2026,  7, 28)), 37.0);
+
+  // Past the last entry ΔAT is held (CGPM 2022 Res. 4: no more leap seconds by 2035).
+  ASSERT_EQ(tai_minus_utc(to_ymd(5000,  1,  1)), 37.0);
+
+  ASSERT_THROW({ tai_minus_utc(to_ymd(1971, 12, 31)); }, std::invalid_argument);
+}
+
+
+// Columns: year, month, day, fraction-of-day (UTC), expected TT julian date.
+// Source: pyerfa 2.0.1 (SOFA) dtf2d("UTC") → utctai → taitt, generated 2026-07-28, seed 42;
+// 34 random modern-UTC instants plus both sides of the 2015/2017 leap steps and the table start.
+struct UtcGoldenRow { int32_t y; uint32_t m; uint32_t d; double frac; double tt_jd; };
+const std::vector<UtcGoldenRow> UTC_GOLDEN_ROWS {
+  { 2012,  2,  1,    0.9703089467592593, 2455959.4710749653 },
+  { 1980, 12,  4,     0.908258449074074, 2444578.4088508566 },
+  { 1977, 10, 14,  0.042426180555555554,  2443430.542983866 },
+  { 1986,  9, 20,   0.02444363425925926,  2446693.525082338 },
+  { 2013, 12, 18,    0.5517008333333333,  2456645.052478426 },
+  { 1989,  1, 25,    0.2391823611111111, 2447551.7398326388 },
+  { 1989,  3,  7,    0.4208977430555556,  2447592.921548021 },
+  { 1978,  6, 28,    0.4849059143518518, 2443687.9854751737 },
+  { 1974, 12, 15,    0.7138702083333334, 2442397.2143931715 },
+  { 1996,  2, 18,   0.41224210648148146, 2450131.9129618285 },
+  { 1995, 10,  7,     0.919476261574074, 2449998.4201844097 },
+  { 1986,  5,  3,            0.32993125, 2446553.8305699537 },
+  { 1989,  8, 21,   0.46553483796296297, 2447759.9661851157 },
+  { 1985, 11,  9,    0.9581135648148148, 2446379.4587522685 },
+  { 1976, 10, 21,   0.23245077546296294, 2443072.7329968866 },
+  { 1982,  8, 13,   0.37474998842592594,  2445194.875365544 },
+  { 2007,  4, 22,   0.45400576388888886, 2454212.9547602083 },
+  { 1975,  4, 27,   0.07730239583333333,  2442529.577836933 },
+  { 1989,  2,  7,    0.7893874305555555, 2447565.2900377084 },
+  { 1985, 11, 16,    0.5395239814814815, 2446386.0401626853 },
+  { 2001,  3,  9,   0.17760068287037037,  2451977.678343553 },
+  { 2006,  5, 24,    0.7693734722222223, 2453880.2701279167 },
+  { 1997,  6,  8,   0.18923159722222224, 2450607.6899513192 },
+  { 2020,  1, 28,    0.1316857175925926, 2458876.6324864584 },
+  { 2022, 11, 14,    0.7947116435185184, 2459898.2955123843 },
+  { 2010,  8, 17,    0.3582366435185185,  2455425.859002662 },
+  { 1972, 11, 24,    0.1554755324074074, 2441645.6559753474 },
+  { 2020,  5, 25,    0.8479941319444444,  2458995.348794873 },
+  { 1999,  3, 15,  0.032552662037037036,  2451252.533295532 },
+  { 1988,  9, 25,   0.23118931712962965,  2447429.731839595 },
+  { 2012,  5, 27,     0.855978449074074, 2456075.3567444677 },
+  { 1981,  6, 25,   0.23260658564814812,  2444780.733198993 },
+  { 2005,  1, 20,    0.4382079745370371,  2453390.938950845 },
+  { 1995,  5,  8,  0.052693055555555555,  2449845.553401204 },
+  { 1972,  1,  1,                   0.0, 2441317.5004882407 },
+  { 2016, 12, 31,     0.999988425925926, 2457754.5007775924 },
+  { 2017,  1,  1,                   0.0,  2457754.500800741 },
+  { 2015,  6, 30,     0.999994212962963, 2457204.5007718056 },
+  { 2015,  7,  1, 5.787037037037037e-06, 2457204.5007949537 },
+  { 2026,  7, 28,                   0.5,  2461250.000800741 },
+};
+
+
+TEST(LeapSecond, UtcToJdeGolden) {
+  // Tolerance: measured residual is exactly 0 over all rows (both sides round to the same double);
+  // 1e-9 day ≈ 2 ulp of a modern julian date ≈ 86 µs keeps headroom without losing discrimination.
+  for (const auto& row : UTC_GOLDEN_ROWS) {
+    const Datetime utc_dt { to_ymd(row.y, row.m, row.d), row.frac };
+    ASSERT_NEAR(astro::julian_day::utc_to_jde(utc_dt), row.tt_jd, 1e-9);
+  }
+}
+
+
+TEST(LeapSecond, JdeToUtcGolden) {
+  // The inverse direction exercises the guess-then-refine ΔAT lookup that the production
+  // `jde_to_utc8` path depends on — the forward golden alone cannot vouch for it.
+  // Tolerance: measured worst residual is 18.2 µs (JD quantization); 100 µs gives 5× headroom.
+  for (const auto& row : UTC_GOLDEN_ROWS) {
+    const Datetime utc_dt { to_ymd(row.y, row.m, row.d), row.frac };
+    const auto recovered = astro::julian_day::jde_to_utc(row.tt_jd);
+
+    if (utc_dt.ymd == MODERN_UTC_START and utc_dt.fraction() == 0.0) {
+      // Knife edge: this TT sits exactly on the table-start boundary, where one ulp decides
+      // between the table path (exact) and the pre-1972 fallback (off by the ~68 ms seam).
+      // Either side is within the documented seam magnitude.
+      ASSERT_LT(std::abs(diff_ns(recovered, utc_dt)), 500'000'000);
+      continue;
+    }
+
+    ASSERT_LT(std::abs(diff_ns(recovered, utc_dt)), 100'000);
+  }
+}
+
+
+TEST(LeapSecond, RoundTrip) {
+  // Fixed seed: reproducible on failure, and cannot flake by landing inside an inserted second
+  // for a different draw (#69 background).
+  std::mt19937 rng { 42 };
+  std::uniform_int_distribution<int32_t> year_dist { 1972, 2100 };
+  std::uniform_int_distribution<uint32_t> month_dist { 1, 12 };
+  std::uniform_int_distribution<uint32_t> day_dist { 1, 28 };
+  std::uniform_real_distribution<double> frac_dist { 0.0, 1.0 };
+
+  for (int i = 0; i < 1000; ++i) {
+    const Datetime utc_dt { to_ymd(year_dist(rng), month_dist(rng), day_dist(rng)), frac_dist(rng) };
+    const auto recovered = tt_to_utc(utc_to_tt(utc_dt));
+
+    // Each `Datetime` construction truncates to whole nanoseconds; two hops cost a few ns at most.
+    ASSERT_LE(std::abs(diff_ns(recovered, utc_dt)), 10);
+  }
+}
+
+
+TEST(LeapSecond, LeapStepBehavior) {
+  // Across an inserted leap second, one elapsed UTC second spans two TT seconds.
+  const Datetime before_2017 { to_ymd(2016, 12, 31), std::chrono::hh_mm_ss { 23h + 59min + 59s } };
+  const Datetime start_2017  { to_ymd(2017,  1,  1), 0.0 };
+  const double leap_gap_s = (astro::julian_day::utc_to_jde(start_2017)
+                           - astro::julian_day::utc_to_jde(before_2017)) * 86400.0;
+  ASSERT_NEAR(leap_gap_s, 2.0, 1e-4);
+
+  // The same wall-clock pair across an ordinary New Year spans exactly one second.
+  const Datetime before_2018 { to_ymd(2017, 12, 31), std::chrono::hh_mm_ss { 23h + 59min + 59s } };
+  const Datetime start_2018  { to_ymd(2018,  1,  1), 0.0 };
+  const double plain_gap_s = (astro::julian_day::utc_to_jde(start_2018)
+                            - astro::julian_day::utc_to_jde(before_2018)) * 86400.0;
+  ASSERT_NEAR(plain_gap_s, 1.0, 1e-4);
+}
+
+
+TEST(LeapSecond, InsertedSecondMapsForward) {
+  // The inserted second 2016-12-31 23:59:60.5 (UTC) is TT 2017-01-01 00:01:08.684. A `Datetime`
+  // cannot carry 23:59:60, so `tt_to_utc` lands it in the first second of the next day —
+  // documented duplication.
+  const Datetime tt_dt { to_ymd(2017, 1, 1), std::chrono::hh_mm_ss { 1min + 8s + 684ms } };
+  const auto utc_dt = tt_to_utc(tt_dt);
+  ASSERT_EQ(utc_dt.ymd, to_ymd(2017, 1, 1));
+  ASSERT_NEAR(utc_dt.fraction() * 86400.0, 0.5, 1e-4);
+
+  // Contract: on that 1 s TT interval the conversion is not invertible — the round trip
+  // comes back exactly one second late (the inserted second collapses onto the next one,
+  // whose ΔAT is already one higher).
+  const auto round_trip = utc_to_tt(tt_to_utc(tt_dt));
+  ASSERT_NEAR(static_cast<double>(diff_ns(round_trip, tt_dt)), 1e9, 100.0);
+}
+
+
+TEST(LeapSecond, Pre1972FallsBackToUt1) {
+  const Datetime dt { to_ymd(1950, 6, 15), 0.5 };
+  ASSERT_EQ(utc_to_tt(dt), delta_t::ut1_to_tt(dt));
+  ASSERT_EQ(tt_to_utc(dt), delta_t::tt_to_ut1(dt));
+
+  // A TT instant inside the first 42.184 s of 1972-01-01 still maps below the table start —
+  // that band belongs to the fallback as well.
+  const Datetime tt_band { to_ymd(1972, 1, 1), std::chrono::hh_mm_ss { 30s } };
+  ASSERT_EQ(tt_to_utc(tt_band), delta_t::tt_to_ut1(tt_band));
+
+  // The seam at 1972-01-01 is ΔT(1972.0) − 42.184 s — the two paths agree to well under a second.
+  const Datetime seam { to_ymd(1972, 1, 1), 0.0 };
+  ASSERT_LT(std::abs(diff_ns(utc_to_tt(seam), delta_t::ut1_to_tt(seam))), 500'000'000);
+}
+
+
+TEST(LeapSecond, UtcBoundaryFormula) {
+  // New-year midnight UTC in JDE is the calendar julian date plus TT − UTC — nothing else (#84:
+  // the moments() year bound used to add model ΔT here instead, which drifts away from
+  // ΔAT + 32.184 s without bound).
+  for (const int32_t year : { 1980, 2026, 2500, 4500 }) {
+    const Datetime jan1 { to_ymd(year, 1, 1), 0.0 };
+    const double calendar_jd = astro::julian_day::ut1_to_jd(jan1); // pure calendar arithmetic
+    ASSERT_NEAR(astro::julian_day::utc_to_jde(jan1), calendar_jd + tt_minus_utc(jan1.ymd) / 86400.0, 1e-9);
+  }
+}
+
+} // namespace astro::leap_second::test

--- a/src/test/astro/leap_second_test.cpp
+++ b/src/test/astro/leap_second_test.cpp
@@ -47,14 +47,14 @@ TEST(LeapSecond, TableMatchesIERS) {
 
   ASSERT_EQ(LEAP_SECOND_TABLE.size(), expected.size());
   for (std::size_t i = 0; i < expected.size(); ++i) {
-    ASSERT_EQ(LEAP_SECOND_TABLE[i].start_utc, to_ymd(expected[i].y, expected[i].m, 1));
-    ASSERT_EQ(LEAP_SECOND_TABLE[i].tai_minus_utc, expected[i].dat);
+    ASSERT_EQ(LEAP_SECOND_TABLE.at(i).start_utc, to_ymd(expected[i].y, expected[i].m, 1));
+    ASSERT_EQ(LEAP_SECOND_TABLE.at(i).tai_minus_utc, expected[i].dat);
   }
 
   // Structure: dates strictly increase, and every step inserts exactly one second.
   for (std::size_t i = 1; i < LEAP_SECOND_TABLE.size(); ++i) {
-    ASSERT_LT(LEAP_SECOND_TABLE[i - 1].start_utc, LEAP_SECOND_TABLE[i].start_utc);
-    ASSERT_EQ(LEAP_SECOND_TABLE[i].tai_minus_utc - LEAP_SECOND_TABLE[i - 1].tai_minus_utc, 1.0);
+    ASSERT_LT(LEAP_SECOND_TABLE.at(i - 1).start_utc, LEAP_SECOND_TABLE.at(i).start_utc);
+    ASSERT_EQ(LEAP_SECOND_TABLE.at(i).tai_minus_utc - LEAP_SECOND_TABLE.at(i - 1).tai_minus_utc, 1.0);
   }
 }
 

--- a/src/test/astro/moon_phase_test.cpp
+++ b/src/test/astro/moon_phase_test.cpp
@@ -57,9 +57,9 @@ TEST(NewMoon, Moments) {
   for (int i = 0; i < 10; ++i) {
     const auto roots_in_year = moments(year + i);
 
-    // Ensure all roots in this year are really in this year.
+    // Ensure all roots in this year are really in this year. The year is bounded in UTC (#84).
     for (const auto root : roots_in_year) {
-      const auto dt = astro::julian_day::jde_to_ut1(root);
+      const auto dt = astro::julian_day::jde_to_utc(root);
       const auto [y, _, __] = util::from_ymd(dt.ymd);
       ASSERT_EQ(y, year + i);
     }
@@ -82,42 +82,8 @@ TEST(NewMoon, Moments) {
 }
 
 
-TEST(NewMoon, DiffTest1) {
-  using namespace std::ranges;
-  using namespace std::chrono_literals;
-  using hms = std::chrono::hh_mm_ss<std::chrono::nanoseconds>;
-
-  // Datetimes in UTC+8 (Beijing time).
-  // Data source: https://github.com/leetcola/nong/wiki/算法系列之十九：用天文方法计算日月合朔（新月）
-  const std::vector<calendar::Datetime> datetimes {
-    calendar::Datetime { util::to_ymd(2011, 11, 25), hms { 14h +  9min + 41s + 250ms } },
-    calendar::Datetime { util::to_ymd(2011, 12, 25), hms {  2h +  6min + 27s + 250ms } },
-    calendar::Datetime { util::to_ymd(2012,  1, 23), hms { 15h + 39min + 24s + 160ms } },
-    calendar::Datetime { util::to_ymd(2012,  2, 22), hms {  6h + 34min + 40s + 840ms } },
-    calendar::Datetime { util::to_ymd(2012,  3, 22), hms { 22h + 37min +  8s + 910ms } },
-    calendar::Datetime { util::to_ymd(2012,  4, 21), hms { 15h + 18min + 22s + 120ms } },
-    calendar::Datetime { util::to_ymd(2012,  5, 21), hms {  7h + 46min + 59s + 970ms } },
-    calendar::Datetime { util::to_ymd(2012,  6, 19), hms { 23h +  2min +  6s + 390ms } },
-    calendar::Datetime { util::to_ymd(2012,  7, 19), hms { 12h + 24min +  2s + 830ms } },
-    calendar::Datetime { util::to_ymd(2012,  8, 17), hms { 23h + 54min + 28s +  30ms } },
-    calendar::Datetime { util::to_ymd(2012,  9, 16), hms { 10h + 10min + 36s + 990ms } },
-    calendar::Datetime { util::to_ymd(2012, 10, 15), hms { 20h +  2min + 30s + 980ms } },
-    calendar::Datetime { util::to_ymd(2012, 11, 14), hms {  6h +  8min +  5s + 900ms } },
-    calendar::Datetime { util::to_ymd(2012, 12, 13), hms { 16h + 41min + 37s + 600ms } },
-    calendar::Datetime { util::to_ymd(2013,  1, 12), hms {  3h + 43min + 31s + 340ms } },
-  };
-
-  const auto jdes = datetimes 
-                  | views::transform(astro::julian_day::ut1_to_jde) // Actually the data is in UTC, but ignore that here.
-                  | views::transform([&](const double jde) { return jde - 8.0 / 24.0; }) // Back to UTC+0.
-                  | to<std::vector>();
-
-  RootGenerator gen(jdes[0] - 0.5); // Start from a little before the first root.
-  for (const auto expected_root : jdes) {
-    const auto actual_root = gen.next();
-    ASSERT_NEAR(expected_root, actual_root, 0.00002);
-  }
-}
+// DiffTest1 (nong-wiki conjunctions) retired under #68/#84 — the source states no time scale;
+// superseded by DiffTest2 (HKO) and the boundary tests below.
 
 
 TEST(NewMoon, DiffTest2) {
@@ -143,9 +109,10 @@ TEST(NewMoon, DiffTest2) {
     calendar::Datetime { util::to_ymd(2024, 12, 31), hms {  6h + 27min } },
   };
 
-  const auto jdes = datetimes 
-                  | views::transform(astro::julian_day::ut1_to_jde) // Actually the data is in UTC, but ignore that here.
-                  | views::transform([&](const double jde) { return jde - 8.0 / 24.0; }) // Back to UTC+0.
+  const auto jdes = datetimes
+                  | views::transform([](const calendar::Datetime& utc8) { // UTC+8 civil time → UTC → JDE (#84)
+                      return astro::julian_day::utc_to_jde(calendar::add_seconds(utc8, -8.0 * 3600.0));
+                    })
                   | to<std::vector>();
 
   const auto actual_roots = moments(2024);
@@ -154,6 +121,33 @@ TEST(NewMoon, DiffTest2) {
 
   for (const auto [root, expected_root] : views::zip(actual_roots, jdes)) {
     ASSERT_NEAR(root, expected_root, 0.0005);
+  }
+}
+
+
+TEST(NewMoon, MomentsYearBoundaryIsUtc) {
+  // #84: the year bounds are UTC; under the old UT1 bounds a conjunction between the two
+  // midnights was attributed to the neighbouring year. The gap is ΔT − (ΔAT + 32.184) s:
+  // sub-second today, hours by the fifth millennium.
+  // Provenance: flip cases from a 1972-5000 scan of this library's own (Horizons-validated)
+  // chain, 2026-07-28; the assertion under test is the year attribution, whose boundary
+  // formula is pinned against pyerfa in `LeapSecond.UtcBoundaryFormula`.
+  struct Case { int32_t year; std::size_t n; std::size_t n_prev; double first; };
+  const std::vector<Case> cases {
+    { 3312, 13, 12, 2930742.50177006 }, // conjunction 83.7 s after UTC new-year midnight
+    { 3999, 13, 12, 3181664.62194254 },
+    { 4933, 13, 12, 3522801.58333821 },
+  };
+
+  for (const auto& c : cases) {
+    const auto roots = moments(c.year);
+    ASSERT_EQ(roots.size(), c.n);
+    ASSERT_NEAR(roots.front(), c.first, 1e-5);
+
+    // The boundary-adjacent conjunction must not leak into the previous year.
+    const auto prev_roots = moments(c.year - 1);
+    ASSERT_EQ(prev_roots.size(), c.n_prev);
+    ASSERT_LT(prev_roots.back(), c.first - 25.0); // a synodic month before, not the same root
   }
 }
 

--- a/src/test/datetime_test.cpp
+++ b/src/test/datetime_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <print>
+#include <limits>
 #include <ranges>
 #include "util.hpp"
 #include "datetime.hpp"
@@ -400,6 +401,28 @@ TEST(Datetime, OperatorsSpaceship) {
   ASSERT_TRUE(dt4 >= dt3);
   ASSERT_TRUE(dt3 >= dt1);
   ASSERT_TRUE(dt2 >= dt1);
+}
+
+TEST(Datetime, AddSeconds) {
+  using namespace std::chrono_literals;
+
+  const Datetime noon { util::to_ymd(2024, 6, 15), 0.5 };
+  ASSERT_EQ(add_seconds(noon, 3600.0),   (Datetime { util::to_ymd(2024, 6, 15), std::chrono::hh_mm_ss { 13h } }));
+  ASSERT_EQ(add_seconds(noon, 43200.0),  (Datetime { util::to_ymd(2024, 6, 16), 0.0 }));
+  ASSERT_EQ(add_seconds(noon, -43200.0), (Datetime { util::to_ymd(2024, 6, 15), 0.0 }));
+  ASSERT_EQ(add_seconds(noon, -86400.0 * 2.5), (Datetime { util::to_ymd(2024, 6, 13), 0.0 }));
+
+  // #84 review: a shift landing exactly on midnight can leave the fractional sum a half-ulp
+  // below zero, which floor/carry used to round into fraction == 1.0 — a constructor throw on
+  // a perfectly valid shift. Shift one nanosecond back to midnight, the smallest such case.
+  const Datetime just_past_midnight { util::to_ymd(2024, 6, 15), std::chrono::hh_mm_ss { 1ns } };
+  const auto back = add_seconds(just_past_midnight, -1e-9);
+  ASSERT_EQ(back, (Datetime { util::to_ymd(2024, 6, 15), 0.0 }));
+
+  // Non-finite or day-carry-overflowing offsets must throw, not reach the float→int cast.
+  ASSERT_THROW({ add_seconds(noon, std::numeric_limits<double>::quiet_NaN()); }, std::invalid_argument);
+  ASSERT_THROW({ add_seconds(noon, 4e14); }, std::invalid_argument);
+  ASSERT_THROW({ add_seconds(noon, -4e14); }, std::invalid_argument);
 }
 
 } // namespace calendar::test

--- a/src/test/datetime_test.cpp
+++ b/src/test/datetime_test.cpp
@@ -423,6 +423,11 @@ TEST(Datetime, AddSeconds) {
   ASSERT_THROW({ add_seconds(noon, std::numeric_limits<double>::quiet_NaN()); }, std::invalid_argument);
   ASSERT_THROW({ add_seconds(noon, 4e14); }, std::invalid_argument);
   ASSERT_THROW({ add_seconds(noon, -4e14); }, std::invalid_argument);
+
+  // Offsets under the day-carry bound can still leave `chrono::year`'s ±32767 — beyond it the
+  // stored year is unspecified and `ok()` cannot be trusted, so this must throw, not wrap.
+  ASSERT_THROW({ add_seconds(noon, 86400.0 * 2.0e7); }, std::invalid_argument);
+  ASSERT_THROW({ add_seconds(noon, -86400.0 * 2.0e7); }, std::invalid_argument);
 }
 
 } // namespace calendar::test

--- a/src/test/lunar/algo2_test.cpp
+++ b/src/test/lunar/algo2_test.cpp
@@ -8,7 +8,6 @@ namespace calendar::lunar::algo2::test {
 using namespace calendar::lunar::algo2;
 using namespace calendar::lunar::common;
 using astro::julian_day::ut1_to_jde;
-using astro::julian_day::jde_to_ut1;
 
 TEST(LunarAlgo2, LunarMonthGenerator) {
   const double random_jde = astro::julian_day::J2000 + util::random(-365250.0, 365250.0);
@@ -26,8 +25,8 @@ TEST(LunarAlgo2, LunarMonthGenerator) {
     ASSERT_EQ(a.end_moment_utc8, b.start_moment_utc8);
 
     for (const auto jq_pair : a.contained_jieqis) {
-      // Raw `.jde` is in UT1, add 8 hours to make it in UT1+8.
-      const auto jq_moment_utc8 = jde_to_ut1(jq_pair.jde + 8.0 / 24.0);
+      // Raw `.jde` is in TT; render it in civil UTC+8 the same way the generator does (#84).
+      const auto jq_moment_utc8 = jde_to_utc8(jq_pair.jde);
       const auto jq_date = jq_moment_utc8.ymd;
 
       ASSERT_GE(jq_date, a.start_moment_utc8.ymd);
@@ -292,6 +291,47 @@ TEST(LunarAlgo2, MetadataSharesCache) {
   // a copied `std::function` forks its own cache replica and recomputes from scratch.
   ASSERT_EQ(&AlgoMetadata<Algo::ALGO_2>::get_info_for_year, &algo2::get_info_for_year);
   ASSERT_EQ(&AlgoMetadata<Algo::ALGO_2>::bounds, &algo2::bounds);
+}
+
+
+TEST(LunarAlgo2, MonthBoundaryIsLeapSecondAwareUtc8) {
+  // #84: a month bound is its conjunction rendered in civil UTC+8, i.e. the TT moment shifted
+  // by exactly 8 h − (ΔAT + 32.184) s. Reconstruct that from raw julian-day arithmetic with the
+  // post-2017 constants — independent of `leap_second.hpp`'s lookup — and demand sub-millisecond
+  // agreement. The old UT1 path was off by model ΔT − 69.184 s on every bound.
+  const double start_jde = astro::julian_day::utc_to_jde(
+    calendar::Datetime { util::to_ymd(2025, 1, 1), 0.0 }
+  );
+
+  LunarMonthGenerator month_gen { start_jde };
+  astro::moon_phase::new_moon::RootGenerator root_gen { start_jde };
+
+  for (int i = 0; i < 12; ++i) {
+    const auto month = month_gen.next();
+    const double root = root_gen.next();
+
+    // 69.184 s = ΔAT (37 s since 2017) + (TT − TAI, 32.184 s).
+    const auto expected = astro::julian_day::jde_to_tt(root - (69.184 / 86400.0) + (8.0 / 24.0));
+
+    ASSERT_EQ(month.start_moment_utc8.ymd, expected.ymd);
+    ASSERT_NEAR(month.start_moment_utc8.fraction(), expected.fraction(), 1e-3 / 86400.0);
+  }
+}
+
+
+TEST(LunarAlgo2, Utc8DateFlipNearMidnight) {
+  // #84 directed: an instant 50 ms after UTC+8 midnight, in an era where the old UT1 rendering
+  // sits ~28 s behind UTC (ΔT(2120) ≈ 97 s vs ΔAT + 32.184 = 69.184 s) — through UT1 the same
+  // TT instant rendered on the previous civil day. The JDE is built from raw calendar
+  // arithmetic, independent of the conversion under test.
+  const double jd_civil = astro::julian_day::ut1_to_jd( // pure calendar arithmetic
+    calendar::Datetime { util::to_ymd(2120, 6, 14), 16.0 / 24.0 } // UTC+8 midnight of Jun 15
+  );
+  const double jde = jd_civil + (0.050 / 86400.0) + (69.184 / 86400.0);
+
+  const auto utc8 = jde_to_utc8(jde);
+  ASSERT_EQ(utc8.ymd, util::to_ymd(2120, 6, 15));
+  ASSERT_NEAR(utc8.fraction() * 86400.0, 0.050, 1e-3);
 }
 
 } // namespace calendar::lunar::algo2::test

--- a/statistics/common.py
+++ b/statistics/common.py
@@ -388,6 +388,8 @@ def new_moons_in_year(year: int) -> NewMoons:
 
   # Return the result as an instance of the NewMoons data class.
   jdes = [slots[i] for i in range(num_written)]
+  # Rendered in UT1 while the C++ side now attributes years by UTC (#84) — the scales differ
+  # by model ΔT − (ΔAT + 32.184 s), harmless for these notebooks' years.
   moments = [jde_to_ut1(jde) for jde in jdes]
   return NewMoons(
     year=year,


### PR DESCRIPTION
Closes #84

## 内容

- 新增 `astro/leap_second.hpp`：ΔAT（TAI−UTC）闰秒表（1972 起 28 条，IERS Bulletin C）+ `TT_MINUS_TAI_SEC = 32.184` + `MODERN_UTC_START` + `tt_minus_utc` + `utc_to_tt` / `tt_to_utc`。TT→UTC 方向 ΔAT 依赖尚未算出的 UTC 日期，用「先猜（TT 日期）后精化一轮（UTC 日期）」处理阶跃；插入秒内的 TT 瞬间映射进次日第一秒（不可逆区间，往返 +1s，文档化 + 契约测试）。
- 口径：1972 前现代 UTC 未定义 → 回退 UT1 代理（接缝 = ΔT(1972.0) − 42.184s ≈ +0.068s 前跳、无回跳，实测单调）；表尾后 ΔAT 冻结 37s（2017 后无闰秒公告，CGPM 2022 决议 2035 前废止）。
- `julian_day.hpp` 新增 `utc_to_jde` / `jde_to_utc`（与 ut1 族对称）。
- `datetime.hpp` 新增 `calendar::add_seconds`：含午夜舍入进位（浮点和落 (−2⁻⁵³,0) 时 remainder 舍成 1.0 曾致构造抛出，kimi 实测 8% 时刻可触发）与偏移守卫（非有限/超 int32 日进位范围 throw，#77 同款契约）；`delta_t.hpp` 两个转换收敛到它（表达式同序，位级等价，既有 golden 不动）。
- **#84 修点 1**：`moments(year)` 年界从 UT1 改 UTC，API 契约注明「年界为 UTC，1972 前退化 UT1」。
- **#84 修点 2**：algo2 新增 `jde_to_utc8`（闰秒感知）替换三处 `jde_to_ut1(jde+8/24)`。

## 测试

- 新增 `leap_second_test.cpp` 9 条：表转录 golden + 结构断言；查表边界与 pre-1972 throw；pyerfa 正向 golden（40 行）；**反向 golden**（同批行走 `jde_to_utc`，1972 表首刀口行单列接缝断言）；1000 点定种往返 ≤10ns；闰秒阶跃（跨 2017 元旦墙钟 1s = TT 2s）；插入秒 +1s 契约；pre-1972 回退等价 + 42s 回退带 + 接缝量级；UTC 边界公式（对 pyerfa 锚定，年界测试的承重墙）。
- `moments` 年界定向 golden：扫描 1972–5000 实测 **12 个翻转年**（合朔落在新旧年界之间，全在 3312 年起），取 3312（合朔在 UTC 元旦午夜后 83.7s）/3999/4933——个数 12↔13 翻动 + 首根值。
- algo2 月界结构测试（2025 年 12 个月界 == 原始 TT 算术独立重构，亚毫秒）+ 2120 年翻日期定向测试（旧 UT1 渲染落后 UTC ~28s，同一 TT 瞬间民用日期差一天）。
- `Datetime.AddSeconds`：常规位移 + 午夜进位回归 + 守卫 throw。
- **检出率 3/3**：worktree 注入旧行为（两处消费点回退），三条定向测试全部按预期挂掉；LeapSecond API 套件两边全绿（API 正确性与消费点解耦）。
- 全量 **172/172**。

## 验证

- **闰秒表**：pyerfa `erfa.dat` 逐月扫描 1972–2026 重建阶跃表，与头文件逐条机器 diff 28/28。
- **UTC↔TT**：pyerfa（SOFA）40 行正向 golden 残差**恰好 0**；反向实测 worst 18.2µs（JD 量化级），容差 100µs（5×）。
- **三方独立正确性审阅**（本地先审）：grok（阶跃邻域穷举仿真，P2×4 已修）；kimi k3（收敛性证明 + 28 偏移 ±2µs ns 级扫描 + pyerfa 位级复算，P2×1 已修）；Claude Fable 5（**22,066 点双向 oracle 对拍 worst 1ns**、1ms 步进单调性/接缝扫描、定向测试检出力独立证实，P1/P2 零）。
- **风格/设计双轮**（新流程首跑）：kimi k3 + Claude Opus 5，注释纪律/抽象层级/命名遮蔽批全部落地（`tt_minus_utc`/`MODERN_UTC_START` 抽取、`offset_sec`/`day_carry` 去遮蔽、测量叙事移出代码）。
- 既有 golden 全绿不动：DE441 节气双轴、HKO 168 值、Horizons 日月、algo1/algo3 diff_test——2099 前新旧年界 gap < ~28s、无翻转，烤入数据零变化与实测吻合。

## 范围说明

- **DiffTest1（nong-wiki 2011–2013 合朔）退役**（维护者拍板）：源未声明 ΔT/UTC 约定，其毫秒级值只在「减模型 ΔT」的旧读法下复现（严格 UTC 读法 worst 1.39s→1.84s 超容差 1.728s）；覆盖已被 Horizons 月位置 golden、DiffTest2（HKO 官方源，本 PR 切严格 UTC 读法，worst 31.98s 在分钟舍入内）与边界定向测试接管。#68 归档。
- `jieqi_ut1_moment` 与 shared_lib 的 UT1 系 API **不动**：命名如实，jieqi golden 的 HKO 轴容差覆盖尺度差；`jieqi.hpp` 加了一行 @note 标明缝。`sun::find_roots` / `JieqiGenerator` 的同款 UT1 年界残留（节气距元旦 ≥4 天，无错归属风险）→ 后续 issue。
- `jd_to_ut1` 上界缺失（`jd ≥ 2³²−0.5` UB，#77 只堵了下界）为既有债，新 API 面继承 → 记 #86。
- `moments(year+1)` 在 `INT32_MAX` 的溢出随 #67 B 类入参校验兜底（Phase E）。
- 现代年份行为变化 ≤0.2s、无任何日期翻转；行为变化实际发生在 3312 年起的远未来合朔年归属，UTC 契约下是修正而非回归。
- `LEAP_SECOND_TABLE` 用 `inline constexpr`（AGENTS 原文 + #71 内部链接偿债方向；全仓既有表为裸 `constexpr`，新代码不再新增该债）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
