### PR TITLE
docs: #90 残量 + #79 注释漂移 + #80 错别字清扫

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,9 @@ This is precision astronomy, not vibes. Every algorithm traces to a named refere
   stay inside algo5; a new algoN is only for a methodology change. algo1–algo4 are frozen
   exhibits and comparison baselines (algo4: `DeltaT/models.ipynb`, two segments, the 2024.0+
   one fitted on USNO *predictions*; its drift vs truth is measured in #104). In-repo
-  `statistics/` holds evaluation notebooks only. That repo also carries the raw IERS/USNO EOP
-  data and the full VSOP87 coefficient files (coefficient-level audits under #94).
+  `statistics/` holds the evaluation notebooks and the golden-dataset crawlers — no model
+  training. That repo also carries the raw IERS/USNO EOP data and the full VSOP87 coefficient
+  files (coefficient-level audits under #94).
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 * Conversions between Gregorian, Lunar, and Ganzhi dates (公历、阴历、干支历之间的转换)
 * Accurate Jieqi moment queries (查询某一年的某节气的具体时刻)
 * Sunrise, sunset, transit, twilight, and polar day/night queries, within ±2 min of external references (USNO / NOAA / JPL DE) (日出日落、中天、曙暮光、极昼极夜)
+* Geocentric apparent positions: ecliptic coordinates for the Sun and Moon, equatorial for the Sun, plus New Moon moments (日月视位置与合朔)
+* Equation of time and local apparent solar time (均时差与真太阳时)
+* Time scales and time-related quantities: UT1 / UTC / TT with leap seconds and ΔT, Julian Day, sidereal time, obliquity, nutation (时标转换、儒略日、恒星时、黄赤交角、章动)
+* A C ABI shared library (`src/shared_lib/celestial.h`), so the library is consumable from other languages (C 接口动态库)
+
+The supported year range of lunar conversions depends on the algorithm: 1901–2099 for algo1 (Hong Kong Observatory data), 1600–2199 for algo3 (baked table), and 410–5000 for algo2 (computed from VSOP87D / ELP2000-82B — that window is a convention, algo2 itself has no hard limit). In C++ the bounds are the `START_YEAR` / `END_YEAR` constants of each `calendar::lunar::algoN`; the C ABI exports algo1 and algo2, and `get_supported_lunar_year_range` reports their bounds.
 
 ## 2. Requirements
 
@@ -15,6 +21,7 @@
 * CMake >=3.22, and make
 * Python 3, mostly for build automation
   * Install dependencies: `python3 -m pip install -r Requirements.txt`
+  * `Requirements.txt` covers the build/test automation only. The linters come separately (see §4), and the notebooks and crawlers under `statistics/` need `python3 -m pip install -r Requirements-statistics.txt`
 
 ## 3. How to Build
 
@@ -54,6 +61,12 @@ chmod +x project.py
 
 Follow these steps to set up, build, and test the project on Windows. Ensure you have a C++23 compatible compiler installed.
 
+Windows carries neither LLVM nor `make` out of the box, and the build drives CMake through the `Unix Makefiles` generator, so both are needed. Install them first — this is what CI does:
+
+```powershell
+choco install -y make llvm
+```
+
 Before building the project, you should specify the compiler to use. For example, to use `clang++`, run:
 
 ```powershell
@@ -87,7 +100,13 @@ The project is written in C++, and automated with Python scripts.
 
 For C++ codes, `clang-tidy` is used; For Python codes, `ruff` is used.
 
-Ensure `clang-tidy` and `ruff` are installed by `python3 -m pip install -r Requirements.txt`.
+Neither is part of `Requirements.txt` — install them directly, the way CI does:
+
+```sh
+python3 -m pip install ruff clang-tidy==18.1.8
+```
+
+`clang-tidy` is pinned to match the clang 18 toolchain: it runs with `WarningsAsErrors: '*'`, and a newer version ships new checks that flag pre-existing code.
 
 The check configuration for `clang-tidy` is placed at `.clang-tidy`.
 
@@ -183,8 +202,8 @@ There are basically two ways to download:
   * Modules
   * Ranges and views (e.g. cartesian_product...)
   * Use `std::generator` in Newton's method (moon_phase and jiqei).
-* Support conversions between UTC and UT1
-  * Their differences are subtle and are ignored at this moment...
+* DUT1 (i.e. UT1 - UTC) is not modelled
+  * UTC became a first-class time scale in v0.4.0 (leap-second aware, `utc_to_tt` / `tt_to_utc`), but UT1 and UTC are still treated as interchangeable — the gap stays below 0.9 s while leap seconds are in force.
 
 ## 8. References
 

--- a/Requirements-statistics.txt
+++ b/Requirements-statistics.txt
@@ -1,0 +1,13 @@
+# Dependencies of the analysis layer under `statistics/` (crawlers and notebooks).
+# Not needed to build, test, or lint the project - see `Requirements.txt` for that.
+# The crawlers fetch over HTTP, hence `requests` from the file below.
+-r Requirements.txt
+
+pandas
+beautifulsoup4
+numpy
+matplotlib
+scikit-learn
+skyfield
+pyerfa  # imported as `erfa`
+jupyter

--- a/Requirements.txt
+++ b/Requirements.txt
@@ -1,1 +1,5 @@
+# Dependencies of the build/test automation (`project.py`, `automation/`, `toolbox/`).
+# The CI jobs and the Dockerfile install this file alone, so keep it minimal.
+# Linters are installed separately (README section 4); the `statistics/` layer has
+# its own `Requirements-statistics.txt`.
 requests

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -125,7 +125,7 @@
 
 - Added `Datetime`, a struct to hold a date and an accurate time, representing a UT1 or UTC moment.
 - Supported conversions between Lunar dates and Gregorian dates.
-  - Currently, only Gregorian years between 1901 and 2099 are supported.
+  - At this release, only Gregorian years between 1901 and 2099 were supported — v0.2.0 brought more algorithms, and the README states the range each one covers.
 - Applied Newton's method to approximate the moment when the Sun reaches a certain longitude.
 - Supported queries of the Jieqi (节气) moments in given Gregorian years.
 

--- a/src/astro/moon.hpp
+++ b/src/astro/moon.hpp
@@ -36,7 +36,7 @@ using astro::elp2000_82b::Context;
 /**
  * @brief Calculate perturbation of the Moon's geocentric longitude.
  * @details As per Astronomical Algorithms, Jean Meeus, 1998, Chapter 47, 
- *          the Moon is perturbated by Venus, Jupiter, and Earth.
+ *          the Moon is perturbed by Venus, Jupiter, and Earth.
  * @param ctx The context.
  * @return The perturbation of the Moon's geocentric longitude. Unit is 0.000001 degrees.
  * @see Astronomical Algorithms, Jean Meeus, 1998, Chapter 47.
@@ -51,7 +51,7 @@ inline auto longitude(const Context& ctx) -> double {
 /**
  * @brief Calculate perturbation of the Moon's geocentric latitude.
  * @details As per Astronomical Algorithms, Jean Meeus, 1998, Chapter 47, 
- *          the Moon is perturbated by Venus, Jupiter, and Earth.
+ *          the Moon is perturbed by Venus, Jupiter, and Earth.
  * @param ctx The context.
  * @return The perturbation of the Moon's geocentric latitude. Unit is 0.000001 degrees.
  * @see Astronomical Algorithms, Jean Meeus, 1998, Chapter 47.
@@ -114,7 +114,7 @@ inline auto apparent(const double jde) -> SphericalCoordinate {
 
 /**
  * @brief Calculate the equatorial horizontal parallax of the Moon.
- * @param coord The geocentric ecliptic position of the Moon.
+ * @param distance The geocentric distance of the Moon.
  * @return The equatorial horizontal parallax of the Moon.
  */
 inline auto equatorial_horizontal_parallax(const Distance<KM>& distance) -> Angle<RAD> {

--- a/src/astro/sun.hpp
+++ b/src/astro/sun.hpp
@@ -105,10 +105,10 @@ inline auto apparent(const double jde) -> SphericalCoordinate {
   // Use VSOP87D to calculate the geocentric ecliptic position of the Sun.
   const auto vsop_coord = vsop87d(jde);
 
-  // Calculate the correction for the VSIO87D result, in order to convert it to FK5 system.
+  // Calculate the correction for the VSOP87D result, in order to convert it to FK5 system.
   const auto correction = fk5_correction(jde, vsop_coord);
 
-  // Calculate the Earth's nutation in longtitude.
+  // Calculate the Earth's nutation in longitude.
   const auto nutation = astro::earth::nutation::longitude(jde);
 
   // Calculate the Solar aberration, Meeus (25.11).
@@ -242,7 +242,7 @@ inline auto discriminant(const int32_t year, const double lon) -> uint32_t {
 // In Newton's method, we will approximate the root with the previous root, iteratively.
 // The formula is: Xn+1 = Xn - f(Xn) / f'(Xn).
 // Where we can use the following formula to approximate f'(x):
-// f'(x) = (f(x+h) - f(x-h)) / (2*h), where h is a small number, usally [1e-8, 1e-5].
+// f'(x) = (f(x+h) - f(x-h)) / (2*h), where h is the central-difference half-width picked by `toolbox::newton_method`.
 //
 // As mentioned before, our goal is to find the root (JDE) at which the Sun reaches the expected longitude in a given year.
 // In our context, f is defined as:
@@ -251,8 +251,8 @@ inline auto discriminant(const int32_t year, const double lon) -> uint32_t {
 //
 // Newton's method requires f to be differentiable (smooth).
 // So we need to modify the function of `solar_longitude`.
-// Bacause the beginning position of Sun in a year is roughly 280.0 degrees, and we need to make it negative.
-// Actually, for any JDE befire Spring Equinox this year, we need to substract 360 from `solar_longitude`'s result to make f smooth.
+// Because the beginning position of Sun in a year is roughly 280.0 degrees, and we need to make it negative.
+// Actually, for any JDE before Spring Equinox this year, we need to subtract 360 from `solar_longitude`'s result to make f smooth.
 // 
 // So the actual f is defined as:
 // f(jde) = modified_solar_longitude(jde) - expected_lon
@@ -266,7 +266,7 @@ inline auto make_f(const int32_t year, const double expected_lon) -> FuncType {
   const auto modified_solar_longitude = [=](const double jde) -> double {
     const double raw_value = solar_longitude(jde);
 
-    // We mostly want to substract 360.0 from those JDEs before Spring Equinox.
+    // We mostly want to subtract 360.0 from those JDEs before Spring Equinox.
     //
     // We are here using the fact that the beginning of the year is roughly 280.0 degrees,
     // and it continues growing to 360 degrees (which is also 0 degrees) until Spring Equinox.

--- a/src/astro/vsop87d/defines.hpp
+++ b/src/astro/vsop87d/defines.hpp
@@ -105,7 +105,7 @@ enum class Planet : uint8_t { EAR, /* SAT, MAR, ... */ };
 
 /** @struct The type trait for the VSOP87D tables. Expected specializations in `*_coeff.hpp`s. */
 template <Planet planet>
-struct PlannetTables;
+struct PlanetTables;
 
 /**
  * @struct The result of the VSOP87D evaluation.
@@ -126,9 +126,9 @@ struct Evaluation {
  */
 template <Planet planet>
 inline auto evaluate(const double jm) -> Evaluation {
-  const auto& L = PlannetTables<planet>::L;
-  const auto& B = PlannetTables<planet>::B;
-  const auto& R = PlannetTables<planet>::R;
+  const auto& L = PlanetTables<planet>::L;
+  const auto& B = PlanetTables<planet>::B;
+  const auto& R = PlanetTables<planet>::R;
 
   return {
     .λ = evaluate_tables(L, jm), 

--- a/src/astro/vsop87d/earth_coeff.hpp
+++ b/src/astro/vsop87d/earth_coeff.hpp
@@ -2545,9 +2545,9 @@ constexpr Vsop87dTables R { R_array };
 
 namespace astro::vsop87d {
 
-/** @brief Specialize `PlannetTables` for `Planet::EAR`. */
+/** @brief Specialize `PlanetTables` for `Planet::EAR`. */
 template <>
-struct PlannetTables<Planet::EAR> {
+struct PlanetTables<Planet::EAR> {
   static const inline Vsop87dTables& L = vsop87d::earth_coeff::L;
   static const inline Vsop87dTables& B = vsop87d::earth_coeff::B;
   static const inline Vsop87dTables& R = vsop87d::earth_coeff::R;

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -166,7 +166,7 @@ struct Datetime {
   /**
    * @brief Constructs a `Datetime` from a `year_month_day` and `hh_mm_ss`.
    * @param ymd The year, month, and day.
-   * @param fraction The time of day.
+   * @param time_of_day The time of day.
    */
   template <IsDuration Duration>
   constexpr explicit Datetime(const year_month_day& ymd, const hh_mm_ss<Duration>& time_of_day)

--- a/src/test/datetime_test.cpp
+++ b/src/test/datetime_test.cpp
@@ -310,7 +310,7 @@ TEST(Datetime, EdgeCases) {
     {
       const Datetime dt { today_tp, 1.0 - 1e-11 };
       ASSERT_EQ(dt.ymd, today_tp);
-      ASSERT_NEAR(dt.fraction(), 1.0, 1e-10); // Enforce strict equality here.
+      ASSERT_NEAR(dt.fraction(), 1.0, 1e-10); // The input is 1e-11 day (864 ns) short of 1.0, so it round-trips just below.
     }
 
     {

--- a/src/test/lunar/diff_test.cpp
+++ b/src/test/lunar/diff_test.cpp
@@ -4,7 +4,7 @@
 #include "lunar/algo1.hpp"
 #include "lunar/algo2.hpp"
 
-// In this file, we test that algo1 and glao2 generates the same lunar month data.
+// In this file, we test that algo1 and algo2 generate the same lunar month data.
 
 namespace calendar::lunar::test {
 

--- a/src/util/hash.hpp
+++ b/src/util/hash.hpp
@@ -34,7 +34,7 @@ namespace util::hash {
 template <typename T>
 inline auto hash_combine(std::size_t seed, T&& v) -> std::size_t {
   // NOLINTBEGIN(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-  // Don't lint this code, because clang-tidy compalins about calculating hash for `std::string`.
+  // Don't lint this code, because clang-tidy complains about calculating hash for `std::string`.
   auto v_hash = std::hash<std::decay_t<T>>{}(std::forward<T>(v));
   // NOLINTEND(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 

--- a/statistics/sun_longitude.ipynb
+++ b/statistics/sun_longitude.ipynb
@@ -533,7 +533,7 @@
     "def newton_method(f: Callable[[float], float], sjde: float, ejde: float) -> float:\n",
     "  # Iteratively compute the root to let f(jde) = 0, where jde is in half-open interval [sjde, ejde).\n",
     "  # Xn+1 = Xn - f(Xn) / f'(Xn)\n",
-    "  # f'(x) = (f(x+h) - f(x-h)) / (2*h), where h is a small number, usally [1e-8, 1e-5].\n",
+    "  # f'(x) = (f(x+h) - f(x-h)) / (2*h), where h is a small number, usually [1e-8, 1e-5].\n",
     "  # The initial guess is (sjde + ejde) / 2.\n",
     "\n",
     "  jde = (sjde + ejde) / 2.0\n",


### PR DESCRIPTION
## 内容

清三个文档类 issue 的账,不碰任何数值行为。

**#90 残量**(v0.3.0 / v0.4.0 已修的部分只核对,不重写)

- `README.md`
  - §1 Features 补齐现有公开能力(日月视位置与合朔、均时差与真太阳时、时标/儒略日/恒星时/黄赤交角/章动、C ABI 动态库),并写明三个阴历算法各自的支持年份区间与查询方式
  - §2 点明 `Requirements.txt` 只覆盖构建自动化,linter 与 `statistics/` 依赖各走各的
  - §3.2 Windows 段补 `choco install -y make llvm` 前置 —— CI 一直这么做,文档从未提
  - §4 linter 安装改成实际可行的 `pip install ruff clang-tidy==18.1.8`(原文说 `-r Requirements.txt` 装得上,而该文件只有 `requests`)
  - §7 TODO 里「Support conversions between UTC and UT1」已随 v0.4.0 落地,改写为「DUT1 未建模」
- 新增 `Requirements-statistics.txt`(`statistics/` 的爬虫与 notebook 依赖);`Requirements.txt` 维持只有 `requests`,加注说明用途
- `docs/CHANGELOG.md` v0.0.0 条目里「Currently, only Gregorian years between 1901 and 2099 are supported」改为过去时并指向 README
- `AGENTS.md` 的「In-repo `statistics/` holds evaluation notebooks only」已过期(现在还有 golden 生成脚本),按 issue 最新评论校准

**#79**(注释与代码不符)

- `moon.hpp` `@param coord` → `@param distance`;`datetime.hpp` `@param fraction` → `@param time_of_day`
- `datetime_test.cpp` 的 "Enforce strict equality here" 是从上一段复制来的,与 `ASSERT_NEAR` 自相矛盾,改写为真实理由
- `sun.hpp` 里 Newton 步长 h 的注释还写着 `[1e-8, 1e-5]`,而 h 现在由 `toolbox::newton_method` 决定,改为指向它
- 表格另外三处已在前序 PR 中消失(见「范围说明」)

**#80**(错别字)

- `Bacause` / `befire` / `substract`×2 / `usally` / `VSIO87D` / `longtitude` / `perturbated`×2 / `compalins` / `glao2`,共 11 处
- `PlannetTables` → `PlanetTables`:这是标识符不是注释,`vsop87d/defines.hpp` 4 处 + `earth_coeff.hpp` 2 处;该模板在 `astro::vsop87d` 内部,不进 C ABI
- 另在 `statistics/sun_longitude.ipynb` 抓到同一个 `usally`(issue 清单外)

## 测试

本 PR 不改行为,无新增测试。本地门禁:

- `project.py --all` → `EXIT=0`,199/199 全过
- `ruff check .` → All checks passed
- clang-tidy:本机 macOS 钉版(18.1.8)因 libc++ 头文件环境问题只跑得出既有噪音,告警全部落在本 PR 未触及的行上;Linux CI 是权威门禁

## 验证

- 三个阴历算法的年份区间逐个对着 `algo{1,2,3}.hpp` 的 `START_YEAR` / `END_YEAR` 常量核过;`get_supported_lunar_year_range` 的口径按 `lib_lunar.cpp:37-55` 写 —— 它只认 algo1/algo2,algo3 返回 `valid=false`,所以 README 明确区分 C++ 常量与 C ABI 导出
- Windows 前置与 `build_and_test.yml:234`、`core_tests.yml:182` 的 `choco install -y make llvm` 逐字一致;依据是 `automation/build.py:42` 硬编码 `-G "Unix Makefiles"`、`project.py:174` 要求 `Tool("make")`
- linter 安装命令与 `core_tests.yml:29` 逐字一致
- `Requirements.txt` 的消费方全部核过:`core_tests.yml` 5 处、`build_and_test.yml` 2 处、`Dockerfile:36`、`automation/env.py:37` —— 都只需要 `requests`,拆分后这些路径零变化
- `Requirements-statistics.txt` 按 `statistics/` 下 `.py` 与 notebook 的**真实 import** 清点,含两个 crawler 用的 `skyfield` / `pyerfa`(issue 清单写于这两个 crawler 落地之前);并用 `pip install --dry-run` 实测该文件可解析、包名全部存在、`-r` 递归正常
- `datetime_test.cpp` 新注释的数字跑过探针:`(1.0 - 1e-11) × 8.64e13 = 86399999999136.0`,截断损失 0 ns,往返精确,偏差就是那 864 ns
- `PlannetTables` 改名后全库 grep 零残留,构建与 199/199 测试全绿

## 范围说明

- **不改任何数值行为**,不动 C-ABI 导出面
- issue 里已失效的条目(核对后未改,关单时可一并勾掉):
  - #79 `delta_t.hpp:387` 的 2035 口径:algo5(#64 / PR #107)已是默认 dispatch 且无 2035 断崖,algo4 现有注释与代码一致;验收第 2 条「接 #64 补 2035 跳变警告」已由 dispatch 的 doc 满足
  - #79 `sun.hpp:292-293`、`moon_phase.hpp:62-63` 的 epsilon / max_iter 默认值:参数已随 #76 / PR #95 的求根器重构消失
  - #80 `episilon` / `luanr` / `algoritms`:已被前序 PR 修掉
  - #90 的 RELEASE_NOTES(v0.3.0 `4fc1bfe` 已改为只装当前版本)、CHANGELOG 补 Phase 2-4(v0.3.0 / v0.4.0 条目已覆盖)、AGENTS.md 与 `.github/copilot-instructions.md` 的 sunrise/sunset 表述(Phase 5 落地后已属实)
- 两处因与并行分支文件重叠而跳过,留给对应分支:`src/util/random.hpp:61`、`src/test/astro/sun_test.cpp:236`(均为 #79 评论项)
- 关联 issue 用 Refs 不用 Closes —— #90 / #79 / #80 的关闭权留维护者

Refs #90, #79, #80
