### PR TITLE
fix(c-abi): C-ABI 安全加固 + EoT/真太阳时导出 (#67, #56 接缝)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -111,6 +111,9 @@ jobs:
           cp "$OUTPUT_DIR/build_info.json" "$DEST_DIR/"
           cp "$OUTPUT_DIR/cpu_info.json" "$DEST_DIR/"
 
+          # Ship the published C-ABI header alongside the library
+          cp "$ROOT_DIR/src/shared_lib/celestial.h" "$DEST_DIR/"
+
           # Set environment variables for GitHub Actions
           {
             echo "artifact_name=${OS}_${ARCH}"
@@ -183,6 +186,9 @@ jobs:
 
         # Find and copy real files (not symlinks)
         find ./build/shared_lib -name "*.dylib" -type f -exec cp {} ./macos_arm64 \;
+
+        # Ship the published C-ABI header alongside the library
+        cp ./src/shared_lib/celestial.h ./macos_arm64/
 
         # Pack the "build_info.json" to the "macos_arm64" folder
         chmod +x ./toolbox/build_info.py
@@ -263,6 +269,9 @@ jobs:
           foreach ($lib in $libFiles) {
             Copy-Item -Path $lib.FullName -Destination $destDir
           }
+
+          # Ship the published C-ABI header alongside the library
+          Copy-Item -Path ./src/shared_lib/celestial.h -Destination $destDir
 
           # Pack the "build_info.json" to the "windows_x86_64" folder
           python3 ./toolbox/build_info.py --save-to $destDir

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,5 +17,7 @@ include_directories(${PROJECT_SOURCE_DIR}/calendar)
 include_directories(${PROJECT_SOURCE_DIR}/util)
 
 # Add subdirectories
-add_subdirectory(test)
+# `shared_lib` first: the C-ABI smoke test links the `celestial_calendar` target (#67),
+# and `target_link_libraries` only binds a real target if it is already defined.
 add_subdirectory(shared_lib)
+add_subdirectory(test)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,8 +16,7 @@ include_directories(${PROJECT_SOURCE_DIR}/astro)
 include_directories(${PROJECT_SOURCE_DIR}/calendar)
 include_directories(${PROJECT_SOURCE_DIR}/util)
 
-# Add subdirectories
-# `shared_lib` first: the C-ABI smoke test links the `celestial_calendar` target (#67),
-# and `target_link_libraries` only binds a real target if it is already defined.
+# Add subdirectories. The order is for readability only — CMake binds targets at generate
+# time, so `test` may reference `celestial_calendar` before its directory is processed (#67).
 add_subdirectory(shared_lib)
 add_subdirectory(test)

--- a/src/astro/julian_day.hpp
+++ b/src/astro/julian_day.hpp
@@ -113,6 +113,8 @@ inline auto ut1_to_jd(const calendar::Datetime& ut1_dt) -> double {
  * @return The datetime in UT1.
  * @throw std::runtime_error if `jd` is not finite, beyond the `year_month_day`-representable
  *        years, or the estimated gregorian year is < 401.
+ * @note `ut1_to_jd(32767-12-31, fraction ≈ 1)` rounds up to exactly the upper bound
+ *       13689325.5, which this function rejects — a 1-ulp round-trip break callers must expect.
  */
 inline auto jd_to_ut1(const double jd) -> calendar::Datetime {
   /*
@@ -157,7 +159,7 @@ inline auto jd_to_ut1(const double jd) -> calendar::Datetime {
   // #67: bound the domain at the last `year_month_day`-representable day — JD 13689325.5 is
   // (conceptually) 32768-01-01 00:00, and `std::chrono::year` stops at 32767. Above it the
   // uint32 arithmetic below wraps into *valid-looking but wrong* dates that `ymd.ok()` cannot
-  // catch (measured: jd 2e7 → year -15490, jd 4e9 → 2403-12-05, both `ok()`).
+  // catch.
   if (jd >= 13689325.5) {
     throw std::runtime_error {
       std::format("The julian day number {} is beyond the representable years.", jd)

--- a/src/astro/julian_day.hpp
+++ b/src/astro/julian_day.hpp
@@ -111,7 +111,8 @@ inline auto ut1_to_jd(const calendar::Datetime& ut1_dt) -> double {
  * @brief Convert julian day number to UT1 datetime.
  * @param jd The julian day number.
  * @return The datetime in UT1.
- * @throw std::runtime_error if `jd` is not finite, or the estimated gregorian year is < 401.
+ * @throw std::runtime_error if `jd` is not finite, beyond the `year_month_day`-representable
+ *        years, or the estimated gregorian year is < 401.
  */
 inline auto jd_to_ut1(const double jd) -> calendar::Datetime {
   /*
@@ -151,6 +152,16 @@ inline auto jd_to_ut1(const double jd) -> calendar::Datetime {
   // the first two days of year 401).
   if (jd < 1867522.5) {
     throw std::runtime_error("The estimated gregorian year is < 401.");
+  }
+
+  // #67: bound the domain at the last `year_month_day`-representable day — JD 13689325.5 is
+  // (conceptually) 32768-01-01 00:00, and `std::chrono::year` stops at 32767. Above it the
+  // uint32 arithmetic below wraps into *valid-looking but wrong* dates that `ymd.ok()` cannot
+  // catch (measured: jd 2e7 → year -15490, jd 4e9 → 2403-12-05, both `ok()`).
+  if (jd >= 13689325.5) {
+    throw std::runtime_error {
+      std::format("The julian day number {} is beyond the representable years.", jd)
+    };
   }
 
   // NOLINTBEGIN

--- a/src/astro/solar_time.hpp
+++ b/src/astro/solar_time.hpp
@@ -77,19 +77,12 @@ constexpr auto sun_mean_longitude(const double jde_tt) -> astro::toolbox::Angle<
  *         |E| stays under 5° (20 min of time).
  * @details The wrap matters near the equinoxes, where the apparent right ascension α and
  *          the mean longitude L0 can sit on opposite sides of the 0°/360° seam.
- * @throw std::invalid_argument if `jde_tt` is not finite.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Formula (28.1).
  */
 inline auto equation_of_time(const double jde_tt) -> astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> {
   using astro::toolbox::Angle;
   using astro::toolbox::AngleUnit::DEG;
   using astro::toolbox::normalize_pm180;
-
-  if (not std::isfinite(jde_tt)) {
-    throw std::invalid_argument {
-      std::format("Argument `jde_tt` is not finite, whose value is {}", jde_tt)
-    };
-  }
 
   const auto L0 = detail::sun_mean_longitude(jde_tt);
   const auto α  = astro::sun::equatorial_coord::apparent(jde_tt).α;

--- a/src/astro/solar_time.hpp
+++ b/src/astro/solar_time.hpp
@@ -77,12 +77,19 @@ constexpr auto sun_mean_longitude(const double jde_tt) -> astro::toolbox::Angle<
  *         |E| stays under 5° (20 min of time).
  * @details The wrap matters near the equinoxes, where the apparent right ascension α and
  *          the mean longitude L0 can sit on opposite sides of the 0°/360° seam.
+ * @throw std::invalid_argument if `jde_tt` is not finite.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Formula (28.1).
  */
 inline auto equation_of_time(const double jde_tt) -> astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> {
   using astro::toolbox::Angle;
   using astro::toolbox::AngleUnit::DEG;
   using astro::toolbox::normalize_pm180;
+
+  if (not std::isfinite(jde_tt)) {
+    throw std::invalid_argument {
+      std::format("Argument `jde_tt` is not finite, whose value is {}", jde_tt)
+    };
+  }
 
   const auto L0 = detail::sun_mean_longitude(jde_tt);
   const auto α  = astro::sun::equatorial_coord::apparent(jde_tt).α;

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -115,10 +115,8 @@ constexpr auto from_fraction(const double fraction) -> hh_mm_ss<nanoseconds> {
  *       `fraction < 0.0 or fraction >= 1.0` test is always false for NaN and lets it through
  *       to the undefined double→int64 cast in `from_fraction`.
  */
-constexpr auto validate_day_fraction(const double fraction) -> double {
-  // DeMorgan-ing this into two `<` comparisons is exactly what lets NaN through (#67);
-  // keep the negated form.
-  if (not (fraction >= 0.0 and fraction < 1.0)) { // NOLINT(readability-simplify-boolean-expr)
+constexpr auto validate_fraction(const double fraction) -> double {
+  if (not (fraction >= 0.0 and fraction < 1.0)) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#67).
     throw std::invalid_argument {
       std::vformat(
         "Argument `fraction` out of range [0.0, 1.0), whose value is {}",
@@ -197,7 +195,7 @@ struct Datetime {
     : ymd         { ymd },
       // #67: validate before the narrowing cast inside `from_fraction` — after the cast,
       // NaN/huge inputs are already UB.
-      time_of_day { from_fraction(validate_day_fraction(fraction)) }
+      time_of_day { from_fraction(validate_fraction(fraction)) }
   {
     if (not ymd.ok()) {
       throw std::invalid_argument { 

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -107,6 +107,30 @@ constexpr auto from_fraction(const double fraction) -> hh_mm_ss<nanoseconds> {
 
 
 /**
+ * @brief Validate the fraction of a day, *before* any narrowing conversion happens.
+ * @param fraction The fraction of a day, expected in [0.0, 1.0).
+ * @return `fraction`, unchanged.
+ * @throw std::invalid_argument if `fraction` is outside [0.0, 1.0).
+ * @note #67: written as `not (x >= lo and x < hi)` so NaN fails the check too — a plain
+ *       `fraction < 0.0 or fraction >= 1.0` test is always false for NaN and lets it through
+ *       to the undefined double→int64 cast in `from_fraction`.
+ */
+constexpr auto validate_day_fraction(const double fraction) -> double {
+  // DeMorgan-ing this into two `<` comparisons is exactly what lets NaN through (#67);
+  // keep the negated form.
+  if (not (fraction >= 0.0 and fraction < 1.0)) { // NOLINT(readability-simplify-boolean-expr)
+    throw std::invalid_argument {
+      std::vformat(
+        "Argument `fraction` out of range [0.0, 1.0), whose value is {}",
+        std::make_format_args(fraction)
+      )
+    };
+  }
+  return fraction;
+}
+
+
+/**
  * @struct Represents a date and a time in the form of `year_month_day` and `hh_mm_ss`.
  * @note The precision of the `time_of_day` field is `std::chrono::nanoseconds`.
  * @note The `time_of_day` field (i.e. `hh_mm_ss`) is positive and less than 24:00:00.0 (i.e. 1 day).
@@ -171,7 +195,9 @@ struct Datetime {
    */
   constexpr explicit Datetime(const year_month_day& ymd, double fraction)
     : ymd         { ymd },
-      time_of_day { from_fraction(fraction) }
+      // #67: validate before the narrowing cast inside `from_fraction` — after the cast,
+      // NaN/huge inputs are already UB.
+      time_of_day { from_fraction(validate_day_fraction(fraction)) }
   {
     if (not ymd.ok()) {
       throw std::invalid_argument { 
@@ -179,15 +205,6 @@ struct Datetime {
           "Argument gregorian date `ymd` is invalid, whose value is `{}`", 
           std::make_format_args(this->ymd)
         ) 
-      };
-    }
-
-    if (fraction < 0.0 or fraction >= 1.0) {
-      throw std::invalid_argument {
-        std::vformat(
-          "Argument `fraction` out of range [0.0, 1.0), whose value is {}",
-          std::make_format_args(fraction)
-        )
       };
     }
 

--- a/src/calendar/lunar/algo1.hpp
+++ b/src/calendar/lunar/algo1.hpp
@@ -98,7 +98,7 @@ template <>
 struct AlgoMetadata<Algo::ALGO_1> {
   // Not memoized: a `LUNAR_DATA[]` lookup is cheaper than the cache wrapper (#75).
   static auto get_info_for_year(const int32_t year) -> LunarYear { return algo1::calc_lunar_year(year); }
-  static const inline auto& bounds = algo1::bounds;
+  static auto bounds() -> const common::AlgoBounds& { return algo1::bounds; }
 };
 
 } // namespace calendar::lunar::common

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -445,8 +445,18 @@ constexpr int32_t START_YEAR = 410; // Algo2 actually has no limit on year. Simp
 /** @brief The last supported lunar year. */
 constexpr int32_t END_YEAR = 5000; // Algo2 actually has no limit on year. Simply use 5000 here.
 
-/** @brief The bounds of the algorithm, i.e. the supported range of lunar and Gregorian dates. */
-const inline auto bounds = calc_bounds(START_YEAR, END_YEAR, get_info_for_year);
+/**
+ * @brief The bounds of the algorithm, i.e. the supported range of lunar and Gregorian dates.
+ * @return The lazily computed bounds.
+ * @note #67: function-local `static`, not a namespace-scope variable — the latter computes at
+ *       static-init time, i.e. runs the whole astro pipeline (VSOP87D + ELP2000 + nutation)
+ *       while the shared library is still being loaded, where an escaping exception would
+ *       terminate the host before `main`. Function-local `static` init is also thread-safe.
+ */
+inline auto bounds() -> const common::AlgoBounds& {
+  static const common::AlgoBounds value = calc_bounds(START_YEAR, END_YEAR, get_info_for_year);
+  return value;
+}
 
 } // namespace calendar::lunar::algo2
 
@@ -459,7 +469,7 @@ struct AlgoMetadata<Algo::ALGO_2> {
   // Bind, don't copy: a copied `std::function` would fork its own cache replica,
   // recomputing every year already cached on the namespace-level path (#78).
   static const inline auto& get_info_for_year = algo2::get_info_for_year;
-  static const inline auto& bounds = algo2::bounds;
+  static const inline auto& bounds = algo2::bounds(); // #67: `bounds` is a function now (lazy init).
 };
 
 } // namespace calendar::lunar::common

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -451,7 +451,7 @@ constexpr int32_t END_YEAR = 5000; // Algo2 actually has no limit on year. Simpl
  * @note #67: function-local `static`, not a namespace-scope variable — the latter computes at
  *       static-init time, i.e. runs the whole astro pipeline (VSOP87D + ELP2000 + nutation)
  *       while the shared library is still being loaded, where an escaping exception would
- *       terminate the host before `main`. Function-local `static` init is also thread-safe.
+ *       terminate the host before `main`.
  */
 inline auto bounds() -> const common::AlgoBounds& {
   static const common::AlgoBounds value = calc_bounds(START_YEAR, END_YEAR, get_info_for_year);
@@ -469,7 +469,9 @@ struct AlgoMetadata<Algo::ALGO_2> {
   // Bind, don't copy: a copied `std::function` would fork its own cache replica,
   // recomputing every year already cached on the namespace-level path (#78).
   static const inline auto& get_info_for_year = algo2::get_info_for_year;
-  static const inline auto& bounds = algo2::bounds(); // #67: `bounds` is a function now (lazy init).
+  // #67: an accessor, not an eager binding — an `inline` static member would initialize at
+  // image load, running the whole astro pipeline before `main` and defeating `algo2::bounds()`.
+  static auto bounds() -> const common::AlgoBounds& { return algo2::bounds(); }
 };
 
 } // namespace calendar::lunar::common

--- a/src/calendar/lunar/algo3.hpp
+++ b/src/calendar/lunar/algo3.hpp
@@ -142,7 +142,7 @@ template <>
 struct AlgoMetadata<Algo::ALGO_3> {
   // Not memoized: a `LUNAR_DATA[]` lookup is cheaper than the cache wrapper (#75).
   static auto get_info_for_year(const int32_t year) -> LunarYear { return algo3::calc_lunar_year(year); }
-  static const inline auto& bounds = algo3::bounds;
+  static auto bounds() -> const common::AlgoBounds& { return algo3::bounds; }
 };
 
 } // namespace calendar::lunar::common

--- a/src/calendar/lunar/common.hpp
+++ b/src/calendar/lunar/common.hpp
@@ -157,6 +157,8 @@ enum class Algo : uint8_t { ALGO_1, ALGO_2, ALGO_3 };
  *                          to the algorithm's cached callable (algo2, #78) — same call syntax.
  * @param bounds The bounds of the algorithm, i.e. the supported range of lunar and Gregorian dates.
  *               算法支持的阴历和公历日期的范围。
+ *               Returned through an accessor function — an eagerly-bound member would
+ *               initialize at image load (defeating algo2's lazy init, #67).
  */
 template <Algo algo>
 struct AlgoMetadata;

--- a/src/calendar/lunar/converter.hpp
+++ b/src/calendar/lunar/converter.hpp
@@ -56,8 +56,8 @@ struct Converter {
     if (not date.ok()) {
       return false;
     }
-    if (date < AlgoMetadata::bounds.first_gregorian_date or 
-        date > AlgoMetadata::bounds.last_gregorian_date) {
+    if (date < AlgoMetadata::bounds().first_gregorian_date or 
+        date > AlgoMetadata::bounds().last_gregorian_date) {
       return false;
     }
     return true;
@@ -70,8 +70,8 @@ struct Converter {
    * @return `true` if valid, otherwise `false`. 如果有效，返回 `true`，否则返回 `false`。
    */
   static auto is_valid_lunar(const year_month_day& lunar_date) -> bool {
-    if (lunar_date < AlgoMetadata::bounds.first_lunar_date or 
-        lunar_date > AlgoMetadata::bounds.last_lunar_date) {
+    if (lunar_date < AlgoMetadata::bounds().first_lunar_date or 
+        lunar_date > AlgoMetadata::bounds().last_lunar_date) {
       return false;
     }
 
@@ -132,7 +132,7 @@ struct Converter {
 
     // First, check if lunar date and gregorian_date date are in the same year.
     const auto& [g_year, _, __] = util::from_ymd(gregorian_date);
-    if (g_year <= AlgoMetadata::bounds.end_lunar_year) {
+    if (g_year <= AlgoMetadata::bounds().end_lunar_year) {
       using namespace util::ymd_operator;
       const auto& info = AlgoMetadata::get_info_for_year(g_year);
       const auto& ml = info.month_lengths;

--- a/src/shared_lib/CMakeLists.txt
+++ b/src/shared_lib/CMakeLists.txt
@@ -17,3 +17,8 @@ add_library(celestial_calendar SHARED ${SOURCES})
 set_target_properties(celestial_calendar PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 set_target_properties(celestial_calendar PROPERTIES VERSION ${VERSION_NUMBER})
+
+# #67: compile-check the published C header as pure C (layouts pinned by `_Static_assert`
+# inside). Built as part of the default target, so CI exercises it on every platform.
+add_library(c_header_check OBJECT c_header_check.c)
+set_target_properties(c_header_check PROPERTIES C_STANDARD 11 C_STANDARD_REQUIRED ON)

--- a/src/shared_lib/CMakeLists.txt
+++ b/src/shared_lib/CMakeLists.txt
@@ -21,4 +21,4 @@ set_target_properties(celestial_calendar PROPERTIES VERSION ${VERSION_NUMBER})
 # #67: compile-check the published C header as pure C (layouts pinned by `_Static_assert`
 # inside). Built as part of the default target, so CI exercises it on every platform.
 add_library(c_header_check OBJECT c_header_check.c)
-set_target_properties(c_header_check PROPERTIES C_STANDARD 11 C_STANDARD_REQUIRED ON)
+set_target_properties(c_header_check PROPERTIES C_STANDARD 11 C_STANDARD_REQUIRED ON C_EXTENSIONS OFF)

--- a/src/shared_lib/c_header_check.c
+++ b/src/shared_lib/c_header_check.c
@@ -24,6 +24,7 @@
 /*
  * #67: compile `celestial.h` as pure C and pin the ABI — field offsets and struct sizes
  * are part of the published contract, so any layout drift fails the build here.
+ * The absolute offsets below assume 64-bit natural alignment (the CI matrix is all 64-bit).
  */
 
 #include "celestial.h"
@@ -64,35 +65,7 @@ _Static_assert(offsetof(DeltaT, value) == 8 && sizeof(DeltaT) == 16, "DeltaT lay
 _Static_assert(offsetof(EquationOfTime, value) == 8 && sizeof(EquationOfTime) == 16,
                "EquationOfTime layout drifted");
 
-_Static_assert(offsetof(SolarTime, year) == 4 && offsetof(SolarTime, month) == 8 &&
-               offsetof(SolarTime, day) == 12 && offsetof(SolarTime, fraction) == 16 &&
-               sizeof(SolarTime) == 24, "SolarTime layout drifted");
+_Static_assert(offsetof(ApparentSolarTime, year) == 4 && offsetof(ApparentSolarTime, month) == 8 &&
+               offsetof(ApparentSolarTime, day) == 12 && offsetof(ApparentSolarTime, fraction) == 16 &&
+               sizeof(ApparentSolarTime) == 24, "ApparentSolarTime layout drifted");
 
-
-/* Reference every exported symbol, so a declaration/definition name drift fails here too.
- * External linkage, or `-Werror -Wunused-variable` would fire on an unreferenced static. */
-void *const celestial_exported_symbols[] = {
-  (void *)&set_log_verbosity,
-  (void *)&last_error,
-  (void *)&ut1_to_jd,
-  (void *)&ut1_to_jde,
-  (void *)&jde_to_ut1,
-  (void *)&sun_apparent_geocentric_coord,
-  (void *)&moon_apparent_geocentric_coord,
-  (void *)&solar_lon_root_discriminant,
-  (void *)&solar_lon_roots,
-  (void *)&new_moons_after_jde,
-  (void *)&new_moons_in_year,
-  (void *)&equation_of_time,
-  (void *)&apparent_solar_time,
-  (void *)&query_jieqi_moment,
-  (void *)&get_jieqi_name,
-  (void *)&get_supported_lunar_year_range,
-  (void *)&get_lunar_year_info,
-  (void *)&delta_t_algo1,
-  (void *)&delta_t_algo2,
-  (void *)&delta_t_algo3,
-  (void *)&delta_t_algo4,
-  (void *)&delta_t_algo5,
-  (void *)&delta_t,
-};

--- a/src/shared_lib/c_header_check.c
+++ b/src/shared_lib/c_header_check.c
@@ -61,6 +61,13 @@ _Static_assert(offsetof(LunarYearInfo, year) == 4 && offsetof(LunarYearInfo, mon
 
 _Static_assert(offsetof(DeltaT, value) == 8 && sizeof(DeltaT) == 16, "DeltaT layout drifted");
 
+_Static_assert(offsetof(EquationOfTime, value) == 8 && sizeof(EquationOfTime) == 16,
+               "EquationOfTime layout drifted");
+
+_Static_assert(offsetof(SolarTime, year) == 4 && offsetof(SolarTime, month) == 8 &&
+               offsetof(SolarTime, day) == 12 && offsetof(SolarTime, fraction) == 16 &&
+               sizeof(SolarTime) == 24, "SolarTime layout drifted");
+
 
 /* Reference every exported symbol, so a declaration/definition name drift fails here too.
  * External linkage, or `-Werror -Wunused-variable` would fire on an unreferenced static. */
@@ -76,6 +83,8 @@ void *const celestial_exported_symbols[] = {
   (void *)&solar_lon_roots,
   (void *)&new_moons_after_jde,
   (void *)&new_moons_in_year,
+  (void *)&equation_of_time,
+  (void *)&apparent_solar_time,
   (void *)&query_jieqi_moment,
   (void *)&get_jieqi_name,
   (void *)&get_supported_lunar_year_range,

--- a/src/shared_lib/c_header_check.c
+++ b/src/shared_lib/c_header_check.c
@@ -1,0 +1,89 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2026 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * #67: compile `celestial.h` as pure C and pin the ABI — field offsets and struct sizes
+ * are part of the published contract, so any layout drift fails the build here.
+ */
+
+#include "celestial.h"
+
+#include <stddef.h>
+
+_Static_assert(offsetof(JulianDay, value) == 8 && sizeof(JulianDay) == 16, "JulianDay layout drifted");
+
+_Static_assert(offsetof(UT1Time, year) == 4 && offsetof(UT1Time, month) == 8 &&
+               offsetof(UT1Time, day) == 12 && offsetof(UT1Time, fraction) == 16 &&
+               sizeof(UT1Time) == 24, "UT1Time layout drifted");
+
+_Static_assert(offsetof(SunCoordinate, lon) == 8 && offsetof(SunCoordinate, lat) == 16 &&
+               offsetof(SunCoordinate, r) == 24 && sizeof(SunCoordinate) == 32,
+               "SunCoordinate layout drifted");
+
+_Static_assert(offsetof(MoonCoordinate, lon) == 8 && offsetof(MoonCoordinate, lat) == 16 &&
+               offsetof(MoonCoordinate, r) == 24 && sizeof(MoonCoordinate) == 32,
+               "MoonCoordinate layout drifted");
+
+_Static_assert(offsetof(Discriminant, count) == 4 && sizeof(Discriminant) == 8, "Discriminant layout drifted");
+
+_Static_assert(offsetof(JieqiMomentQuery, jq_idx) == 1 && offsetof(JieqiMomentQuery, y) == 4 &&
+               offsetof(JieqiMomentQuery, m) == 8 && offsetof(JieqiMomentQuery, d) == 12 &&
+               offsetof(JieqiMomentQuery, frac) == 16 && sizeof(JieqiMomentQuery) == 24,
+               "JieqiMomentQuery layout drifted");
+
+_Static_assert(offsetof(SupportedLunarYearRange, start) == 4 && offsetof(SupportedLunarYearRange, end) == 8 &&
+               sizeof(SupportedLunarYearRange) == 12, "SupportedLunarYearRange layout drifted");
+
+_Static_assert(offsetof(LunarYearInfo, year) == 4 && offsetof(LunarYearInfo, month) == 8 &&
+               offsetof(LunarYearInfo, day) == 9 && offsetof(LunarYearInfo, leap_month) == 10 &&
+               offsetof(LunarYearInfo, month_len) == 12 && sizeof(LunarYearInfo) == 16,
+               "LunarYearInfo layout drifted");
+
+_Static_assert(offsetof(DeltaT, value) == 8 && sizeof(DeltaT) == 16, "DeltaT layout drifted");
+
+
+/* Reference every exported symbol, so a declaration/definition name drift fails here too.
+ * External linkage, or `-Werror -Wunused-variable` would fire on an unreferenced static. */
+void *const celestial_exported_symbols[] = {
+  (void *)&set_log_verbosity,
+  (void *)&last_error,
+  (void *)&ut1_to_jd,
+  (void *)&ut1_to_jde,
+  (void *)&jde_to_ut1,
+  (void *)&sun_apparent_geocentric_coord,
+  (void *)&moon_apparent_geocentric_coord,
+  (void *)&solar_lon_root_discriminant,
+  (void *)&solar_lon_roots,
+  (void *)&new_moons_after_jde,
+  (void *)&new_moons_in_year,
+  (void *)&query_jieqi_moment,
+  (void *)&get_jieqi_name,
+  (void *)&get_supported_lunar_year_range,
+  (void *)&get_lunar_year_info,
+  (void *)&delta_t_algo1,
+  (void *)&delta_t_algo2,
+  (void *)&delta_t_algo3,
+  (void *)&delta_t_algo4,
+  (void *)&delta_t_algo5,
+  (void *)&delta_t,
+};

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -185,6 +185,31 @@ typedef struct LunarYearInfo {
 LunarYearInfo get_lunar_year_info(uint8_t algo, int32_t year);
 
 
+/* ---------- Solar Time ---------- */
+
+typedef struct EquationOfTime {
+  bool   valid; /* Indicates if the result is valid. */
+  double value; /* E in degrees of hour angle; x240 for seconds of time. */
+} EquationOfTime;
+
+/** @brief Compute the equation of time E = apparent solar time - mean solar time (Meeus ch. 28). */
+EquationOfTime equation_of_time(double jde);
+
+typedef struct SolarTime {
+  bool     valid;    /* Indicates if the result is valid. */
+  int32_t  year;     /* The year. */
+  uint32_t month;    /* The month. */
+  uint32_t day;      /* The day. */
+  double   fraction; /* The fraction of the day, in the range [0.0, 1.0). */
+} SolarTime;
+
+/**
+ * @brief Convert a civil UTC moment to local apparent (true) solar time.
+ *        `longitude` is positive east, in [-180, 180].
+ */
+SolarTime apparent_solar_time(int32_t y, uint32_t m, uint32_t d, double fraction, double longitude);
+
+
 /* ---------- Delta T ---------- */
 
 typedef struct DeltaT {

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -1,0 +1,215 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2026 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef CELESTIAL_CALENDAR_H
+#define CELESTIAL_CALENDAR_H
+
+/*
+ * The published C-ABI of `libcelestial_calendar` (#67). Pure C — consumable from C,
+ * ctypes, and any FFI. The `lib*.cpp` implementations include this header, so the
+ * struct layouts below are the single source of truth; `c_header_check.c` pins the
+ * offsets at compile time.
+ *
+ * Error contract: every function is `noexcept` at the boundary. Struct-returning
+ * functions signal failure with `valid = false`; the rest return `0` / `false`.
+ * On failure the Julian Day functions also record a thread-local message readable
+ * through `last_error` (#97 pilot).
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* NOLINTBEGIN(modernize-use-trailing-return-type, modernize-use-using):
+ * this header must stay valid C — C has neither trailing return types nor `using`. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* ---------- Global configuration ---------- */
+
+/** @brief Set the verbosity level of log printing. `false` if `new_value` is out of range. */
+bool set_log_verbosity(uint8_t new_value);
+
+/**
+ * @brief Get the last-error message of the calling thread.
+ * @returns A pointer to a thread-local C string, empty if there is no recorded error.
+ *          The pointer stays valid until the next C-ABI call on the same thread.
+ * @note #97 pilot: only the Julian Day functions record messages for now.
+ */
+const char *last_error(void);
+
+
+/* ---------- Julian Days ---------- */
+
+typedef struct JulianDay {
+  bool   valid; /* Indicates if the result is valid. */
+  double value; /* The value. Either JD or JDE. */
+} JulianDay;
+
+/** @brief Convert UT1 datetime to Julian Day Number (JD). `fraction` must be in [0.0, 1.0). */
+JulianDay ut1_to_jd(int32_t y, uint32_t m, uint32_t d, double fraction);
+
+/** @brief Convert UT1 datetime to Julian Ephemeris Day Number (JDE, TT-based). */
+JulianDay ut1_to_jde(int32_t y, uint32_t m, uint32_t d, double fraction);
+
+typedef struct UT1Time {
+  bool     valid;    /* Indicates if the result is valid. */
+  int32_t  year;     /* The year. */
+  uint32_t month;    /* The month. */
+  uint32_t day;      /* The day. */
+  double   fraction; /* The fraction of the day, in the range [0.0, 1.0). */
+} UT1Time;
+
+/** @brief Convert Julian Ephemeris Day Number (JDE, TT-based) to UT1 datetime. */
+UT1Time jde_to_ut1(double jde);
+
+
+/* ---------- Sun and Moon Apparent Geocentric Position ---------- */
+
+typedef struct SunCoordinate {
+  bool valid; /* Indicates if the result is valid. */
+  double lon; /* The longitude. In degrees. */
+  double lat; /* The latitude. In degrees. */
+  double   r; /* The radius. In AU. */
+} SunCoordinate;
+
+/** @brief Calculate the apparent geocentric position of the Sun. */
+SunCoordinate sun_apparent_geocentric_coord(double jde);
+
+typedef struct MoonCoordinate {
+  bool valid; /* Indicates if the result is valid. */
+  double lon; /* The longitude. In degrees. */
+  double lat; /* The latitude. In degrees. */
+  double   r; /* The radius. In KM. */
+} MoonCoordinate;
+
+/** @brief Calculate the apparent geocentric position of the Moon. */
+MoonCoordinate moon_apparent_geocentric_coord(double jde);
+
+
+/* ---------- Sun Position ---------- */
+
+typedef struct Discriminant {
+  bool     valid; /* Indicates if the result is valid. */
+  uint32_t count; /* The count of the roots, which is 0, 1, or 2. */
+} Discriminant;
+
+/** @brief Count how many times the Sun reaches `longitude` in `year` (0, 1, or 2). */
+Discriminant solar_lon_root_discriminant(int32_t year, double longitude);
+
+/**
+ * @brief Find the JDE(s) at which the Sun reaches `longitude` in `year`, written to `slots`.
+ * @returns How many slots are written. `slots` may be null only when `slot_count` is 0.
+ */
+uint32_t solar_lon_roots(int32_t year, double longitude, double *slots, uint32_t slot_count);
+
+
+/* ---------- Sun Moon Conjunction ---------- */
+
+/**
+ * @brief Find the next `slot_count` new-moon JDE(s) after `jde`, written to `slots`.
+ * @returns How many slots are written. `slots` may be null only when `slot_count` is 0.
+ */
+uint32_t new_moons_after_jde(double jde, double *slots, uint32_t slot_count);
+
+/**
+ * @brief Find the new-moon JDE(s) in `year`; the total count goes to `root_count`,
+ *        up to `slot_count` of them are written to `slots`.
+ * @returns How many slots are written. Neither `root_count` nor `slots` may be null
+ *          (`slots` may be null only when `slot_count` is 0).
+ */
+uint32_t new_moons_in_year(int32_t year, uint32_t *root_count, double *slots, uint32_t slot_count);
+
+
+/* ---------- Jieqi ---------- */
+
+typedef struct JieqiMomentQuery {
+  bool     valid;  /* Indicates if the result is valid. */
+  uint8_t  jq_idx; /* The index of the Jieqi, in the range [0, 24). */
+  int32_t  y;      /* The year. */
+  uint32_t m;      /* The month. */
+  uint32_t d;      /* The day. */
+  double   frac;   /* The fraction of the day, in the range [0.0, 1.0). */
+} JieqiMomentQuery;
+
+/** @brief Query the accurate UT1 moment of Jieqi `jq_idx` in `year`. */
+JieqiMomentQuery query_jieqi_moment(int32_t year, uint8_t jq_idx);
+
+/** @brief Write the Chinese name of Jieqi `jq_idx` to `buf`. `false` on any failure. */
+bool get_jieqi_name(uint8_t jq_idx, char *buf, uint32_t buf_size);
+
+
+/* ---------- Lunar Calendar ---------- */
+
+typedef struct SupportedLunarYearRange {
+  bool    valid; /* Indicates if the result is valid. */
+  int32_t start; /* The first supported lunar year. */
+  int32_t end;   /* The last supported lunar year. */
+} SupportedLunarYearRange;
+
+/** @brief Get the supported lunar year range of algorithm `algo` (1 or 2). */
+SupportedLunarYearRange get_supported_lunar_year_range(uint8_t algo);
+
+typedef struct LunarYearInfo {
+  bool     valid;      /* Indicates if the result is valid. */
+  int32_t  year;       /* Gregorian year of the first day of the lunar year. */
+  uint8_t  month;      /* Gregorian month of the first day of the lunar year. */
+  uint8_t  day;        /* Gregorian day of the first day of the lunar year. */
+  uint8_t  leap_month; /* The leap month (1-12), or 0 if there is none. */
+  uint16_t month_len;  /* Least 12/13 bits: 1 = 30-day month, 0 = 29-day month. */
+} LunarYearInfo;
+
+/** @brief Get the lunar year information for `year`, using algorithm `algo` (1 or 2). */
+LunarYearInfo get_lunar_year_info(uint8_t algo, int32_t year);
+
+
+/* ---------- Delta T ---------- */
+
+typedef struct DeltaT {
+  bool   valid; /* Indicates if the result is valid. */
+  double value; /* The value of delta T. */
+} DeltaT;
+
+/** @brief Compute delta T of a given moment using algorithm 1. */
+DeltaT delta_t_algo1(double year);
+/** @brief Compute delta T of a given moment using algorithm 2. */
+DeltaT delta_t_algo2(double year);
+/** @brief Compute delta T of a given moment using algorithm 3. */
+DeltaT delta_t_algo3(double year);
+/** @brief Compute delta T of a given moment using algorithm 4. */
+DeltaT delta_t_algo4(double year);
+/** @brief Compute delta T of a given moment using algorithm 5. */
+DeltaT delta_t_algo5(double year);
+/** @brief Compute delta T of a given moment, using the best algorithm. */
+DeltaT delta_t(double year);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/* NOLINTEND(modernize-use-trailing-return-type, modernize-use-using) */
+
+#endif /* CELESTIAL_CALENDAR_H */

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -39,6 +39,12 @@
  * functions signal failure with `valid = false`; the rest return `0` / `false`.
  * On failure the Julian Day functions also record a thread-local message readable
  * through `last_error` (#97 pilot).
+ *
+ * Platform note: the library logs to stdout and swallows any logging failure. On
+ * Windows (UCRT), however, writing to a closed stdout fail-fasts the process
+ * (0xc0000409) through the invalid-parameter handler — not an exception path, so
+ * the library cannot catch it. Hosts must not close the logging stream out from
+ * under the library; an opt-out log sink is tracked on the backlog.
  */
 
 #include <stdbool.h>

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -30,6 +30,11 @@
  * struct layouts below are the single source of truth; `c_header_check.c` pins the
  * offsets at compile time.
  *
+ * Two deliberate decisions: the exported symbols carry no prefix, matching the exports
+ * shipped since 0.3.0 — the collision risk is accepted and revisited at the next major
+ * version. And no dllexport/dllimport macros: `WINDOWS_EXPORT_ALL_SYMBOLS` exports
+ * everything, and imports resolve implicitly against the import library.
+ *
  * Error contract: every function is `noexcept` at the boundary. Struct-returning
  * functions signal failure with `valid = false`; the rest return `0` / `false`.
  * On failure the Julian Day functions also record a thread-local message readable
@@ -49,13 +54,21 @@ extern "C" {
 
 /* ---------- Global configuration ---------- */
 
-/** @brief Set the verbosity level of log printing. `false` if `new_value` is out of range. */
+/**
+ * @brief Set the verbosity level of log printing.
+ * @param new_value The new verbosity level (in `uint8_t`): 0 = none, 1 = info, 2 = debug.
+ *                  The initial level is 2 (debug).
+ * @returns `true` if the level was stored, `false` if `new_value` is out of range.
+ */
 bool set_log_verbosity(uint8_t new_value);
 
 /**
  * @brief Get the last-error message of the calling thread.
  * @returns A pointer to a thread-local C string, empty if there is no recorded error.
- *          The pointer stays valid until the next C-ABI call on the same thread.
+ *          Only the Julian Day functions (`ut1_to_jd`, `ut1_to_jde`, `jde_to_ut1`) write
+ *          and clear the message; other functions neither set nor clear it, so the pointer
+ *          always refers to the most recent Julian Day call on this thread. It stays valid
+ *          until the next Julian Day call on the same thread.
  * @note #97 pilot: only the Julian Day functions record messages for now.
  */
 const char *last_error(void);
@@ -68,10 +81,24 @@ typedef struct JulianDay {
   double value; /* The value. Either JD or JDE. */
 } JulianDay;
 
-/** @brief Convert UT1 datetime to Julian Day Number (JD). `fraction` must be in [0.0, 1.0). */
+/**
+ * @brief Convert UT1 datetime to Julian Day Number (JD).
+ * @param y The year.
+ * @param m The month.
+ * @param d The day.
+ * @param fraction The fraction of the day. Must be in the range [0.0, 1.0).
+ * @returns A `JulianDay` struct. JD is based on UT1.
+ */
 JulianDay ut1_to_jd(int32_t y, uint32_t m, uint32_t d, double fraction);
 
-/** @brief Convert UT1 datetime to Julian Ephemeris Day Number (JDE, TT-based). */
+/**
+ * @brief Convert UT1 datetime to Julian Ephemeris Day Number (JDE).
+ * @param y The year.
+ * @param m The month.
+ * @param d The day.
+ * @param fraction The fraction of the day. Must be in the range [0.0, 1.0).
+ * @returns A `JulianDay` struct. JDE is based on TT.
+ */
 JulianDay ut1_to_jde(int32_t y, uint32_t m, uint32_t d, double fraction);
 
 typedef struct UT1Time {
@@ -82,46 +109,70 @@ typedef struct UT1Time {
   double   fraction; /* The fraction of the day, in the range [0.0, 1.0). */
 } UT1Time;
 
-/** @brief Convert Julian Ephemeris Day Number (JDE, TT-based) to UT1 datetime. */
+/**
+ * @brief Convert Julian Ephemeris Day Number (JDE) to UT1 datetime.
+ * @param jde The julian ephemeris day number, which is based on TT.
+ * @returns A `UT1Time` struct.
+ */
 UT1Time jde_to_ut1(double jde);
 
 
 /* ---------- Sun and Moon Apparent Geocentric Position ---------- */
 
 typedef struct SunCoordinate {
-  bool valid; /* Indicates if the result is valid. */
-  double lon; /* The longitude. In degrees. */
-  double lat; /* The latitude. In degrees. */
-  double   r; /* The radius. In AU. */
+  bool   valid; /* Indicates if the result is valid. */
+  double lon;   /* The longitude. In degrees. */
+  double lat;   /* The latitude. In degrees. */
+  double r;     /* The radius. In AU. */
 } SunCoordinate;
 
-/** @brief Calculate the apparent geocentric position of the Sun. */
+/**
+ * @brief Calculate the apparent geocentric position of the Sun.
+ * @param jde The julian ephemeris day number, which is based on TT.
+ * @returns A `SunCoordinate` struct.
+ */
 SunCoordinate sun_apparent_geocentric_coord(double jde);
 
 typedef struct MoonCoordinate {
-  bool valid; /* Indicates if the result is valid. */
-  double lon; /* The longitude. In degrees. */
-  double lat; /* The latitude. In degrees. */
-  double   r; /* The radius. In KM. */
+  bool   valid; /* Indicates if the result is valid. */
+  double lon;   /* The longitude. In degrees. */
+  double lat;   /* The latitude. In degrees. */
+  double r;     /* The radius. In KM. */
 } MoonCoordinate;
 
-/** @brief Calculate the apparent geocentric position of the Moon. */
+/**
+ * @brief Calculate the apparent geocentric position of the Moon.
+ * @param jde The julian ephemeris day number, which is based on TT.
+ * @returns A `MoonCoordinate` struct.
+ */
 MoonCoordinate moon_apparent_geocentric_coord(double jde);
 
 
-/* ---------- Sun Position ---------- */
+/* ---------- Solar Longitude Roots ---------- */
 
 typedef struct Discriminant {
   bool     valid; /* Indicates if the result is valid. */
   uint32_t count; /* The count of the roots, which is 0, 1, or 2. */
 } Discriminant;
 
-/** @brief Count how many times the Sun reaches `longitude` in `year` (0, 1, or 2). */
+/**
+ * @brief Calculate the JDE discriminant — count how many times the Sun reaches the given
+ *        geocentric `longitude` in the given `year`.
+ * @param year The year.
+ * @param longitude The geocentric longitude.
+ * @returns A `Discriminant` struct; `count` is 0, 1, or 2: the Sun won't reach the longitude
+ *          in the year, reaches it once, or reaches it twice.
+ */
 Discriminant solar_lon_root_discriminant(int32_t year, double longitude);
 
 /**
  * @brief Find the JDE(s) at which the Sun reaches `longitude` in `year`, written to `slots`.
- * @returns How many slots are written. `slots` may be null only when `slot_count` is 0.
+ * @param year The year.
+ * @param longitude The geocentric longitude.
+ * @param slots The output slots, allocated and freed by the caller; may be null only when
+ *              `slot_count` is 0.
+ * @param slot_count The count of slots.
+ * @returns How many slots are written.
  */
 uint32_t solar_lon_roots(int32_t year, double longitude, double *slots, uint32_t slot_count);
 
@@ -130,17 +181,62 @@ uint32_t solar_lon_roots(int32_t year, double longitude, double *slots, uint32_t
 
 /**
  * @brief Find the next `slot_count` new-moon JDE(s) after `jde`, written to `slots`.
- * @returns How many slots are written. `slots` may be null only when `slot_count` is 0.
+ * @param jde The julian ephemeris day number, which is based on TT.
+ * @param slots The output slots, allocated and freed by the caller; may be null only when
+ *              `slot_count` is 0.
+ * @param slot_count The count of slots.
+ * @returns How many slots are written.
  */
 uint32_t new_moons_after_jde(double jde, double *slots, uint32_t slot_count);
 
 /**
  * @brief Find the new-moon JDE(s) in `year`; the total count goes to `root_count`,
  *        up to `slot_count` of them are written to `slots`.
- * @returns How many slots are written. Neither `root_count` nor `slots` may be null
- *          (`slots` may be null only when `slot_count` is 0).
+ * @param year The Gregorian year.
+ * @param root_count Where the total count of the roots is written. Must not be null.
+ * @param slots The output slots, allocated and freed by the caller; may be null only when
+ *              `slot_count` is 0.
+ * @param slot_count The count of slots.
+ * @returns How many slots are written.
  */
 uint32_t new_moons_in_year(int32_t year, uint32_t *root_count, double *slots, uint32_t slot_count);
+
+
+/* ---------- Solar Time ---------- */
+
+typedef struct EquationOfTime {
+  bool   valid; /* Indicates if the result is valid. */
+  double value; /* E in degrees of hour angle; x240 for seconds of time. */
+} EquationOfTime;
+
+/**
+ * @brief Compute the equation of time E = apparent solar time - mean solar time
+ *        (Meeus ch. 28).
+ * @param jde The julian ephemeris day number, which is based on TT.
+ * @returns An `EquationOfTime` struct; `value` is E in degrees of hour angle
+ *          (x240 = seconds of time).
+ */
+EquationOfTime equation_of_time(double jde);
+
+typedef struct ApparentSolarTime {
+  bool     valid;    /* Indicates if the result is valid. */
+  int32_t  year;     /* The year of the local apparent solar date. */
+  uint32_t month;    /* The month of the local apparent solar date. */
+  uint32_t day;      /* The day of the local apparent solar date. */
+  double   fraction; /* The fraction of the local apparent solar day, in the range [0.0, 1.0). */
+} ApparentSolarTime;
+
+/**
+ * @brief Convert a civil UTC moment to local apparent (true) solar time.
+ * @param y The year (UTC).
+ * @param m The month (UTC).
+ * @param d The day (UTC).
+ * @param fraction The fraction of the day (UTC). Must be in the range [0.0, 1.0).
+ * @param longitude The observer's geographic longitude in degrees, positive east, in [-180, 180].
+ * @returns An `ApparentSolarTime` struct; the local apparent solar date may differ from the
+ *          input UTC date — a large enough longitude shifts the moment across midnight.
+ */
+ApparentSolarTime apparent_solar_time(int32_t y, uint32_t m, uint32_t d, double fraction, double longitude);
 
 
 /* ---------- Jieqi ---------- */
@@ -154,10 +250,21 @@ typedef struct JieqiMomentQuery {
   double   frac;   /* The fraction of the day, in the range [0.0, 1.0). */
 } JieqiMomentQuery;
 
-/** @brief Query the accurate UT1 moment of Jieqi `jq_idx` in `year`. */
+/**
+ * @brief Query the accurate UT1 moment of the Jieqi in the given `year`.
+ * @param year The year, in gregorian calendar.
+ * @param jq_idx The index of the Jieqi. Expected to be in the range [0, 24).
+ * @returns A `JieqiMomentQuery` struct.
+ */
 JieqiMomentQuery query_jieqi_moment(int32_t year, uint8_t jq_idx);
 
-/** @brief Write the Chinese name of Jieqi `jq_idx` to `buf`. `false` on any failure. */
+/**
+ * @brief Write the Chinese name of the Jieqi to `buf`.
+ * @param jq_idx The index of the Jieqi. Expected to be in the range [0, 24).
+ * @param buf The name memory, allocated and freed by the caller.
+ * @param buf_size Maximum bytes that can be written to `buf`.
+ * @returns `true` if the name is successfully written to `buf`.
+ */
 bool get_jieqi_name(uint8_t jq_idx, char *buf, uint32_t buf_size);
 
 
@@ -169,7 +276,11 @@ typedef struct SupportedLunarYearRange {
   int32_t end;   /* The last supported lunar year. */
 } SupportedLunarYearRange;
 
-/** @brief Get the supported lunar year range of algorithm `algo` (1 or 2). */
+/**
+ * @brief Get the supported lunar year range of the algorithm.
+ * @param algo The algorithm. Expected to be 1 or 2.
+ * @returns A `SupportedLunarYearRange` struct.
+ */
 SupportedLunarYearRange get_supported_lunar_year_range(uint8_t algo);
 
 typedef struct LunarYearInfo {
@@ -181,33 +292,13 @@ typedef struct LunarYearInfo {
   uint16_t month_len;  /* Least 12/13 bits: 1 = 30-day month, 0 = 29-day month. */
 } LunarYearInfo;
 
-/** @brief Get the lunar year information for `year`, using algorithm `algo` (1 or 2). */
-LunarYearInfo get_lunar_year_info(uint8_t algo, int32_t year);
-
-
-/* ---------- Solar Time ---------- */
-
-typedef struct EquationOfTime {
-  bool   valid; /* Indicates if the result is valid. */
-  double value; /* E in degrees of hour angle; x240 for seconds of time. */
-} EquationOfTime;
-
-/** @brief Compute the equation of time E = apparent solar time - mean solar time (Meeus ch. 28). */
-EquationOfTime equation_of_time(double jde);
-
-typedef struct SolarTime {
-  bool     valid;    /* Indicates if the result is valid. */
-  int32_t  year;     /* The year. */
-  uint32_t month;    /* The month. */
-  uint32_t day;      /* The day. */
-  double   fraction; /* The fraction of the day, in the range [0.0, 1.0). */
-} SolarTime;
-
 /**
- * @brief Convert a civil UTC moment to local apparent (true) solar time.
- *        `longitude` is positive east, in [-180, 180].
+ * @brief Get the lunar year information for the given year.
+ * @param algo The algorithm. Expected to be 1 or 2.
+ * @param year The lunar year.
+ * @returns A `LunarYearInfo` struct.
  */
-SolarTime apparent_solar_time(int32_t y, uint32_t m, uint32_t d, double fraction, double longitude);
+LunarYearInfo get_lunar_year_info(uint8_t algo, int32_t year);
 
 
 /* ---------- Delta T ---------- */
@@ -217,17 +308,41 @@ typedef struct DeltaT {
   double value; /* The value of delta T. */
 } DeltaT;
 
-/** @brief Compute delta T of a given moment using algorithm 1. */
+/**
+ * @brief Compute delta T of a given moment using algorithm 1.
+ * @param year The year.
+ * @returns A `DeltaT` struct.
+ */
 DeltaT delta_t_algo1(double year);
-/** @brief Compute delta T of a given moment using algorithm 2. */
+/**
+ * @brief Compute delta T of a given moment using algorithm 2.
+ * @param year The year.
+ * @returns A `DeltaT` struct.
+ */
 DeltaT delta_t_algo2(double year);
-/** @brief Compute delta T of a given moment using algorithm 3. */
+/**
+ * @brief Compute delta T of a given moment using algorithm 3.
+ * @param year The year.
+ * @returns A `DeltaT` struct.
+ */
 DeltaT delta_t_algo3(double year);
-/** @brief Compute delta T of a given moment using algorithm 4. */
+/**
+ * @brief Compute delta T of a given moment using algorithm 4.
+ * @param year The year.
+ * @returns A `DeltaT` struct.
+ */
 DeltaT delta_t_algo4(double year);
-/** @brief Compute delta T of a given moment using algorithm 5. */
+/**
+ * @brief Compute delta T of a given moment using algorithm 5.
+ * @param year The year.
+ * @returns A `DeltaT` struct.
+ */
 DeltaT delta_t_algo5(double year);
-/** @brief Compute delta T of a given moment, using the best algorithm. */
+/**
+ * @brief Compute delta T of a given moment, using the best algorithm.
+ * @param year The year.
+ * @returns A `DeltaT` struct.
+ */
 DeltaT delta_t(double year);
 
 

--- a/src/shared_lib/lib.cpp
+++ b/src/shared_lib/lib.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "lib.hpp"
+#include "celestial.h"
 
 // This cpp file is holding the functions to control the global configuration, such as log verbosity level.
 
@@ -33,14 +34,31 @@ extern "C" {
  * @returns `true` if the verbosity level is changed to the specified value, `false` otherwise.
  */
 auto set_log_verbosity(const uint8_t new_value) -> bool {
-  if (new_value >= static_cast<uint8_t>(lib::Verbosity::COUNT)) {
-    lib::info("Invalid verbosity level: {}", new_value);
+  try {
+    if (new_value >= static_cast<uint8_t>(lib::Verbosity::COUNT)) {
+      lib::info("Invalid verbosity level: {}", new_value);
+      return false;
+    }
+
+    const auto new_verbosity = static_cast<lib::Verbosity>(new_value);
+    const auto current_verbosity = lib::set_verbosity(new_verbosity);
+    return current_verbosity == new_verbosity;
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
     return false;
   }
+}
 
-  const auto new_verbosity = static_cast<lib::Verbosity>(new_value);
-  const auto current_verbosity = lib::set_verbosity(new_verbosity);
-  return current_verbosity == new_verbosity;
+
+/**
+ * @brief Get the last-error message of the calling thread.
+ * @returns A pointer to a thread-local C string, empty if there is no recorded error.
+ *          The pointer stays valid until the next C-ABI call on the same thread.
+ * @note #97 pilot: only the Julian Day exports (`ut1_to_jd`, `ut1_to_jde`, `jde_to_ut1`)
+ *       record messages for now.
+ */
+auto last_error() -> const char* {
+  return lib::last_error_message();
 }
 
 }

--- a/src/shared_lib/lib.cpp
+++ b/src/shared_lib/lib.cpp
@@ -25,38 +25,20 @@
 #include "celestial.h"
 
 // This cpp file is holding the functions to control the global configuration, such as log verbosity level.
+// #67: every export catches all exceptions and degrades to `valid = false` / `0`; contract: see celestial.h.
 
 extern "C" {
 
-/** 
- * @brief Set the verbosity level of log printing. 
- * @param new_value The new verbosity level (in `uint8_t`).
- * @returns `true` if the verbosity level is changed to the specified value, `false` otherwise.
- */
 auto set_log_verbosity(const uint8_t new_value) -> bool {
   try {
-    if (new_value >= static_cast<uint8_t>(lib::Verbosity::COUNT)) {
-      lib::info("Invalid verbosity level: {}", new_value);
-      return false;
-    }
-
-    const auto new_verbosity = static_cast<lib::Verbosity>(new_value);
-    const auto current_verbosity = lib::set_verbosity(new_verbosity);
-    return current_verbosity == new_verbosity;
+    return lib::set_verbosity(static_cast<lib::Verbosity>(new_value));
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return false;
   }
 }
 
 
-/**
- * @brief Get the last-error message of the calling thread.
- * @returns A pointer to a thread-local C string, empty if there is no recorded error.
- *          The pointer stays valid until the next C-ABI call on the same thread.
- * @note #97 pilot: only the Julian Day exports (`ut1_to_jd`, `ut1_to_jde`, `jde_to_ut1`)
- *       record messages for now.
- */
+// Contract: see celestial.h.
 auto last_error() -> const char* {
   return lib::last_error_message();
 }

--- a/src/shared_lib/lib.hpp
+++ b/src/shared_lib/lib.hpp
@@ -24,7 +24,9 @@
 #pragma once
 
 #include <print>
+#include <atomic>
 #include <format>
+#include <string>
 
 
 namespace lib {
@@ -39,7 +41,8 @@ enum class Verbosity : uint8_t {
 };
 
 
-inline Verbosity GLOBAL_VERBOSITY = Verbosity::DEBUG; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+// #67: written via `set_log_verbosity` and read on every log path — atomic, or the two race.
+inline std::atomic<Verbosity> GLOBAL_VERBOSITY = Verbosity::DEBUG; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 
 /** @brief Set the verbosity level of log printing. */
@@ -51,13 +54,24 @@ inline auto set_verbosity(const Verbosity new_verbosity) -> Verbosity {
 }
 
 
+// #67: logging runs inside the C-ABI catch handlers, so it must never throw — `vformat`
+// throws on an ill-formed format string, `println` on a failed stream ([print.fun]) — and
+// an escape there would cross the `extern "C"` boundary and terminate the host.
+template <typename... Args>
+inline void log_noexcept(const std::string& format_str, Args&&... args) { // NOLINT(cppcoreguidelines-missing-std-forward)
+  try {
+    // TODO: Currently std::forward<Args>(args)... is not supported on some platforms. Forward args when available.
+    const std::string formatted_message = std::vformat(format_str, std::make_format_args(args...));
+    std::println("{}", formatted_message);
+  } catch (...) { // NOLINT(bugprone-empty-catch) — nowhere left to report; swallowing is the contract.
+  }
+}
+
 /** @brief Log a message, at the `INFO` verbosity level. */
 template <typename... Args>
 inline void info(const std::string& format_str, Args&&... args) { // NOLINT(cppcoreguidelines-missing-std-forward)
   if (GLOBAL_VERBOSITY >= Verbosity::INFO) {
-    // TODO: Currently std::forward<Args>(args)... is not supported on some platforms. Forward args when available.
-    const std::string formatted_message = std::vformat(format_str, std::make_format_args(args...));
-    std::println("{}", formatted_message);
+    log_noexcept(format_str, args...);
   }
 }
 
@@ -65,10 +79,29 @@ inline void info(const std::string& format_str, Args&&... args) { // NOLINT(cppc
 template <typename... Args>
 inline void debug(const std::string& format_str, Args&&... args) { // NOLINT(cppcoreguidelines-missing-std-forward)
   if (GLOBAL_VERBOSITY >= Verbosity::DEBUG) {
-    // TODO: Currently std::forward<Args>(args)... is not supported on some platforms. Forward args when available.
-    const std::string formatted_message = std::vformat(format_str, std::make_format_args(args...));
-    std::println("{}", formatted_message);
+    log_noexcept(format_str, args...);
   }
+}
+
+
+// #97 pilot: a thread-local last-error channel, so an FFI caller that got `valid = false`
+// can learn *why* (the log goes to the library's stdout, which hosts may never see).
+// Only the Julian Day exports fill it for now — pilot, not a full rollout.
+inline thread_local std::string LAST_ERROR; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+/** @brief Clear the calling thread's last-error message. */
+inline auto clear_last_error() -> void {
+  LAST_ERROR.clear();
+}
+
+/** @brief Record the calling thread's last-error message. */
+inline auto set_last_error(const std::string& message) -> void {
+  LAST_ERROR = message;
+}
+
+/** @brief Read the calling thread's last-error message (empty if none). */
+inline auto last_error_message() -> const char* {
+  return LAST_ERROR.c_str();
 }
 
 

--- a/src/shared_lib/lib.hpp
+++ b/src/shared_lib/lib.hpp
@@ -23,11 +23,14 @@
 
 #pragma once
 
-#include <print>
 #include <atomic>
 #include <format>
+#include <print>
 #include <string>
+#include <string_view>
 
+// Internal helpers for the C-ABI layer (`lib*.cpp`): an atomic verbosity knob, never-throwing
+// logging safe to call inside catch handlers, and a thread-local last-error channel.
 
 namespace lib {
 
@@ -41,24 +44,33 @@ enum class Verbosity : uint8_t {
 };
 
 
-// #67: written via `set_log_verbosity` and read on every log path — atomic, or the two race.
+/**
+ * @brief The global verbosity level of log printing.
+ * @note #67: written via `set_log_verbosity` and read on every log path — atomic, or the two race.
+ */
 inline std::atomic<Verbosity> GLOBAL_VERBOSITY = Verbosity::DEBUG; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 
-/** @brief Set the verbosity level of log printing. */
-inline auto set_verbosity(const Verbosity new_verbosity) -> Verbosity {
-  if (new_verbosity < Verbosity::COUNT) {
-    GLOBAL_VERBOSITY = new_verbosity;
+/** @brief Set the verbosity level of log printing.
+ *  @return `true` if the level was stored, `false` if `new_verbosity` is out of range.
+ */
+inline auto set_verbosity(const Verbosity new_verbosity) -> bool {
+  if (new_verbosity >= Verbosity::COUNT) {
+    return false;
   }
-  return GLOBAL_VERBOSITY;
+  GLOBAL_VERBOSITY = new_verbosity;
+  return true;
 }
 
 
-// #67: logging runs inside the C-ABI catch handlers, so it must never throw — `vformat`
-// throws on an ill-formed format string, `println` on a failed stream ([print.fun]) — and
-// an escape there would cross the `extern "C"` boundary and terminate the host.
+/**
+ * @brief Log a message, never throwing.
+ * @note #67: logging runs inside the C-ABI catch handlers, so it must never throw — `vformat`
+ *       throws on an ill-formed format string, `println` on a failed stream ([print.fun]) — and
+ *       an escape there would cross the `extern "C"` boundary and terminate the host.
+ */
 template <typename... Args>
-inline void log_noexcept(const std::string& format_str, Args&&... args) { // NOLINT(cppcoreguidelines-missing-std-forward)
+inline void log_noexcept(const std::string_view format_str, Args&&... args) noexcept { // NOLINT(cppcoreguidelines-missing-std-forward)
   try {
     // TODO: Currently std::forward<Args>(args)... is not supported on some platforms. Forward args when available.
     const std::string formatted_message = std::vformat(format_str, std::make_format_args(args...));
@@ -69,7 +81,7 @@ inline void log_noexcept(const std::string& format_str, Args&&... args) { // NOL
 
 /** @brief Log a message, at the `INFO` verbosity level. */
 template <typename... Args>
-inline void info(const std::string& format_str, Args&&... args) { // NOLINT(cppcoreguidelines-missing-std-forward)
+inline void info(const std::string_view format_str, Args&&... args) { // NOLINT(cppcoreguidelines-missing-std-forward)
   if (GLOBAL_VERBOSITY >= Verbosity::INFO) {
     log_noexcept(format_str, args...);
   }
@@ -77,16 +89,19 @@ inline void info(const std::string& format_str, Args&&... args) { // NOLINT(cppc
 
 /** @brief Log a message, at the `DEBUG` verbosity level. */
 template <typename... Args>
-inline void debug(const std::string& format_str, Args&&... args) { // NOLINT(cppcoreguidelines-missing-std-forward)
+inline void debug(const std::string_view format_str, Args&&... args) { // NOLINT(cppcoreguidelines-missing-std-forward)
   if (GLOBAL_VERBOSITY >= Verbosity::DEBUG) {
     log_noexcept(format_str, args...);
   }
 }
 
 
-// #97 pilot: a thread-local last-error channel, so an FFI caller that got `valid = false`
-// can learn *why* (the log goes to the library's stdout, which hosts may never see).
-// Only the Julian Day exports fill it for now — pilot, not a full rollout.
+/**
+ * @brief The calling thread's last-error message.
+ * @note #97 pilot: a thread-local last-error channel, so an FFI caller that got `valid = false`
+ *       can learn *why* (the log goes to the library's stdout, which hosts may never see).
+ *       Only the Julian Day exports fill it for now — pilot, not a full rollout.
+ */
 inline thread_local std::string LAST_ERROR; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 /** @brief Clear the calling thread's last-error message. */
@@ -94,9 +109,16 @@ inline auto clear_last_error() -> void {
   LAST_ERROR.clear();
 }
 
-/** @brief Record the calling thread's last-error message. */
-inline auto set_last_error(const std::string& message) -> void {
-  LAST_ERROR = message;
+/**
+ * @brief Record the calling thread's last-error message.
+ * @note `noexcept`: the string assignment can throw `bad_alloc`; on failure the previous
+ *       message is kept.
+ */
+inline auto set_last_error(const std::string& message) noexcept -> void {
+  try {
+    LAST_ERROR = message;
+  } catch (...) { // NOLINT(bugprone-empty-catch) — nowhere left to report; swallowing is the contract.
+  }
 }
 
 /** @brief Read the calling thread's last-error message (empty if none). */

--- a/src/shared_lib/lib_astro.cpp
+++ b/src/shared_lib/lib_astro.cpp
@@ -33,17 +33,10 @@
 
 extern "C" {
 
+// #67: every export catches all exceptions and degrades to `valid = false` / `0`; contract: see celestial.h.
+
 #pragma region Julian Days
 
-/**
- * @brief Convert UT1 datetime to Julian Day Number (JD).
- * @param y The year.
- * @param m The month.
- * @param d The day.
- * @param fraction The fraction of the day. Must be in the range [0.0, 1.0).
- * @returns A `JulianDay` struct.
- * @details JD is based on UT1.
- */
 auto ut1_to_jd(const int32_t y, const uint32_t m, const uint32_t d, const double fraction) -> JulianDay {
   lib::clear_last_error();
 
@@ -63,22 +56,12 @@ auto ut1_to_jd(const int32_t y, const uint32_t m, const uint32_t d, const double
 
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     lib::set_last_error("Unknown error in ut1_to_jd.");
     return {};
   }
 }
 
 
-/**
- * @brief Convert UT1 datetime to Julian Ephemeris Day Number (JDE).
- * @param y The year.
- * @param m The month.
- * @param d The day.
- * @param fraction The fraction of the day. Must be in the range [0.0, 1.0).
- * @returns A `JulianDay` struct.
- * @details JDE is based on TT.
- */
 auto ut1_to_jde(const int32_t y, const uint32_t m, const uint32_t d, const double fraction) -> JulianDay {
   lib::clear_last_error();
 
@@ -98,18 +81,12 @@ auto ut1_to_jde(const int32_t y, const uint32_t m, const uint32_t d, const doubl
 
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     lib::set_last_error("Unknown error in ut1_to_jde.");
     return {};
   }
 }
 
 
-/**
- * @brief Convert Julian Ephemeris Day Number (JDE) to UT1 datetime.
- * @param jde The julian ephemeris day number, which is based on TT.
- * @returns A `UT1Time` struct.
- */
 auto jde_to_ut1(const double jde) -> UT1Time {
   lib::clear_last_error();
 
@@ -133,7 +110,6 @@ auto jde_to_ut1(const double jde) -> UT1Time {
 
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     lib::set_last_error("Unknown error in jde_to_ut1.");
     return {};
   }
@@ -145,13 +121,14 @@ auto jde_to_ut1(const double jde) -> UT1Time {
 
 #pragma region Solar Apparent Geocentric Position
 
-/**
- * @brief Calculate the apparent geocentric position of the Sun.
- * @param jde The julian ephemeris day number, which is based on TT.
- * @returns A `SunCoordinate` struct.
- */
 auto sun_apparent_geocentric_coord(const double jde) -> SunCoordinate {
   try {
+    if (not std::isfinite(jde)) {
+      throw std::invalid_argument {
+        std::format("Argument `jde` is not finite, whose value is {}", jde)
+      };
+    }
+
     const auto coord = astro::sun::geocentric_coord::apparent(jde);
 
     return {
@@ -166,7 +143,6 @@ auto sun_apparent_geocentric_coord(const double jde) -> SunCoordinate {
 
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }
@@ -176,13 +152,14 @@ auto sun_apparent_geocentric_coord(const double jde) -> SunCoordinate {
 
 #pragma region Moon Apparent Geocentric Position
 
-/**
- * @brief Calculate the apparent geocentric position of the Moon.
- * @param jde The julian ephemeris day number, which is based on TT.
- * @returns A `MoonCoordinate` struct.
- */
 auto moon_apparent_geocentric_coord(const double jde) -> MoonCoordinate {
   try {
+    if (not std::isfinite(jde)) {
+      throw std::invalid_argument {
+        std::format("Argument `jde` is not finite, whose value is {}", jde)
+      };
+    }
+
     const auto coord = astro::moon::geocentric_coord::apparent(jde);
 
     return {
@@ -197,7 +174,6 @@ auto moon_apparent_geocentric_coord(const double jde) -> MoonCoordinate {
 
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }
@@ -205,19 +181,16 @@ auto moon_apparent_geocentric_coord(const double jde) -> MoonCoordinate {
 #pragma endregion
 
 
-#pragma region Sun Position
+#pragma region Solar Longitude Roots
 
-/**
- * @brief Calculate the JDE discriminant, which is the count of the roots for the given `year` and `lon`.
- * @param year The year.
- * @param longitude The geocentric longitude.
- * @returns The count of the roots, which is 0, 1, or 2.
- *          0 indicates that Sun won't reach the given geocentric longitude in the given year.
- *          1 indicates that Sun will reach the given geocentric longitude once in the given year.
- *          2 indicates that Sun will reach the given geocentric longitude twice in the given year.
- */
 auto solar_lon_root_discriminant(const int32_t year, const double longitude) -> Discriminant {
   try {
+    if (not std::isfinite(longitude)) {
+      throw std::invalid_argument {
+        std::format("Argument `longitude` is not finite, whose value is {}", longitude)
+      };
+    }
+
     return {
       .valid = true,
       .count = astro::sun::geocentric_coord::math::discriminant(year, longitude),
@@ -227,21 +200,11 @@ auto solar_lon_root_discriminant(const int32_t year, const double longitude) -> 
     lib::debug("root_discriminant: year = {}, lon = {}, error = {}", year, longitude, e.what());
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }
 
 
-/**
- * @brief Find the JDE(s) at which the Sun reaches the given `longitude` in the given `year`.
- *        The result is written to the provided slots. It's caller's responsibility to allocate and free the slots.
- * @param year The year.
- * @param longitude The geocentric longitude.
- * @param slots The slots. It's caller's responsibility to allocate and free the slots.
- * @param slot_count The count of slots.
- * @return How many slots are written.
- */
 auto solar_lon_roots(
   const int32_t year, 
   const double longitude, 
@@ -250,13 +213,18 @@ auto solar_lon_roots(
 ) -> uint32_t {
   using namespace astro::sun::geocentric_coord::math;
 
-  // #67: the out-pointer is written to unconditionally below — reject null up front.
   if (slots == nullptr and slot_count > 0) {
     lib::info("Error in solar_lon_roots: `slots` is null, but `slot_count` is {}.", slot_count);
     return 0;
   }
 
   try {
+    if (not std::isfinite(longitude)) {
+      throw std::invalid_argument {
+        std::format("Argument `longitude` is not finite, whose value is {}", longitude)
+      };
+    }
+
     auto roots = find_roots(year, longitude);
 
     // Some sanity check...
@@ -278,7 +246,6 @@ auto solar_lon_roots(
 
     return 0;
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return 0;
   }
 }
@@ -288,27 +255,23 @@ auto solar_lon_roots(
 
 #pragma region Sun Moon Conjunction
 
-/**
- * @brief Find the JDE(s) at which the Sun and Moon are at the same logitude.
- *        The function finds the conjunction moments after `jde`.
- *        The result is written to the provided slots. It's caller's responsibility to allocate and free the slots.
- * @param jde The julian ephemeris day number, which is based on TT.
- * @param slots The slots. It's caller's responsibility to allocate and free the slots.
- * @param slot_count The count of slots.
- * @return How many slots are written.
- */
 auto new_moons_after_jde(
   const double jde, 
   double * const slots, 
   const uint32_t slot_count
 ) -> uint32_t {
-  // #67: the out-pointer is written to unconditionally below — reject null up front.
   if (slots == nullptr and slot_count > 0) {
     lib::info("Error in new_moons_after_jde: `slots` is null, but `slot_count` is {}.", slot_count);
     return 0;
   }
 
   try {
+    if (not std::isfinite(jde)) {
+      throw std::invalid_argument {
+        std::format("Argument `jde` is not finite, whose value is {}", jde)
+      };
+    }
+
     std::vector<double> roots;
     roots.reserve(slot_count);
 
@@ -323,29 +286,17 @@ auto new_moons_after_jde(
 
     return 0;
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return 0;
   }
 }
 
 
-/**
- * @brief Find the JDE(s) at which the Sun and Moon are at the same logitude.
- *        The function finds the conjunction moments in the given year.
- *        The result is written to the provided slots. It's caller's responsibility to allocate and free the slots.
- * @param year The Gregorian year.
- * @param root_count The pointer to uint32_t where the count of the roots will be written.
- * @param slots The slots. It's caller's responsibility to allocate and free the slots.
- * @param slot_count The count of slots.
- * @return How many slots are written.
- */
 auto new_moons_in_year(
   const int32_t year, 
   uint32_t * const root_count,
   double * const slots, 
   const uint32_t slot_count
 ) -> uint32_t {
-  // #67: the out-pointers are written to unconditionally below — reject null up front.
   if (root_count == nullptr) {
     lib::info("Error in new_moons_in_year: `root_count` is null.");
     return 0;
@@ -370,7 +321,6 @@ auto new_moons_in_year(
 
     return 0;
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return 0;
   }
 }
@@ -380,21 +330,8 @@ auto new_moons_in_year(
 
 #pragma region Solar Time
 
-/**
- * @brief Compute the equation of time E = apparent solar time − mean solar time.
- * @param jde The julian ephemeris day number, which is based on TT.
- * @returns A `EquationOfTime` struct; `value` is E in degrees of hour angle (×240 = seconds of time).
- */
 auto equation_of_time(const double jde) -> EquationOfTime {
   try {
-    // The core pipeline has no finite guard — a NaN JDE would come back as
-    // `valid = true, value = NaN`.
-    if (not std::isfinite(jde)) {
-      throw std::invalid_argument {
-        std::format("Argument `jde` is not finite, whose value is {}", jde)
-      };
-    }
-
     return {
       .valid = true,
       .value = astro::solar_time::equation_of_time(jde).deg(),
@@ -405,35 +342,24 @@ auto equation_of_time(const double jde) -> EquationOfTime {
 
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }
 
 
-/**
- * @brief Convert a civil UTC moment to local apparent (true) solar time.
- * @param y The year (UTC).
- * @param m The month (UTC).
- * @param d The day (UTC).
- * @param fraction The fraction of the day (UTC). Must be in the range [0.0, 1.0).
- * @param longitude The observer's geographic longitude in degrees, positive east, in [−180, 180].
- * @returns A `SolarTime` struct.
- */
 auto apparent_solar_time(
   const int32_t y,
   const uint32_t m,
   const uint32_t d,
   const double fraction,
   const double longitude
-) -> SolarTime {
+) -> ApparentSolarTime {
   try {
     const auto ymd = util::to_ymd(y, m, d);
     const auto utc_dt = calendar::Datetime(ymd, fraction);
     const auto lon = astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> { longitude };
     const auto apparent_dt = astro::solar_time::apparent(utc_dt, lon);
 
-    // Named differently from the `y/m/d` params — structured bindings declare new names.
     const auto [ay, am, ad] = util::from_ymd(apparent_dt.ymd);
 
     return {
@@ -452,7 +378,6 @@ auto apparent_solar_time(
 
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }

--- a/src/shared_lib/lib_astro.cpp
+++ b/src/shared_lib/lib_astro.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 
 #include "lib.hpp"
+#include "celestial.h"
 
 #include "astro.hpp"
 #include "util.hpp"
@@ -33,11 +34,6 @@
 extern "C" {
 
 #pragma region Julian Days
-
-struct JulianDay {
-  bool   valid; // Indicates if the result is valid.
-  double value; // The value. Either JD or JDE.
-};
 
 /**
  * @brief Convert UT1 datetime to Julian Day Number (JD).
@@ -49,6 +45,8 @@ struct JulianDay {
  * @details JD is based on UT1.
  */
 auto ut1_to_jd(const int32_t y, const uint32_t m, const uint32_t d, const double fraction) -> JulianDay {
+  lib::clear_last_error();
+
   try {
     const auto ymd = util::to_ymd(y, m, d);
     const auto ut1_dt = calendar::Datetime(ymd, fraction);
@@ -59,9 +57,14 @@ auto ut1_to_jd(const int32_t y, const uint32_t m, const uint32_t d, const double
       .value = jd,
     };
   } catch (const std::exception& e) {
+    lib::set_last_error(e.what());
     lib::info("Error in ut1_jd: {}", e.what());
     lib::debug("ut1_to_jd: y = {}, m = {}, d = {}, fraction = {}", y, m, d, fraction);
 
+    return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
+    lib::set_last_error("Unknown error in ut1_to_jd.");
     return {};
   }
 }
@@ -77,6 +80,8 @@ auto ut1_to_jd(const int32_t y, const uint32_t m, const uint32_t d, const double
  * @details JDE is based on TT.
  */
 auto ut1_to_jde(const int32_t y, const uint32_t m, const uint32_t d, const double fraction) -> JulianDay {
+  lib::clear_last_error();
+
   try {
     const auto ymd = util::to_ymd(y, m, d);
     const auto ut1_dt = calendar::Datetime(ymd, fraction);
@@ -87,21 +92,17 @@ auto ut1_to_jde(const int32_t y, const uint32_t m, const uint32_t d, const doubl
       .value = jde,
     };
   } catch (const std::exception& e) {
+    lib::set_last_error(e.what());
     lib::info("Error in ut1_jde: {}", e.what());
     lib::debug("ut1_to_jde: y = {}, m = {}, d = {}, fraction = {}", y, m, d, fraction);
 
     return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
+    lib::set_last_error("Unknown error in ut1_to_jde.");
+    return {};
   }
 }
-
-
-struct UT1Time {
-  bool     valid;    // Indicates if the result is valid.
-  int32_t  year;     // The year.
-  uint32_t month;    // The month.
-  uint32_t day;      // The day.
-  double   fraction; // The fraction of the day. Must be in the range [0.0, 1.0).
-};
 
 
 /**
@@ -110,6 +111,8 @@ struct UT1Time {
  * @returns A `UT1Time` struct.
  */
 auto jde_to_ut1(const double jde) -> UT1Time {
+  lib::clear_last_error();
+
   try {
     const auto ut1_dt = astro::julian_day::jde_to_ut1(jde);
 
@@ -124,9 +127,14 @@ auto jde_to_ut1(const double jde) -> UT1Time {
       .fraction   = fraction,
     };
   } catch (const std::exception& e) {
+    lib::set_last_error(e.what());
     lib::info("Error in jde_to_ut1: {}", e.what());
     lib::debug("jde_to_ut1: jde = {}", jde);
 
+    return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
+    lib::set_last_error("Unknown error in jde_to_ut1.");
     return {};
   }
 }
@@ -136,13 +144,6 @@ auto jde_to_ut1(const double jde) -> UT1Time {
 
 
 #pragma region Solar Apparent Geocentric Position
-
-struct SunCoordinate {
-  bool valid; // Indicates if the result is valid.
-  double lon; // The longitude. In degrees.
-  double lat; // The latitude. In degrees.
-  double   r; // The radius. In AU.
-};
 
 /**
  * @brief Calculate the apparent geocentric position of the Sun.
@@ -164,6 +165,9 @@ auto sun_apparent_geocentric_coord(const double jde) -> SunCoordinate {
     lib::debug("sun_apparent_geocentric_position: jde = {}", jde);
 
     return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
+    return {};
   }
 }
 
@@ -171,14 +175,6 @@ auto sun_apparent_geocentric_coord(const double jde) -> SunCoordinate {
 
 
 #pragma region Moon Apparent Geocentric Position
-
-struct MoonCoordinate {
-  bool valid; // Indicates if the result is valid.
-  double lon; // The longitude. In degrees.
-  double lat; // The latitude. In degrees.
-  double   r; // The radius. In KM.
-};
-
 
 /**
  * @brief Calculate the apparent geocentric position of the Moon.
@@ -200,6 +196,9 @@ auto moon_apparent_geocentric_coord(const double jde) -> MoonCoordinate {
     lib::debug("moon_apparent_geocentric_position: jde = {}", jde);
 
     return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
+    return {};
   }
 }
 
@@ -207,11 +206,6 @@ auto moon_apparent_geocentric_coord(const double jde) -> MoonCoordinate {
 
 
 #pragma region Sun Position
-
-struct Discriminant {
-  bool     valid; // Indicates if the result is valid.
-  uint32_t count; // The count of the roots, which is 0, 1, or 2.
-};
 
 /**
  * @brief Calculate the JDE discriminant, which is the count of the roots for the given `year` and `lon`.
@@ -231,6 +225,9 @@ auto solar_lon_root_discriminant(const int32_t year, const double longitude) -> 
   } catch (const std::exception& e) {
     lib::info("Exception raised during execution of root_discriminant");
     lib::debug("root_discriminant: year = {}, lon = {}, error = {}", year, longitude, e.what());
+    return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }
@@ -253,6 +250,12 @@ auto solar_lon_roots(
 ) -> uint32_t {
   using namespace astro::sun::geocentric_coord::math;
 
+  // #67: the out-pointer is written to unconditionally below — reject null up front.
+  if (slots == nullptr and slot_count > 0) {
+    lib::info("Error in solar_lon_roots: `slots` is null, but `slot_count` is {}.", slot_count);
+    return 0;
+  }
+
   try {
     auto roots = find_roots(year, longitude);
 
@@ -273,6 +276,9 @@ auto solar_lon_roots(
     lib::info("Exception raised during execution of copy_roots");
     lib::debug("copy_roots: year = {}, lon = {}, error = {}", year, longitude, e.what());
 
+    return 0;
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
     return 0;
   }
 }
@@ -296,6 +302,12 @@ auto new_moons_after_jde(
   double * const slots, 
   const uint32_t slot_count
 ) -> uint32_t {
+  // #67: the out-pointer is written to unconditionally below — reject null up front.
+  if (slots == nullptr and slot_count > 0) {
+    lib::info("Error in new_moons_after_jde: `slots` is null, but `slot_count` is {}.", slot_count);
+    return 0;
+  }
+
   try {
     std::vector<double> roots;
     roots.reserve(slot_count);
@@ -309,6 +321,9 @@ auto new_moons_after_jde(
     lib::info("Exception thrown during execution of sun_moon_conjunctions_after_jde");
     lib::debug("sun_moon_conjunctions_after_jde: jde = {}, error = {}", jde, e.what());
 
+    return 0;
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
     return 0;
   }
 }
@@ -330,6 +345,16 @@ auto new_moons_in_year(
   double * const slots, 
   const uint32_t slot_count
 ) -> uint32_t {
+  // #67: the out-pointers are written to unconditionally below — reject null up front.
+  if (root_count == nullptr) {
+    lib::info("Error in new_moons_in_year: `root_count` is null.");
+    return 0;
+  }
+  if (slots == nullptr and slot_count > 0) {
+    lib::info("Error in new_moons_in_year: `slots` is null, but `slot_count` is {}.", slot_count);
+    return 0;
+  }
+
   try {
     const auto roots = astro::moon_phase::new_moon::moments(year);
 
@@ -343,6 +368,9 @@ auto new_moons_in_year(
     lib::info("Exception thrown during execution of sun_moon_conjunctions_in_year");
     lib::debug("sun_moon_conjunctions_in_year: year = {}, error = {}", year, e.what());
 
+    return 0;
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
     return 0;
   }
 }

--- a/src/shared_lib/lib_astro.cpp
+++ b/src/shared_lib/lib_astro.cpp
@@ -377,4 +377,86 @@ auto new_moons_in_year(
 
 #pragma endregion
 
+
+#pragma region Solar Time
+
+/**
+ * @brief Compute the equation of time E = apparent solar time − mean solar time.
+ * @param jde The julian ephemeris day number, which is based on TT.
+ * @returns A `EquationOfTime` struct; `value` is E in degrees of hour angle (×240 = seconds of time).
+ */
+auto equation_of_time(const double jde) -> EquationOfTime {
+  try {
+    // The core pipeline has no finite guard — a NaN JDE would come back as
+    // `valid = true, value = NaN`.
+    if (not std::isfinite(jde)) {
+      throw std::invalid_argument {
+        std::format("Argument `jde` is not finite, whose value is {}", jde)
+      };
+    }
+
+    return {
+      .valid = true,
+      .value = astro::solar_time::equation_of_time(jde).deg(),
+    };
+  } catch (const std::exception& e) {
+    lib::info("Error in equation_of_time: {}", e.what());
+    lib::debug("equation_of_time: jde = {}", jde);
+
+    return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
+    return {};
+  }
+}
+
+
+/**
+ * @brief Convert a civil UTC moment to local apparent (true) solar time.
+ * @param y The year (UTC).
+ * @param m The month (UTC).
+ * @param d The day (UTC).
+ * @param fraction The fraction of the day (UTC). Must be in the range [0.0, 1.0).
+ * @param longitude The observer's geographic longitude in degrees, positive east, in [−180, 180].
+ * @returns A `SolarTime` struct.
+ */
+auto apparent_solar_time(
+  const int32_t y,
+  const uint32_t m,
+  const uint32_t d,
+  const double fraction,
+  const double longitude
+) -> SolarTime {
+  try {
+    const auto ymd = util::to_ymd(y, m, d);
+    const auto utc_dt = calendar::Datetime(ymd, fraction);
+    const auto lon = astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> { longitude };
+    const auto apparent_dt = astro::solar_time::apparent(utc_dt, lon);
+
+    // Named differently from the `y/m/d` params — structured bindings declare new names.
+    const auto [ay, am, ad] = util::from_ymd(apparent_dt.ymd);
+
+    return {
+      .valid    = true,
+      .year     = ay,
+      .month    = am,
+      .day      = ad,
+      .fraction = apparent_dt.fraction(),
+    };
+  } catch (const std::exception& e) {
+    lib::info("Error in apparent_solar_time: {}", e.what());
+    lib::debug(
+      "apparent_solar_time: y = {}, m = {}, d = {}, fraction = {}, longitude = {}",
+      y, m, d, fraction, longitude
+    );
+
+    return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
+    return {};
+  }
+}
+
+#pragma endregion
+
 }

--- a/src/shared_lib/lib_astro.cpp
+++ b/src/shared_lib/lib_astro.cpp
@@ -332,6 +332,12 @@ auto new_moons_in_year(
 
 auto equation_of_time(const double jde) -> EquationOfTime {
   try {
+    if (not std::isfinite(jde)) {
+      throw std::invalid_argument {
+        std::format("Argument `jde` is not finite, whose value is {}", jde)
+      };
+    }
+
     return {
       .valid = true,
       .value = astro::solar_time::equation_of_time(jde).deg(),

--- a/src/shared_lib/lib_delta_t.cpp
+++ b/src/shared_lib/lib_delta_t.cpp
@@ -23,13 +23,21 @@
 
 #include "lib.hpp"
 #include "celestial.h"
+
 #include "delta_t.hpp"
 
 extern "C" {
 
-/** @brief Compute delta T of a given moment using algorithm 1. */
+// #67: every export catches all exceptions and degrades to `valid = false` / `0`; contract: see celestial.h.
+
 auto delta_t_algo1(double year) -> DeltaT {
   try {
+    if (not std::isfinite(year)) {
+      throw std::invalid_argument {
+        std::format("Argument `year` is not finite, whose value is {}", year)
+      };
+    }
+
     return {
       .valid = true,
       .value = astro::delta_t::algo1::compute(year),
@@ -40,14 +48,18 @@ auto delta_t_algo1(double year) -> DeltaT {
 
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }
 
-/** @brief Compute delta T of a given moment using algorithm 2. */
 auto delta_t_algo2(double year) -> DeltaT {
   try {
+    if (not std::isfinite(year)) {
+      throw std::invalid_argument {
+        std::format("Argument `year` is not finite, whose value is {}", year)
+      };
+    }
+
     return {
       .valid = true,
       .value = astro::delta_t::algo2::compute(year),
@@ -58,14 +70,18 @@ auto delta_t_algo2(double year) -> DeltaT {
 
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }
 
-/** @brief Compute delta T of a given moment using algorithm 3. */
 auto delta_t_algo3(double year) -> DeltaT {
   try {
+    if (not std::isfinite(year)) {
+      throw std::invalid_argument {
+        std::format("Argument `year` is not finite, whose value is {}", year)
+      };
+    }
+
     return {
       .valid = true,
       .value = astro::delta_t::algo3::compute(year),
@@ -76,14 +92,18 @@ auto delta_t_algo3(double year) -> DeltaT {
 
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }
 
-/** @brief Compute delta T of a given moment using algorithm 4. */
 auto delta_t_algo4(double year) -> DeltaT {
   try {
+    if (not std::isfinite(year)) {
+      throw std::invalid_argument {
+        std::format("Argument `year` is not finite, whose value is {}", year)
+      };
+    }
+
     return {
       .valid = true,
       .value = astro::delta_t::algo4::compute(year),
@@ -94,14 +114,18 @@ auto delta_t_algo4(double year) -> DeltaT {
 
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }
 
-/** @brief Compute delta T of a given moment using algorithm 5. */
 auto delta_t_algo5(double year) -> DeltaT {
   try {
+    if (not std::isfinite(year)) {
+      throw std::invalid_argument {
+        std::format("Argument `year` is not finite, whose value is {}", year)
+      };
+    }
+
     return {
       .valid = true,
       .value = astro::delta_t::algo5::compute(year),
@@ -112,14 +136,18 @@ auto delta_t_algo5(double year) -> DeltaT {
 
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }
 
-/** @brief Compute delta T of a given moment, using the best algorithm. */
 auto delta_t(double year) -> DeltaT {
   try {
+    if (not std::isfinite(year)) {
+      throw std::invalid_argument {
+        std::format("Argument `year` is not finite, whose value is {}", year)
+      };
+    }
+
     return {
       .valid = true,
       .value = astro::delta_t::compute(year),
@@ -130,7 +158,6 @@ auto delta_t(double year) -> DeltaT {
 
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }   

--- a/src/shared_lib/lib_delta_t.cpp
+++ b/src/shared_lib/lib_delta_t.cpp
@@ -22,14 +22,10 @@
  */
 
 #include "lib.hpp"
+#include "celestial.h"
 #include "delta_t.hpp"
 
 extern "C" {
-
-struct DeltaT {
-  bool   valid; // Indicates if the result is valid.
-  double value; // The value of delta T.
-};
 
 /** @brief Compute delta T of a given moment using algorithm 1. */
 auto delta_t_algo1(double year) -> DeltaT {
@@ -42,6 +38,9 @@ auto delta_t_algo1(double year) -> DeltaT {
     lib::info("Exception raised during execution of delta_t_algo1");
     lib::debug("delta_t_algo1: year = {}, error = {}", year, e.what());
 
+    return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }
@@ -58,6 +57,9 @@ auto delta_t_algo2(double year) -> DeltaT {
     lib::debug("delta_t_algo2: year = {}, error = {}", year, e.what());
 
     return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
+    return {};
   }
 }
 
@@ -72,6 +74,9 @@ auto delta_t_algo3(double year) -> DeltaT {
     lib::info("Exception raised during execution of delta_t_algo3");
     lib::debug("delta_t_algo3: year = {}, error = {}", year, e.what());
 
+    return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }
@@ -88,6 +93,9 @@ auto delta_t_algo4(double year) -> DeltaT {
     lib::debug("delta_t_algo4: year = {}, error = {}", year, e.what());
 
     return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
+    return {};
   }
 }
 
@@ -103,6 +111,9 @@ auto delta_t_algo5(double year) -> DeltaT {
     lib::debug("delta_t_algo5: year = {}, error = {}", year, e.what());
 
     return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
+    return {};
   }
 }
 
@@ -117,6 +128,9 @@ auto delta_t(double year) -> DeltaT {
     lib::info("Exception raised during execution of delta_t");
     lib::debug("delta_t: year = {}, error = {}", year, e.what());
 
+    return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }   

--- a/src/shared_lib/lib_jieqi.cpp
+++ b/src/shared_lib/lib_jieqi.cpp
@@ -25,16 +25,13 @@
 
 #include "lib.hpp"
 #include "celestial.h"
+
 #include "jieqi.hpp"
 
 extern "C" {
 
-/**
- * @brief Query the accurate moment of the Jieqi in the given `year`.
- * @param year The year, in gregorian calendar.
- * @param jq_idx The index of the Jieqi. Expected to be in the range [0, 24). This is the enum value of `Jieqi`.
- * @returns A `JieqiMomentQuery` struct.
- */
+// #67: every export catches all exceptions and degrades to `valid = false` / `0`; contract: see celestial.h.
+
 auto query_jieqi_moment(const int32_t year, const uint8_t jq_idx) -> JieqiMomentQuery { // NOLINT(bugprone-easily-swappable-parameters)
   // Validate the input.
   if (jq_idx >= 24) [[unlikely]] {
@@ -65,32 +62,23 @@ auto query_jieqi_moment(const int32_t year, const uint8_t jq_idx) -> JieqiMoment
 
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }
 
 
-/**
- * @brief Get the Chinese name of the Jieqi.
- * @param jq_idx The index of the Jieqi. Expected to be in the range [0, 24). This is the enum value of `Jieqi`.
- * @param buf The name memory. It's caller's responsibility to allocate and free the memory.
- * @param buf_size Maximum bytes that can be written to `buf`.
- * @returns `true` if the name is successfully written to `buf`.
- */
 auto get_jieqi_name(const uint8_t jq_idx, char * const buf, const uint32_t buf_size) -> bool {
+  // Validate the input.
+  if (jq_idx >= 24) [[unlikely]] {
+    lib::info("Error in get_jieqi_name: jq_idx is {}, but expected to be in the range [0, 24).", jq_idx);
+    return false;
+  }
+  if (buf == nullptr) {
+    lib::info("Error in get_jieqi_name: `buf` is null.");
+    return false;
+  }
+
   try {
-    if (jq_idx >= 24) [[unlikely]] {
-      lib::info("Error in get_jieqi_name: jq_idx is {}, but expected to be in the range [0, 24).", jq_idx);
-      return false;
-    }
-
-    // #67: the out-pointer is written to unconditionally below — reject null up front.
-    if (buf == nullptr) {
-      lib::info("Error in get_jieqi_name: `buf` is null.");
-      return false;
-    }
-
     using namespace calendar::jieqi;
     const std::string_view name = JIEQI_NAME.at(static_cast<Jieqi>(jq_idx));
 
@@ -106,7 +94,6 @@ auto get_jieqi_name(const uint8_t jq_idx, char * const buf, const uint32_t buf_s
 
     return true;
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return false;
   }
 }

--- a/src/shared_lib/lib_jieqi.cpp
+++ b/src/shared_lib/lib_jieqi.cpp
@@ -24,21 +24,10 @@
 #include <cstring>
 
 #include "lib.hpp"
+#include "celestial.h"
 #include "jieqi.hpp"
 
 extern "C" {
-
-struct JieqiMomentQuery {
-  bool     valid;  // Indicates if the result is valid.
-
-  uint8_t  jq_idx; // The index of the Jieqi. Expected to be in the range [0, 24). This is the enum value of `Jieqi`.
-
-  int32_t  y;      // The year.
-  uint32_t m;      // The month.
-  uint32_t d;      // The day.
-  double   frac;   // The fraction of the day. Expected to be in the range [0.0, 1.0).
-};
-
 
 /**
  * @brief Query the accurate moment of the Jieqi in the given `year`.
@@ -75,6 +64,9 @@ auto query_jieqi_moment(const int32_t year, const uint8_t jq_idx) -> JieqiMoment
     lib::info("Error in query_jieqi_moment: {}", e.what());
 
     return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
+    return {};
   }
 }
 
@@ -87,25 +79,36 @@ auto query_jieqi_moment(const int32_t year, const uint8_t jq_idx) -> JieqiMoment
  * @returns `true` if the name is successfully written to `buf`.
  */
 auto get_jieqi_name(const uint8_t jq_idx, char * const buf, const uint32_t buf_size) -> bool {
-  if (jq_idx >= 24) [[unlikely]] {
-    lib::info("Error in get_jieqi_name: jq_idx is {}, but expected to be in the range [0, 24).", jq_idx);
+  try {
+    if (jq_idx >= 24) [[unlikely]] {
+      lib::info("Error in get_jieqi_name: jq_idx is {}, but expected to be in the range [0, 24).", jq_idx);
+      return false;
+    }
+
+    // #67: the out-pointer is written to unconditionally below — reject null up front.
+    if (buf == nullptr) {
+      lib::info("Error in get_jieqi_name: `buf` is null.");
+      return false;
+    }
+
+    using namespace calendar::jieqi;
+    const std::string_view name = JIEQI_NAME.at(static_cast<Jieqi>(jq_idx));
+
+    // Check if the buffer is large enough to hold the name and the null terminator
+    if (buf_size < name.size() + 1) {
+      lib::info("Error in get_jieqi_name: provided buffer is too small. Required {}, actual {}.", name.size() + 1, buf_size);
+      return false;
+    }
+
+    // Copy the name to the buffer
+    std::memcpy(buf, name.data(), name.size());
+    buf[name.size()] = '\0'; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+
+    return true;
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
     return false;
   }
-
-  using namespace calendar::jieqi;
-  const std::string_view name = JIEQI_NAME.at(static_cast<Jieqi>(jq_idx));
-
-  // Check if the buffer is large enough to hold the name and the null terminator
-  if (buf_size < name.size() + 1) {
-    lib::info("Error in get_jieqi_name: provided buffer is too small. Required {}, actual {}.", name.size() + 1, buf_size);
-    return false;
-  }
-
-  // Copy the name to the buffer
-  std::memcpy(buf, name.data(), name.size());
-  buf[name.size()] = '\0'; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-
-  return true;
 }
 
 }

--- a/src/shared_lib/lib_lunar.cpp
+++ b/src/shared_lib/lib_lunar.cpp
@@ -24,18 +24,13 @@
 #include <cassert>
 
 #include "lib.hpp"
+#include "celestial.h"
 
 #include "lunar/algo1.hpp"
 #include "lunar/algo2.hpp"
 
 
 extern "C" {
-
-struct SupportedLunarYearRange {
-  bool valid;
-  int32_t start;
-  int32_t end;
-};
 
 /**
  * @brief Get the supported lunar year range for the algorithm.
@@ -61,25 +56,6 @@ auto get_supported_lunar_year_range(const uint8_t algo) -> SupportedLunarYearRan
 
   return {};
 }
-
-struct LunarYearInfo { // Avoid name conflict with `calendar::lunar::common::LunarYear`.
-  bool valid;
-
-  // The following 3 fields indicate the date of the first day of the lunar year in gregorian calendar.
-  int32_t year;
-  uint8_t month;
-  uint8_t day;
-
-  // `leap_month` indicates the month of the leap month (1 <= leap_month <= 12).
-  // If 0, there is no leap month.
-  uint8_t leap_month;
-  
-  // Use least 12 or 13 bits to indicate the length of each month in the lunar year.
-  // '1' means 30 days, '0' means 29 days.
-  // If `leap_month` is 0, there are 12 months; otherwise there are 13 months.
-  uint16_t month_len;
-};
-
 
 /**
  * @brief Get the lunar year information for the given year.
@@ -123,8 +99,12 @@ auto get_lunar_year_info(const uint8_t algo, const int32_t year) -> LunarYearInf
     };
 
   } catch (const std::exception& e) {
+    // #67: `e.what()` is a message, not a format string — pass it as an argument.
     lib::info("Exception raised during execution of get_lunar_year_info_algo1, year = {}", year);
-    lib::info(e.what());
+    lib::info("{}", e.what());
+    return {};
+  } catch (...) {
+    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }

--- a/src/shared_lib/lib_lunar.cpp
+++ b/src/shared_lib/lib_lunar.cpp
@@ -32,11 +32,8 @@
 
 extern "C" {
 
-/**
- * @brief Get the supported lunar year range for the algorithm.
- * @param algo The algorithm. Expected to be 1 or 2.
- * @return The supported lunar year range.
- */
+// #67: every export catches all exceptions and degrades to `valid = false` / `0`; contract: see celestial.h.
+
 auto get_supported_lunar_year_range(const uint8_t algo) -> SupportedLunarYearRange {
   if (algo == 1) {
     return {
@@ -57,12 +54,6 @@ auto get_supported_lunar_year_range(const uint8_t algo) -> SupportedLunarYearRan
   return {};
 }
 
-/**
- * @brief Get the lunar year information for the given year.
- * @param algo The algorithm. Expected to be 1 or 2.
- * @param year The lunar year.
- * @return The lunar year information.
- */
 auto get_lunar_year_info(const uint8_t algo, const int32_t year) -> LunarYearInfo { // NOLINT(bugprone-easily-swappable-parameters)
   using namespace std::views;
   
@@ -104,7 +95,6 @@ auto get_lunar_year_info(const uint8_t algo, const int32_t year) -> LunarYearInf
     lib::info("{}", e.what());
     return {};
   } catch (...) {
-    // #67: nothing may escape the `extern "C"` boundary.
     return {};
   }
 }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -45,8 +45,8 @@ macro(CELESTIAL_ADD_TEST test_path test_name)
     ${test_name}
     GTest::gtest_main
   )
-  # #67: the C-ABI smoke test drives the real shared library across the `extern "C"` boundary.
-  if(test_name STREQUAL "cabi_smoke_test")
+  # #67: tests under `test/shared_lib/` drive the real shared library across the `extern "C"` boundary.
+  if("${test_path}" MATCHES "/shared_lib/")
     target_link_libraries(${test_name} celestial_calendar)
     target_include_directories(${test_name} PRIVATE ${CMAKE_SOURCE_DIR}/shared_lib)
     # Windows has no rpath — the test executable must find the DLL next to itself.

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -45,6 +45,19 @@ macro(CELESTIAL_ADD_TEST test_path test_name)
     ${test_name}
     GTest::gtest_main
   )
+  # #67: the C-ABI smoke test drives the real shared library across the `extern "C"` boundary.
+  if(test_name STREQUAL "cabi_smoke_test")
+    target_link_libraries(${test_name} celestial_calendar)
+    target_include_directories(${test_name} PRIVATE ${CMAKE_SOURCE_DIR}/shared_lib)
+    # Windows has no rpath — the test executable must find the DLL next to itself.
+    if(WIN32)
+      add_custom_command(
+        TARGET ${test_name} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          $<TARGET_FILE:celestial_calendar> $<TARGET_FILE_DIR:${test_name}>
+      )
+    endif()
+  endif()
   gtest_discover_tests(${test_name} DISCOVERY_TIMEOUT 180) # Increase discovery timeout for docker builds
 endmacro()
 

--- a/src/test/astro/julian_day_test.cpp
+++ b/src/test/astro/julian_day_test.cpp
@@ -122,8 +122,7 @@ TEST(JulianDay, InvalidInput) {
   ASSERT_THROW(jd_to_ut1(-std::numeric_limits<double>::infinity()), std::runtime_error);
 
   // #67: above JD 13689325.5 (conceptually 32768-01-01) `std::chrono::year` overflows, and the
-  // uint32 arithmetic wraps into valid-looking but wrong dates. The bound is exact: the last
-  // representable day still converts, the first unrepresentable one throws.
+  // uint32 arithmetic wraps into valid-looking but wrong dates.
   ASSERT_NO_THROW(jd_to_ut1(13689325.499999));
   ASSERT_THROW(jd_to_ut1(13689325.5), std::runtime_error);
   ASSERT_THROW(jd_to_ut1(4.0e9), std::runtime_error); // wrapped to 2403-12-05 before #67.

--- a/src/test/astro/julian_day_test.cpp
+++ b/src/test/astro/julian_day_test.cpp
@@ -121,6 +121,13 @@ TEST(JulianDay, InvalidInput) {
   ASSERT_THROW(jd_to_ut1(std::numeric_limits<double>::infinity()), std::runtime_error);
   ASSERT_THROW(jd_to_ut1(-std::numeric_limits<double>::infinity()), std::runtime_error);
 
+  // #67: above JD 13689325.5 (conceptually 32768-01-01) `std::chrono::year` overflows, and the
+  // uint32 arithmetic wraps into valid-looking but wrong dates. The bound is exact: the last
+  // representable day still converts, the first unrepresentable one throws.
+  ASSERT_NO_THROW(jd_to_ut1(13689325.499999));
+  ASSERT_THROW(jd_to_ut1(13689325.5), std::runtime_error);
+  ASSERT_THROW(jd_to_ut1(4.0e9), std::runtime_error); // wrapped to 2403-12-05 before #67.
+
   // Smallest supported year converts correctly: JD of 1-01-01 00:00 (gregorian) is 1721425.5.
   ASSERT_NEAR(ut1_to_jd(Datetime { to_ymd(1, 1, 1), 0.0 }), 1721425.5, EPSILON);
 

--- a/src/test/datetime_test.cpp
+++ b/src/test/datetime_test.cpp
@@ -323,6 +323,14 @@ TEST(Datetime, EdgeCases) {
 
       ASSERT_THROW((Datetime { today_tp, -1e-11 }), 
                    std::invalid_argument);
+
+      // #67: NaN and huge fractions slip past `<`-style checks — and used to reach the
+      // undefined double→int64 cast in `from_fraction` before the (too-late) body check.
+      ASSERT_THROW((Datetime { today_tp, std::numeric_limits<double>::quiet_NaN() }),
+                   std::invalid_argument);
+
+      ASSERT_THROW((Datetime { today_tp, 1e300 }),
+                   std::invalid_argument);
     }
   }
 

--- a/src/test/lunar/algo2_test.cpp
+++ b/src/test/lunar/algo2_test.cpp
@@ -290,8 +290,8 @@ TEST(LunarAlgo2, MetadataSharesCache) {
   // #78: `AlgoMetadata` must bind the namespace-level cached function, not copy it —
   // a copied `std::function` forks its own cache replica and recomputes from scratch.
   ASSERT_EQ(&AlgoMetadata<Algo::ALGO_2>::get_info_for_year, &algo2::get_info_for_year);
-  // #67: `bounds` is a function-local static now (lazy init), reached through a function call.
-  ASSERT_EQ(&AlgoMetadata<Algo::ALGO_2>::bounds, &algo2::bounds());
+  // #67: lazy init — reached through a call now.
+  ASSERT_EQ(&AlgoMetadata<Algo::ALGO_2>::bounds(), &algo2::bounds());
 }
 
 

--- a/src/test/lunar/algo2_test.cpp
+++ b/src/test/lunar/algo2_test.cpp
@@ -290,7 +290,8 @@ TEST(LunarAlgo2, MetadataSharesCache) {
   // #78: `AlgoMetadata` must bind the namespace-level cached function, not copy it —
   // a copied `std::function` forks its own cache replica and recomputes from scratch.
   ASSERT_EQ(&AlgoMetadata<Algo::ALGO_2>::get_info_for_year, &algo2::get_info_for_year);
-  ASSERT_EQ(&AlgoMetadata<Algo::ALGO_2>::bounds, &algo2::bounds);
+  // #67: `bounds` is a function-local static now (lazy init), reached through a function call.
+  ASSERT_EQ(&AlgoMetadata<Algo::ALGO_2>::bounds, &algo2::bounds());
 }
 
 

--- a/src/test/lunar/converter_test.cpp
+++ b/src/test/lunar/converter_test.cpp
@@ -173,7 +173,7 @@ TEST(Converter, GregorianToLunarAlgo1) {
   using AlgoMetadata = common::AlgoMetadata<common::Algo::ALGO_1>;
   using Converter = converter::Converter<common::Algo::ALGO_1>;
 
-  for (auto year = AlgoMetadata::bounds.start_lunar_year; year <= AlgoMetadata::bounds.end_lunar_year; ++year) {
+  for (auto year = AlgoMetadata::bounds().start_lunar_year; year <= AlgoMetadata::bounds().end_lunar_year; ++year) {
     const auto& info = AlgoMetadata::get_info_for_year(year);
     ASSERT_EQ(util::to_ymd(year, 1, 1), Converter::gregorian_to_lunar(info.date_of_first_day));
 
@@ -199,8 +199,8 @@ TEST(Converter, GregorianToLunarAlgo2) {
   std::set<int32_t> years;
   for (auto _ = 0; _ < 8; ++_) {
     years.insert(
-      util::random(AlgoMetadata::bounds.start_lunar_year, 
-                   AlgoMetadata::bounds.end_lunar_year
+      util::random(AlgoMetadata::bounds().start_lunar_year, 
+                   AlgoMetadata::bounds().end_lunar_year
       )
     );
   }
@@ -227,7 +227,7 @@ TEST(Converter, GregorianToLunarAlgo3) {
   using AlgoMetadata = common::AlgoMetadata<common::Algo::ALGO_3>;
   using Converter = converter::Converter<common::Algo::ALGO_3>;
 
-  for (auto year = AlgoMetadata::bounds.start_lunar_year; year <= AlgoMetadata::bounds.end_lunar_year; ++year) {
+  for (auto year = AlgoMetadata::bounds().start_lunar_year; year <= AlgoMetadata::bounds().end_lunar_year; ++year) {
     const auto& info = AlgoMetadata::get_info_for_year(year);
     ASSERT_EQ(util::to_ymd(year, 1, 1), Converter::gregorian_to_lunar(info.date_of_first_day));
 
@@ -249,7 +249,7 @@ TEST(Converter, LunarToGregorianAlgo1) {
   using AlgoMetadata = common::AlgoMetadata<common::Algo::ALGO_1>;
   using Converter = converter::Converter<common::Algo::ALGO_1>;
 
-  for (auto year = AlgoMetadata::bounds.start_lunar_year; year <= AlgoMetadata::bounds.end_lunar_year; ++year) {
+  for (auto year = AlgoMetadata::bounds().start_lunar_year; year <= AlgoMetadata::bounds().end_lunar_year; ++year) {
     const auto& info = AlgoMetadata::get_info_for_year(year);
     ASSERT_EQ(info.date_of_first_day, Converter::lunar_to_gregorian(util::to_ymd(year, 1, 1)));
 
@@ -275,8 +275,8 @@ TEST(Converter, LunarToGregorianAlgo2) {
   std::set<int32_t> years;
   for (auto _ = 0; _ < 8; ++_) {
     years.insert(
-      util::random(AlgoMetadata::bounds.start_lunar_year, 
-                   AlgoMetadata::bounds.end_lunar_year
+      util::random(AlgoMetadata::bounds().start_lunar_year, 
+                   AlgoMetadata::bounds().end_lunar_year
       )
     );
   }
@@ -303,7 +303,7 @@ TEST(Converter, LunarToGregorianAlgo3) {
   using AlgoMetadata = common::AlgoMetadata<common::Algo::ALGO_3>;
   using Converter = converter::Converter<common::Algo::ALGO_3>;
 
-  for (auto year = AlgoMetadata::bounds.start_lunar_year; year <= AlgoMetadata::bounds.end_lunar_year; ++year) {
+  for (auto year = AlgoMetadata::bounds().start_lunar_year; year <= AlgoMetadata::bounds().end_lunar_year; ++year) {
     const auto& info = AlgoMetadata::get_info_for_year(year);
     ASSERT_EQ(info.date_of_first_day, Converter::lunar_to_gregorian(util::to_ymd(year, 1, 1)));
 
@@ -327,9 +327,9 @@ TEST(Converter, IntegrationAlgo1) {
   using AlgoMetadata = common::AlgoMetadata<common::Algo::ALGO_1>;
   using Converter = converter::Converter<common::Algo::ALGO_1>;
 
-  const uint32_t difference = (sys_days(AlgoMetadata::bounds.last_gregorian_date) - sys_days(AlgoMetadata::bounds.first_gregorian_date)).count();
+  const uint32_t difference = (sys_days(AlgoMetadata::bounds().last_gregorian_date) - sys_days(AlgoMetadata::bounds().first_gregorian_date)).count();
   for (auto _ = 0; _ < 5000; ++_) {
-    const year_month_day solar_date = AlgoMetadata::bounds.first_gregorian_date + util::random<uint32_t>(0, difference);
+    const year_month_day solar_date = AlgoMetadata::bounds().first_gregorian_date + util::random<uint32_t>(0, difference);
     ASSERT_TRUE(Converter::is_valid_gregorian(solar_date));
 
     const std::optional<year_month_day> optional_lunar_date = Converter::gregorian_to_lunar(solar_date);
@@ -351,9 +351,9 @@ TEST(Converter, IntegrationAlgo2) {
   using AlgoMetadata = common::AlgoMetadata<common::Algo::ALGO_2>;
   using Converter = converter::Converter<common::Algo::ALGO_2>;
 
-  const uint32_t difference = (sys_days(AlgoMetadata::bounds.last_gregorian_date) - sys_days(AlgoMetadata::bounds.first_gregorian_date)).count();
+  const uint32_t difference = (sys_days(AlgoMetadata::bounds().last_gregorian_date) - sys_days(AlgoMetadata::bounds().first_gregorian_date)).count();
   for (auto _ = 0; _ < 16; ++_) {
-    const year_month_day solar_date = AlgoMetadata::bounds.first_gregorian_date + util::random<uint32_t>(0, difference);
+    const year_month_day solar_date = AlgoMetadata::bounds().first_gregorian_date + util::random<uint32_t>(0, difference);
     ASSERT_TRUE(Converter::is_valid_gregorian(solar_date));
 
     const std::optional<year_month_day> optional_lunar_date = Converter::gregorian_to_lunar(solar_date);
@@ -375,9 +375,9 @@ TEST(Converter, IntegrationAlgo3) {
   using AlgoMetadata = common::AlgoMetadata<common::Algo::ALGO_3>;
   using Converter = converter::Converter<common::Algo::ALGO_3>;
 
-  const uint32_t difference = (sys_days(AlgoMetadata::bounds.last_gregorian_date) - sys_days(AlgoMetadata::bounds.first_gregorian_date)).count();
+  const uint32_t difference = (sys_days(AlgoMetadata::bounds().last_gregorian_date) - sys_days(AlgoMetadata::bounds().first_gregorian_date)).count();
   for (auto _ = 0; _ < 5000; ++_) {
-    const year_month_day solar_date = AlgoMetadata::bounds.first_gregorian_date + util::random<uint32_t>(0, difference);
+    const year_month_day solar_date = AlgoMetadata::bounds().first_gregorian_date + util::random<uint32_t>(0, difference);
     ASSERT_TRUE(Converter::is_valid_gregorian(solar_date));
 
     const std::optional<year_month_day> optional_lunar_date = Converter::gregorian_to_lunar(solar_date);

--- a/src/test/shared_lib/cabi_smoke_test.cpp
+++ b/src/test/shared_lib/cabi_smoke_test.cpp
@@ -1,0 +1,232 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2026 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// #67: smoke tests for the C-ABI layer — every export is driven across the real
+// `extern "C"` boundary (this target links the built shared library), including the
+// `valid = false` paths: bad arguments, NaN, null out-pointers, and a closed stdout.
+
+#include <array>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "celestial.h"
+
+#ifdef _WIN32
+  #include <io.h>
+#else
+  #include <unistd.h>
+#endif
+
+
+namespace {
+
+#ifdef _WIN32
+auto dup_fd(const int fd) -> int { return ::_dup(fd); }
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) — mirrors `_dup2`'s own signature.
+auto dup2_fd(const int from, const int to) -> int { return ::_dup2(from, to); }
+auto close_fd(const int fd) -> int { return ::_close(fd); }
+auto stdout_fileno() -> int { return ::_fileno(stdout); }
+#else
+auto dup_fd(const int fd) -> int { return ::dup(fd); }
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) — mirrors `dup2`'s own signature.
+auto dup2_fd(const int from, const int to) -> int { return ::dup2(from, to); }
+auto close_fd(const int fd) -> int { return ::close(fd); }
+auto stdout_fileno() -> int { return ::fileno(stdout); }
+#endif
+
+constexpr double NAN_VALUE = std::numeric_limits<double>::quiet_NaN();
+
+} // namespace
+
+
+TEST(CAbiSmoke, LogVerbosity) {
+  EXPECT_TRUE(set_log_verbosity(0));
+  EXPECT_TRUE(set_log_verbosity(1));
+  EXPECT_TRUE(set_log_verbosity(2));
+  EXPECT_FALSE(set_log_verbosity(3)); // Verbosity::COUNT
+}
+
+
+TEST(CAbiSmoke, DeltaT) {
+  EXPECT_TRUE(delta_t(2024.5).valid);
+  EXPECT_TRUE(delta_t_algo1(2024.5).valid);
+  EXPECT_TRUE(delta_t_algo2(2024.5).valid);
+  EXPECT_TRUE(delta_t_algo3(2024.5).valid);
+  EXPECT_TRUE(delta_t_algo4(2024.5).valid);
+  EXPECT_TRUE(delta_t_algo5(2024.5).valid);
+}
+
+
+TEST(CAbiSmoke, Ut1ToJd) {
+  // 2024-06-01 12:00 UT1 is JD 2460463.0 (USNO, https://aa.usno.navy.mil/data/JulianDate).
+  const JulianDay jd = ut1_to_jd(2024, 6, 1, 0.5);
+  ASSERT_TRUE(jd.valid);
+  ASSERT_NEAR(jd.value, 2460463.0, 1e-6);
+}
+
+TEST(CAbiSmoke, Ut1ToJdRejectsBadInput) {
+  EXPECT_FALSE(ut1_to_jd(2024, 6, 1, 1.5).valid);        // fraction >= 1
+  EXPECT_FALSE(ut1_to_jd(2024, 6, 1, -0.1).valid);       // fraction < 0
+  EXPECT_FALSE(ut1_to_jd(2024, 6, 1, NAN_VALUE).valid);  // NaN slips past `<`-style checks
+  EXPECT_FALSE(ut1_to_jd(2024, 13, 1, 0.5).valid);       // invalid month
+  EXPECT_FALSE(ut1_to_jd(0, 6, 1, 0.5).valid);           // year < 1
+}
+
+
+TEST(CAbiSmoke, Ut1ToJde) {
+  const JulianDay jde = ut1_to_jde(2024, 6, 1, 0.5);
+  ASSERT_TRUE(jde.valid);
+  // JDE is JD plus ΔT (~69 s ≈ 8e-4 day), so it must sit above the plain JD.
+  EXPECT_GT(jde.value, 2460463.0);
+}
+
+TEST(CAbiSmoke, JdeToUt1) {
+  const UT1Time ut1 = jde_to_ut1(2460463.0);
+  ASSERT_TRUE(ut1.valid);
+  // ΔT ≈ 69 s cannot flip the civil date of a noon moment.
+  EXPECT_EQ(ut1.year, 2024);
+  EXPECT_EQ(ut1.month, 6U);
+  EXPECT_EQ(ut1.day, 1U);
+}
+
+TEST(CAbiSmoke, JdeToUt1RejectsBadInput) {
+  EXPECT_FALSE(jde_to_ut1(NAN_VALUE).valid);  // non-finite
+  EXPECT_FALSE(jde_to_ut1(1000.0).valid);     // gregorian year < 401
+  EXPECT_FALSE(jde_to_ut1(13689325.5).valid); // first JD beyond the representable years
+  EXPECT_FALSE(jde_to_ut1(4.0e9).valid);      // uint32 wrap: valid-looking but wrong date
+}
+
+
+// #97 pilot: the Julian Day exports record *why* they failed, readable via `last_error`.
+TEST(CAbiSmoke, LastErrorPilot) {
+  ASSERT_FALSE(ut1_to_jd(2024, 6, 1, NAN_VALUE).valid);
+  EXPECT_NE(std::strstr(last_error(), "fraction"), nullptr);
+
+  ASSERT_FALSE(jde_to_ut1(NAN_VALUE).valid);
+  EXPECT_NE(std::strstr(last_error(), "not finite"), nullptr);
+
+  ASSERT_TRUE(ut1_to_jd(2024, 6, 1, 0.5).valid);
+  EXPECT_STREQ(last_error(), "");
+}
+
+
+TEST(CAbiSmoke, SunMoonCoords) {
+  const SunCoordinate sun = sun_apparent_geocentric_coord(2460463.0);
+  ASSERT_TRUE(sun.valid);
+  EXPECT_GE(sun.lon, 0.0);
+  EXPECT_LT(sun.lon, 360.0);
+
+  const MoonCoordinate moon = moon_apparent_geocentric_coord(2460463.0);
+  ASSERT_TRUE(moon.valid);
+  EXPECT_GE(moon.lon, 0.0);
+  EXPECT_LT(moon.lon, 360.0);
+}
+
+
+TEST(CAbiSmoke, SolarLonRoots) {
+  const Discriminant disc = solar_lon_root_discriminant(2024, 0.0);
+  ASSERT_TRUE(disc.valid);
+  ASSERT_EQ(disc.count, 1U); // The Sun crosses longitude 0° (春分) once a year.
+
+  std::array<double, 2> slots {};
+  EXPECT_EQ(solar_lon_roots(2024, 0.0, slots.data(), slots.size()), 1U);
+  EXPECT_EQ(solar_lon_roots(2024, 0.0, nullptr, 2), 0U); // null out-pointer
+}
+
+
+TEST(CAbiSmoke, NewMoons) {
+  std::array<double, 3> after {};
+  ASSERT_EQ(new_moons_after_jde(2460463.0, after.data(), after.size()), 3U);
+  EXPECT_LT(after.at(0), after.at(1));
+  EXPECT_LT(after.at(1), after.at(2));
+  EXPECT_EQ(new_moons_after_jde(2460463.0, nullptr, 3), 0U); // null out-pointer
+
+  uint32_t root_count = 0;
+  std::array<double, 15> slots {};
+  const uint32_t written = new_moons_in_year(2024, &root_count, slots.data(), slots.size());
+  EXPECT_EQ(written, root_count);
+  EXPECT_TRUE(root_count == 12U or root_count == 13U);
+  EXPECT_EQ(new_moons_in_year(2024, nullptr, slots.data(), slots.size()), 0U); // null root_count
+  EXPECT_EQ(new_moons_in_year(2024, &root_count, nullptr, 15), 0U);            // null slots
+}
+
+
+TEST(CAbiSmoke, Jieqi) {
+  const JieqiMomentQuery query = query_jieqi_moment(2024, 0); // 立春
+  ASSERT_TRUE(query.valid);
+  EXPECT_EQ(query.jq_idx, 0U);
+  EXPECT_EQ(query.y, 2024);
+  EXPECT_EQ(query.m, 2U);
+  EXPECT_FALSE(query_jieqi_moment(2024, 24).valid); // jq_idx out of range
+
+  std::array<char, 32> buf {};
+  ASSERT_TRUE(get_jieqi_name(0, buf.data(), buf.size()));
+  EXPECT_STREQ(buf.data(), "立春");
+  EXPECT_FALSE(get_jieqi_name(0, buf.data(), 2));       // buffer too small
+  EXPECT_FALSE(get_jieqi_name(0, nullptr, buf.size())); // null out-pointer
+  EXPECT_FALSE(get_jieqi_name(24, buf.data(), buf.size()));
+}
+
+
+TEST(CAbiSmoke, Lunar) {
+  const SupportedLunarYearRange range1 = get_supported_lunar_year_range(1);
+  ASSERT_TRUE(range1.valid);
+  EXPECT_LT(range1.start, range1.end);
+
+  const SupportedLunarYearRange range2 = get_supported_lunar_year_range(2);
+  ASSERT_TRUE(range2.valid);
+  EXPECT_LT(range2.start, range2.end);
+
+  EXPECT_FALSE(get_supported_lunar_year_range(0).valid);
+  EXPECT_FALSE(get_supported_lunar_year_range(3).valid);
+
+  EXPECT_TRUE(get_lunar_year_info(2, 2024).valid);
+  EXPECT_FALSE(get_lunar_year_info(9, 2024).valid); // unsupported algorithm
+}
+
+
+// #67: `std::println` throws `std::system_error` on a failed stream — with stdout closed,
+// the log call inside a catch handler must not escape and terminate the host.
+TEST(CAbiSmoke, LoggingSurvivesClosedStdout) {
+  ASSERT_TRUE(set_log_verbosity(1)); // INFO, so the failing call below really logs.
+
+  // stdout is fully buffered when piped (ctest/CI), and a buffered `println` never touches
+  // the fd — go unbuffered, or the write failure never surfaces during the closed window.
+  ASSERT_EQ(std::setvbuf(stdout, nullptr, _IONBF, 0), 0);
+
+  const int saved = dup_fd(stdout_fileno());
+  ASSERT_GE(saved, 0);
+  ASSERT_EQ(close_fd(stdout_fileno()), 0);
+
+  const JulianDay jd = ut1_to_jd(2024, 6, 1, NAN_VALUE); // logs via `lib::info` on failure
+
+  ASSERT_EQ(dup2_fd(saved, stdout_fileno()), stdout_fileno());
+  ASSERT_EQ(close_fd(saved), 0);
+  std::clearerr(stdout); // the failed writes above set the stream's error indicator
+  ASSERT_TRUE(set_log_verbosity(2)); // restore the default
+
+  EXPECT_FALSE(jd.valid);
+}

--- a/src/test/shared_lib/cabi_smoke_test.cpp
+++ b/src/test/shared_lib/cabi_smoke_test.cpp
@@ -26,6 +26,7 @@
 // `valid = false` paths: bad arguments, NaN, null out-pointers, and a closed stdout.
 
 #include <array>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <limits>
@@ -171,6 +172,31 @@ TEST(CAbiSmoke, NewMoons) {
   EXPECT_TRUE(root_count == 12U or root_count == 13U);
   EXPECT_EQ(new_moons_in_year(2024, nullptr, slots.data(), slots.size()), 0U); // null root_count
   EXPECT_EQ(new_moons_in_year(2024, &root_count, nullptr, 15), 0U);            // null slots
+}
+
+
+TEST(CAbiSmoke, EquationOfTime) {
+  const EquationOfTime e = equation_of_time(2460463.0);
+  ASSERT_TRUE(e.valid);
+  EXPECT_LT(std::fabs(e.value), 5.0); // |E| stays under 5° (Meeus ch. 28).
+
+  EXPECT_FALSE(equation_of_time(NAN_VALUE).valid); // non-finite JDE
+}
+
+
+TEST(CAbiSmoke, ApparentSolarTime) {
+  // UTC noon at 116.4°E: apparent time ≈ noon + longitude-in-time ± |E| (< 5°).
+  const SolarTime t = apparent_solar_time(2024, 6, 1, 0.5, 116.4);
+  ASSERT_TRUE(t.valid);
+  EXPECT_EQ(t.year, 2024);
+  EXPECT_EQ(t.month, 6U);
+  EXPECT_EQ(t.day, 1U);
+  EXPECT_GT(t.fraction, 0.5 + 111.4 / 360.0);
+  EXPECT_LT(t.fraction, 0.5 + 121.4 / 360.0);
+
+  EXPECT_FALSE(apparent_solar_time(2024, 6, 1, 0.5, 200.0).valid);     // longitude out of range
+  EXPECT_FALSE(apparent_solar_time(2024, 6, 1, 0.5, NAN_VALUE).valid); // NaN longitude
+  EXPECT_FALSE(apparent_solar_time(2024, 6, 1, NAN_VALUE, 116.4).valid); // NaN fraction
 }
 
 

--- a/src/test/shared_lib/cabi_smoke_test.cpp
+++ b/src/test/shared_lib/cabi_smoke_test.cpp
@@ -60,6 +60,28 @@ auto stdout_fileno() -> int { return ::fileno(stdout); }
 
 constexpr double NAN_VALUE = std::numeric_limits<double>::quiet_NaN();
 
+// Restores stdout on destruction, so an early ASSERT return cannot leak the saved fd
+// or leave stdout closed.
+struct StdoutGuard {
+  int saved;
+
+  StdoutGuard()
+    : saved { dup_fd(stdout_fileno()) }
+  {
+    if (saved >= 0) {
+      close_fd(stdout_fileno());
+    }
+  }
+
+  ~StdoutGuard() {
+    if (saved >= 0) {
+      dup2_fd(saved, stdout_fileno());
+      close_fd(saved);
+      std::clearerr(stdout); // the failed writes set the stream's error indicator
+    }
+  }
+};
+
 } // namespace
 
 
@@ -78,6 +100,21 @@ TEST(CAbiSmoke, DeltaT) {
   EXPECT_TRUE(delta_t_algo3(2024.5).valid);
   EXPECT_TRUE(delta_t_algo4(2024.5).valid);
   EXPECT_TRUE(delta_t_algo5(2024.5).valid);
+}
+
+TEST(CAbiSmoke, DeltaTRejectsNonFiniteYear) {
+  EXPECT_FALSE(delta_t(NAN_VALUE).valid);
+  EXPECT_FALSE(delta_t(HUGE_VAL).valid);
+  EXPECT_FALSE(delta_t_algo1(NAN_VALUE).valid);
+  EXPECT_FALSE(delta_t_algo1(HUGE_VAL).valid);
+  EXPECT_FALSE(delta_t_algo2(NAN_VALUE).valid);
+  EXPECT_FALSE(delta_t_algo2(HUGE_VAL).valid);
+  EXPECT_FALSE(delta_t_algo3(NAN_VALUE).valid);
+  EXPECT_FALSE(delta_t_algo3(HUGE_VAL).valid);
+  EXPECT_FALSE(delta_t_algo4(NAN_VALUE).valid);
+  EXPECT_FALSE(delta_t_algo4(HUGE_VAL).valid);
+  EXPECT_FALSE(delta_t_algo5(NAN_VALUE).valid);
+  EXPECT_FALSE(delta_t_algo5(HUGE_VAL).valid);
 }
 
 
@@ -144,6 +181,11 @@ TEST(CAbiSmoke, SunMoonCoords) {
   ASSERT_TRUE(moon.valid);
   EXPECT_GE(moon.lon, 0.0);
   EXPECT_LT(moon.lon, 360.0);
+
+  EXPECT_FALSE(sun_apparent_geocentric_coord(NAN_VALUE).valid);  // non-finite JDE
+  EXPECT_FALSE(sun_apparent_geocentric_coord(HUGE_VAL).valid);
+  EXPECT_FALSE(moon_apparent_geocentric_coord(NAN_VALUE).valid);
+  EXPECT_FALSE(moon_apparent_geocentric_coord(HUGE_VAL).valid);
 }
 
 
@@ -155,6 +197,11 @@ TEST(CAbiSmoke, SolarLonRoots) {
   std::array<double, 2> slots {};
   EXPECT_EQ(solar_lon_roots(2024, 0.0, slots.data(), slots.size()), 1U);
   EXPECT_EQ(solar_lon_roots(2024, 0.0, nullptr, 2), 0U); // null out-pointer
+
+  EXPECT_FALSE(solar_lon_root_discriminant(2024, NAN_VALUE).valid); // non-finite longitude
+  EXPECT_FALSE(solar_lon_root_discriminant(2024, HUGE_VAL).valid);
+  EXPECT_EQ(solar_lon_roots(2024, NAN_VALUE, slots.data(), slots.size()), 0U);
+  EXPECT_EQ(solar_lon_roots(2024, HUGE_VAL, slots.data(), slots.size()), 0U);
 }
 
 
@@ -164,6 +211,8 @@ TEST(CAbiSmoke, NewMoons) {
   EXPECT_LT(after.at(0), after.at(1));
   EXPECT_LT(after.at(1), after.at(2));
   EXPECT_EQ(new_moons_after_jde(2460463.0, nullptr, 3), 0U); // null out-pointer
+  EXPECT_EQ(new_moons_after_jde(NAN_VALUE, after.data(), after.size()), 0U); // non-finite JDE
+  EXPECT_EQ(new_moons_after_jde(HUGE_VAL, after.data(), after.size()), 0U);
 
   uint32_t root_count = 0;
   std::array<double, 15> slots {};
@@ -186,7 +235,7 @@ TEST(CAbiSmoke, EquationOfTime) {
 
 TEST(CAbiSmoke, ApparentSolarTime) {
   // UTC noon at 116.4°E: apparent time ≈ noon + longitude-in-time ± |E| (< 5°).
-  const SolarTime t = apparent_solar_time(2024, 6, 1, 0.5, 116.4);
+  const ApparentSolarTime t = apparent_solar_time(2024, 6, 1, 0.5, 116.4);
   ASSERT_TRUE(t.valid);
   EXPECT_EQ(t.year, 2024);
   EXPECT_EQ(t.month, 6U);
@@ -243,16 +292,11 @@ TEST(CAbiSmoke, LoggingSurvivesClosedStdout) {
   // the fd — go unbuffered, or the write failure never surfaces during the closed window.
   ASSERT_EQ(std::setvbuf(stdout, nullptr, _IONBF, 0), 0);
 
-  const int saved = dup_fd(stdout_fileno());
-  ASSERT_GE(saved, 0);
-  ASSERT_EQ(close_fd(stdout_fileno()), 0);
+  const StdoutGuard guard {}; // dups stdout, then closes it until scope exit
+  ASSERT_GE(guard.saved, 0);
 
   const JulianDay jd = ut1_to_jd(2024, 6, 1, NAN_VALUE); // logs via `lib::info` on failure
 
-  ASSERT_EQ(dup2_fd(saved, stdout_fileno()), stdout_fileno());
-  ASSERT_EQ(close_fd(saved), 0);
-  std::clearerr(stdout); // the failed writes above set the stream's error indicator
   ASSERT_TRUE(set_log_verbosity(2)); // restore the default
-
   EXPECT_FALSE(jd.valid);
 }

--- a/src/test/shared_lib/cabi_smoke_test.cpp
+++ b/src/test/shared_lib/cabi_smoke_test.cpp
@@ -34,6 +34,7 @@
 #include <gtest/gtest.h>
 
 #include "celestial.h"
+#include "lib.hpp" // the logging-swallow test drives `lib::info` directly
 
 #ifdef _WIN32
   #include <io.h>
@@ -44,12 +45,14 @@
 
 namespace {
 
+// [[maybe_unused]] on the Windows wrappers: `LoggingSurvivesClosedStdout` is skipped on
+// Windows (UCRT fail-fasts on closed-fd writes), so nothing odr-uses them there.
 #ifdef _WIN32
-auto dup_fd(const int fd) -> int { return ::_dup(fd); }
+[[maybe_unused]] auto dup_fd(const int fd) -> int { return ::_dup(fd); }
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) — mirrors `_dup2`'s own signature.
-auto dup2_fd(const int from, const int to) -> int { return ::_dup2(from, to); }
-auto close_fd(const int fd) -> int { return ::_close(fd); }
-auto stdout_fileno() -> int { return ::_fileno(stdout); }
+[[maybe_unused]] auto dup2_fd(const int from, const int to) -> int { return ::_dup2(from, to); }
+[[maybe_unused]] auto close_fd(const int fd) -> int { return ::_close(fd); }
+[[maybe_unused]] auto stdout_fileno() -> int { return ::_fileno(stdout); }
 #else
 auto dup_fd(const int fd) -> int { return ::dup(fd); }
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) — mirrors `dup2`'s own signature.
@@ -72,6 +75,11 @@ struct StdoutGuard {
       close_fd(stdout_fileno());
     }
   }
+
+  StdoutGuard(const StdoutGuard&) = delete;
+  auto operator=(const StdoutGuard&) -> StdoutGuard& = delete;
+  StdoutGuard(StdoutGuard&&) = delete;
+  auto operator=(StdoutGuard&&) -> StdoutGuard& = delete;
 
   ~StdoutGuard() {
     if (saved >= 0) {
@@ -286,6 +294,12 @@ TEST(CAbiSmoke, Lunar) {
 // #67: `std::println` throws `std::system_error` on a failed stream — with stdout closed,
 // the log call inside a catch handler must not escape and terminate the host.
 TEST(CAbiSmoke, LoggingSurvivesClosedStdout) {
+#ifdef _WIN32
+  // UCRT routes writes to a closed fd through the invalid-parameter handler, which is a
+  // process-level `__fastfail` (0xc0000409) in release — not a C++ exception the library
+  // could swallow. The portable counterpart below covers the same swallow path.
+  GTEST_SKIP() << "UCRT fail-fasts on writes to closed fds — not an exception path";
+#else
   ASSERT_TRUE(set_log_verbosity(1)); // INFO, so the failing call below really logs.
 
   // stdout is fully buffered when piped (ctest/CI), and a buffered `println` never touches
@@ -299,4 +313,12 @@ TEST(CAbiSmoke, LoggingSurvivesClosedStdout) {
 
   ASSERT_TRUE(set_log_verbosity(2)); // restore the default
   EXPECT_FALSE(jd.valid);
+#endif
+}
+
+
+// Portable counterpart of the test above: `std::vformat` throws `std::format_error` on a
+// runtime bad format string, and `log_noexcept` must swallow it on every platform.
+TEST(CAbiSmoke, LoggingSwallowsBadFormatString) {
+  ASSERT_NO_THROW(lib::info("{"));
 }


### PR DESCRIPTION
## 内容

#67 C-ABI 安全加固，四类问题全覆盖：

- **A 异常穿越**：23 个导出统一 `catch (const std::exception&)` + `catch (...)` 双兜底，异常降级为 `valid = false` / `0`，绝不逃出 `extern "C"` 边界。`log_noexcept` / `set_last_error` 真 `noexcept`，兜住 catch handler 内的二次抛出（bad_alloc）。
- **B 入参校验**：裸指针 null 前置拒绝（提前 return）；`uint8_t` 枚举码越界拒绝；`validate_fraction` 用 `not (x >= lo and x < hi)` 挡 NaN；`jd_to_ut1` 上界收紧到 13689325.5（chrono year 上限 32767，2e7/4e9 的 uint32 回绕垃圾有实证）；delta_t(year) / sun/moon(jde) / solar_lon(longitude) / new_moons(jde) 补 `isfinite` 守卫；EoT 的 jde 守卫在导出层（与 sun/moon 同形；core 保持全库一致的 NaN 静默传播）。
- **C 线程安全**：`GLOBAL_VERBOSITY` 原子化，`set_verbosity` 单次校验 + 返回 `bool`（消除 store-load 竞态与双重校验）；`LAST_ERROR` thread_local。
- **D 指针出参 + 测试**：手写发布头 `src/shared_lib/celestial.h`（纯 C，struct 布局 SSOT，完整 Doxygen 契约收敛于此）；`c_header_check.c` 以 `_Static_assert` 钉布局 + `C_EXTENSIONS OFF` 真检 ISO C；`cabi_smoke_test.cpp` 逐个调用全部 23 个导出含失败路径。

附带（同 seams）：导出 Phase D 的 `equation_of_time` / `apparent_solar_time`（#56 接缝，归本线）；#97 last_error 试点（仅 Julian Day 三函数，契约措辞已收紧）；`AlgoMetadata::bounds` 三家统一为访问器函数——inline 静态成员的急切绑定会在镜像加载期初始化，抵消 algo2 的 lazy-init（终审 M-1，nm 验证 dylib 符号已消失）。

## 测试

199/199 全绿（含 Windows 跳过 `LoggingSurvivesClosedStdout` 后的可移植替代 `LoggingSwallowsBadFormatString`——UCRT 对已关闭 fd 的写入走 `__fastfail`(0xc0000409)，非异常路径，`catch(...)` 原理上拦不住；`celestial.h` 已补平台注意）。新增：非法入参用例（NaN / HUGE_VAL / null / 越界枚举，逐导出）、`DeltaTRejectsNonFiniteYear`、`LoggingSurvivesClosedStdout`（RAII `StdoutGuard`）、`LastErrorPilot` 生命周期、边界 13689325.5 恰可转/+1ulp 拒绝。

## 验证

- 检出率探针 ×7：逐一注入旧行为（摘除守卫/恢复回绕上界/去 noexcept/去 null 判空）确认对应测试必挂，恢复后全绿。
- 双轮四家审阅：正确性轮 kimi × grok、风格轮 kimi × opus，findings 全部裁决落地；fable 终审抓 M-1（lazy-init 抵消，二进制证据链）修复后定向复核清场。
- 构建零警告（含 `c_header_check` ISO C11）；`nm` 验证 AlgoMetadata eager 成员/guard 不再落入 dylib。

## 范围说明

- #97 只做 last_error 试点（Julian Day 三导出），全量铺开另行立项；#91 不做。
- 既有 core 模块（delta_t/sun/moon/solar_lon）的 finite 守卫留在 C-ABI 层不上移 core——改 core 抛掷行为是既有 C++ 调用方的契约变更，backlog 另记。
- EoT 对"巨大但有限" JDE 的 domain 政策与 core 一致，不在 C-ABI 层额外收紧。
- core 层一律 NaN 静默传播（#116 终审确立的一致性）；所有 isfinite 守卫统一放 C-ABI 导出层。
- 导出符号不加前缀是刻意决策（与 0.3.0 起既有导出一致），已写进 `celestial.h` 头注释；`JieqiMomentQuery` 字段命名（y/m/d/frac vs year/month/day/fraction）的统一记入 backlog（下次 major）。
- 知会：#117 flake 与本线无关，未触碰。

Closes #67
