### PR TITLE
fix(astro): resolve year boundaries via UTC, not UT1 (#115)

### DIFF
--- a/src/astro/sun.hpp
+++ b/src/astro/sun.hpp
@@ -187,13 +187,17 @@ inline auto solar_longitude(const double jde) -> double {
 }
 
 /** @brief Return the JDE of the start of the year. */
+// #115: year boundaries are civil moments — resolve them via the UTC (leap-second-aware)
+// path, matching `moments()` (#84). The UT1/UTC model gap (DUT1 ≤ 0.9 s in the leap era;
+// ≤ ~21 h at year 6772 with the ΔAT table frozen) stays well under the ~4-day clearance
+// between any jieqi and New Year — no year's attribution can move.
 inline auto get_start_jde(const int32_t year) -> double{
-  return astro::julian_day::ut1_to_jde(calendar::Datetime { util::to_ymd(year, 1, 1), 0.0 });
+  return astro::julian_day::utc_to_jde(calendar::Datetime { util::to_ymd(year, 1, 1), 0.0 });
 }
 
 /** @brief Return the JDE of the end of the year. */
 inline auto get_end_jde(const int32_t year) -> double {
-  return astro::julian_day::ut1_to_jde(calendar::Datetime { util::to_ymd(year + 1, 1, 1), 0.0 });
+  return astro::julian_day::utc_to_jde(calendar::Datetime { util::to_ymd(year + 1, 1, 1), 0.0 });
 }
 
 /** @brief Return the apparent geocentric longitude of the Sun at the start of the year. */

--- a/src/calendar/jieqi.hpp
+++ b/src/calendar/jieqi.hpp
@@ -164,7 +164,10 @@ const inline auto jieqi_jde = util::cache::cache_func(calc_jieqi_jde);
  * @return The UT1 (Universal Time 1).
  * @details This is just a thin wrapper around `jieqi_jde`.
  * @note UT1, not UTC — the lunar-calendar rules render civil moments through the
- *       leap-second-aware path instead (#84).
+ *       leap-second-aware path instead (#84). Remaining consumers: the C-ABI
+ *       `query_jieqi_moment` (contract: `celestial.h`) and the HKO golden axis; UT1 stays
+ *       for contract stability. The UT1/UTC gap is DUT1 (≤ 0.9 s while leap seconds are
+ *       applied); past the ΔAT table freeze it follows ΔT−(ΔAT+32.184) (#115).
  */
 inline auto jieqi_ut1_moment(const int32_t year, const Jieqi jq) -> calendar::Datetime {
   return astro::julian_day::jde_to_ut1(jieqi_jde(year, jq));
@@ -181,8 +184,9 @@ private:
 
 public:
   explicit JieqiGenerator(const double start_jde) {
-    const auto start_ut1 = astro::julian_day::jde_to_ut1(start_jde);
-    const auto start_year = start_ut1.year();
+    // #115: the start year is a civil concept — resolve it in UTC, matching `moments()` (#84).
+    const auto start_utc = astro::julian_day::jde_to_utc(start_jde);
+    const auto start_year = start_utc.year();
 
     // Find the first Jieqi after the given JDE.
     _year = start_year;

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -261,6 +261,9 @@ typedef struct JieqiMomentQuery {
  * @param year The year, in gregorian calendar.
  * @param jq_idx The index of the Jieqi. Expected to be in the range [0, 24).
  * @returns A `JieqiMomentQuery` struct.
+ * @note The returned civil moment is UT1; while leap seconds are applied it matches UTC
+ *       to within DUT1 (±0.9 s), so modern-era civil consumers may treat it as UTC.
+ *       Past the ΔAT table freeze the modelled gap follows ΔT−(ΔAT+32.184) (#115).
  */
 JieqiMomentQuery query_jieqi_moment(int32_t year, uint8_t jq_idx);
 

--- a/statistics/sun_jieqi_golden_crawler.py
+++ b/statistics/sun_jieqi_golden_crawler.py
@@ -188,8 +188,8 @@ def wrapped_deg(d: float) -> float:
 def approx_jieqi_jd(year: int, lon: float) -> float:
   """Seed the crossing of apparent longitude `lon` that falls inside calendar year `year`.
   Year boundaries here are proleptic-Gregorian civil midnights taken as TT JDs; the C++
-  window (`get_start_jde`) is UT1-based — a delta-T-scale difference (minutes at most),
-  irrelevant for jieqi that sit days from any year boundary. The lon >= 285 block
+  window (`get_start_jde`) resolves them through the UTC→TT path (#115) — a minute-scale
+  difference, irrelevant for jieqi that sit days from any year boundary. The lon >= 285 block
   (XiaoHan..JingZhe) belongs to the solar cycle begun the PREVIOUS March, landing in
   Jan-Mar of `year`."""
   equinox = 2451623.8 + (year - 2000) * 365.2422


### PR DESCRIPTION
Closes #115.

## 内容

#84(PR #114)把 `moments()` 年界改为 UTC 后,同款 UT1 年界模式残留两处,本 PR 统一为 UTC,并顺路清理 `jieqi_ut1_moment` 消费面口径(issue 原列第三项):

- `src/astro/sun.hpp` `get_start_jde`/`get_end_jde`:`ut1_to_jde` → `utc_to_jde`(find_roots 年窗口)。
- `src/calendar/jieqi.hpp` `JieqiGenerator` 构造:`jde_to_ut1` → `jde_to_utc`(推起始年),变量改名 `start_ut1` → `start_utc`。
- 口径注释(doc-only):`jieqi.hpp` `jieqi_ut1_moment` @note 与 `celestial.h` `query_jieqi_moment` @note 写明 UT1/UTC 模型差语义(闰秒适用期 = DUT1 ≤ 0.9 s;ΔAT 表冻结后 = ΔT−(ΔAT+32.184))与剩余消费者清单(C-ABI 契约 + HKO golden 轴;UT1 保留是为契约稳定)。
- 顺手:`statistics/sun_jieqi_golden_crawler.py` docstring 中 `get_start_jde` 的 UT1 旧口径改为 UTC→TT 路径(grok 审阅知情记录项)。

## 测试

- 无新增测试:行为不变是本 PR 的前提(见验证),既有套件全绿即回归证据。
- 本地门禁 `project.py --all`(cmake + build + test + linter)全绿,199/199(P3 审阅修复为注释/docstring-only,不影响构建)。

## 验证

- issue「无正确性后果」评估成立,并经 grok 探针实证:同一 `make_f` 下新旧年窗求根,现代严格同值、极端年差 ≤ 4e-5 s(数值噪声);24 个标准节气黄经无一落入 `discriminant` 翻转带;401–6772 扫描小寒-元旦最小间隔 ~3.08 天 ≫ 模型窗移(5000 年 ~8.7 h、6772 年 ~21.2 h)。
- 1972 接缝:`utc_to_tt` 在此之前退化为 UT1(ΔT 路径),接缝差 ΔT(1972.0) − 42.184 s ≈ 0.07 s,无害。
- 审阅:降档单家快扫(grok)→ **GO,零 P1/P2**;P3 一条(原注释「DUT1 ≤ 0.9 s」对 ΔAT 表冻结后的远未来过度承诺——那是 IERS 政策叙述,非本库模型事实)已采纳,三处注释按「闰秒适用期/表冻结后」两段式重写。

## 范围说明

- 刻意排除:`sun.hpp:260` `make_f` 的 `apr_1st_jde` 仍用 `ut1_to_jde` —— 非年界;阈值平移 ~1 s 不可能翻转 360° 扣除判定(最近的交点春分离 4/1 约 11 天),grok 探针确认。如需统一口径可另开小件。
- C-ABI 数值行为不变:`query_jieqi_moment` 仍返回 UT1(契约稳定,bazi 冻结表不受影响),仅补注释。
- #93/#36 已纯评论处置(#93 completed / #36 not planned),不属本 PR。
