### PR TITLE
fix(automation): #85 Python 自动化层 bug 批

### DIFF
--- a/automation/env.py
+++ b/automation/env.py
@@ -77,7 +77,9 @@ def check_tool(tool: Tool) -> bool:
 
 def find_c_compilers() -> List[str]:
   """Find the C compilers in `PATH`."""
-  c_compilers_pattern = re.compile(r"^(gcc|clang|icc)(-\d+|\d*)")
+  # Anchored at both ends, or the toolchain's companions (`gcc-ar`, `gcc-nm`, `clang-cl`, ...)
+  # get listed as compilers. The version and `.exe` tails keep Windows and `gcc-14.2` in.
+  c_compilers_pattern = re.compile(r"^(gcc|clang|icc)(-?\d+(\.\d+)*)?(\.exe)?$")
 
   if "PATH" not in os.environ:
     return []
@@ -100,7 +102,7 @@ def find_c_compilers() -> List[str]:
 
 def find_cpp_compilers() -> List[str]:
   """Find the C++ compilers in `PATH`."""
-  cpp_compilers_pattern = re.compile(r"^(g\+\+|clang\+\+|icpc)(-\d+|\d*)")
+  cpp_compilers_pattern = re.compile(r"^(g\+\+|clang\+\+|icpc)(-?\d+(\.\d+)*)?(\.exe)?$")
 
   if "PATH" not in os.environ:
     return []
@@ -270,7 +272,8 @@ def setup_environment(plan: SetupPlan) -> int:
               "Please set CXX environment variable and try again.")
     red_print(60 * "-")
 
-    time.sleep(5) # Give the user time to read the warning
+    if sys.stdout.isatty(): # The warning above goes to stdout; no point pausing when nobody is watching.
+      time.sleep(5)
 
     cpp_compilers = find_cpp_compilers()
     if len(cpp_compilers) != 0:
@@ -289,7 +292,8 @@ def setup_environment(plan: SetupPlan) -> int:
               "Building is likely to fail. Early exiting...")
     red_print(60 * "-")
 
-    time.sleep(5) # Give the user time to read the warning
+    if sys.stdout.isatty(): # The warning above goes to stdout; no point pausing when nobody is watching.
+      time.sleep(5)
     return 1
   
   green_print("# Environment setup complete.")

--- a/automation/github.py
+++ b/automation/github.py
@@ -49,7 +49,7 @@ class GitHub:
     """
     A class for representing a workflow in the repository.
     """
-    id:         str
+    id:         int
     name:       str
     state:      str
     created_at: str
@@ -130,7 +130,7 @@ class GitHub:
     Fetch the download URLs for all artifacts of a specific run.
 
     Args:
-      run_id (str): The ID of the GitHub Actions run.
+      run_id (int): The ID of the GitHub Actions run.
 
     Returns:
       Dict[str, str]: A dictionary mapping artifact names to their download URLs.
@@ -179,7 +179,7 @@ class GitHub:
     Asynchronously fetch all artifacts for a given run.
 
     Args:
-      run_id (str): The ID of the GitHub Actions run.
+      run_id (int): The ID of the GitHub Actions run.
       download_dir (Path): The directory where artifacts should be saved.
       parallel (int): The number of parallel download tasks.
 
@@ -226,7 +226,7 @@ class GitHub:
     Fetching artifacts in parallel.
 
     Args:
-      run_id (str): The ID of the GitHub Actions run.
+      run_id (int): The ID of the GitHub Actions run.
       download_dir (Path): The directory where artifacts should be saved.
       parallel (int, optional): The number of parallel download tasks. Default is 4.
 

--- a/automation/gtest.py
+++ b/automation/gtest.py
@@ -9,6 +9,8 @@
 # This software is distributed without any warranty.
 # See <https://www.gnu.org/licenses/> for more details.
 
+import re
+
 from typing import List, Dict, Optional
 
 from . import paths
@@ -48,8 +50,10 @@ def find_gtests(keywords: List[str]) -> List[str]:
   name_to_no = { v: k for k, v in no_to_name.items() } # {test_name: test_no}
 
   def __find_test_no(keyword: str) -> List[str]:
+    # Match the number exactly. A substring test happens to work while the ids run without gaps,
+    # but the moment one is missing it silently picks a longer id - `-k 7` lands on `#70`.
     for test_no, test_name in no_to_name.items():
-      if f"#{keyword}" in test_no:
+      if test_no.rpartition("#")[2] == keyword.strip():
         return [test_name]
     raise ValueError(f"No tests found for keyword: {keyword}")
 
@@ -75,8 +79,10 @@ def find_gtests(keywords: List[str]) -> List[str]:
       test_list.extend(found)
 
   # Remove duplicates and sort the list by test id.
+  # Compared as a number, so the order does not ride on ctest right-aligning the ids - text order
+  # only agrees with numeric order because the padding spaces sort below '#'.
   test_list = list(set(test_list))
-  return sorted(test_list, key=lambda test_name: name_to_no[test_name])
+  return sorted(test_list, key=lambda test_name: int(name_to_no[test_name].rpartition("#")[2]))
 
 
 def run_gtest(
@@ -89,7 +95,8 @@ def run_gtest(
   assert TEST_DIR.exists(), "Test directory not found"
   assert TEST_DIR.is_dir(), "Test directory is not a directory"
 
-  cmd: List[str] = ["ctest", "-R", f"^{test}$"]
+  # `-R` takes a regex, and every test name carries dots - escape them, or `.` matches anything.
+  cmd: List[str] = ["ctest", "-R", f"^{re.escape(test)}$"]
   if verbose_level == 1:
     cmd.append("-V")
   elif verbose_level == 2:

--- a/project.py
+++ b/project.py
@@ -18,8 +18,6 @@ import os
 import sys
 import argparse
 
-from operator import or_
-from functools import reduce
 from dataclasses import dataclass
 
 from typing import List, Callable, Sequence, Final
@@ -74,7 +72,7 @@ def parse_args() -> argparse.Namespace:
       cores = int(value)
       if cores < 1 or cores > available_cpu_cores:
         raise argparse.ArgumentTypeError(
-          f"Invalid number of CPU cores specified: {value}. Must be between 1 and {os.cpu_count()}."
+          f"Invalid number of CPU cores specified: {value}. Must be between 1 and {available_cpu_cores}."
         )
       return cores
     except ValueError as e:
@@ -225,8 +223,9 @@ def main() -> int:
     blue_print(f"# {task_name:<{max_len}} time: {duration:.5f} seconds")
   print(60 * "#")
 
-  # Resolve the return code
-  retcode = reduce(or_, [t.retcode for t in task_results])
+  # Resolve the return code - the first failure rather than a bitwise fold, which would report a
+  # code nobody returned (1 | 2 == 3) if `run_tasks` ever stopped stopping at the first failure.
+  retcode = next((t.retcode for t in task_results if t.retcode != 0), 0)
 
   if retcode != 0:
     red_print(f"# Return code: {retcode}")

--- a/statistics/common.py
+++ b/statistics/common.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import ctypes
 from ctypes import (
-  c_int32, c_uint32,  c_uint16, c_uint8, c_double, c_bool, 
+  c_int32, c_uint32,  c_uint16, c_uint8, c_double, c_bool, c_char_p,
   POINTER, Structure
 )
 
@@ -53,7 +53,21 @@ assert LIB_PATH.exists(),         f"Shared library not found: {LIB_PATH}"
 
 
 # Define the argument and return types of the C functions.
+#
+# Every export in `src/shared_lib/celestial.h` needs its `argtypes`/`restype` here: without them
+# ctypes assumes `restype = c_int`, which reads a struct return as garbage (#85).
 LIB = ctypes.CDLL(str(LIB_PATH))
+
+
+#region Library-level
+
+LIB.set_log_verbosity.argtypes = [c_uint8]
+LIB.set_log_verbosity.restype = c_bool
+
+LIB.last_error.argtypes = []
+LIB.last_error.restype = c_char_p
+
+#endregion
 
 
 #region Delta T functions
@@ -109,6 +123,16 @@ def delta_t_algo5(year: float) -> float:
   result = LIB.delta_t_algo5(year)
   if not result.valid:
     raise ValueError("Error occurred in delta_t_algo5.")
+  return result.value
+
+LIB.delta_t.argtypes = [c_double]
+LIB.delta_t.restype = DeltaT
+
+def delta_t(year: float) -> float:
+  """The library's default ΔT, currently algo5."""
+  result = LIB.delta_t(year)
+  if not result.valid:
+    raise ValueError("Error occurred in delta_t.")
   return result.value
 
 #endregion
@@ -274,6 +298,32 @@ def moon_apparent_geocentric_coord(jde: float) -> MoonCoordinate:
 #endregion
 
 
+#region Solar Time
+
+class _EquationOfTime(Structure):
+  _fields_ = [
+    ("valid", c_bool),
+    ("value", c_double),
+  ]
+
+LIB.equation_of_time.argtypes = [c_double]
+LIB.equation_of_time.restype = _EquationOfTime
+
+class _ApparentSolarTime(Structure):
+  _fields_ = [
+    ("valid",    c_bool),
+    ("year",     c_int32),
+    ("month",    c_uint32),
+    ("day",      c_uint32),
+    ("fraction", c_double),
+  ]
+
+LIB.apparent_solar_time.argtypes = [c_int32, c_uint32, c_uint32, c_double, c_double]
+LIB.apparent_solar_time.restype = _ApparentSolarTime
+
+#endregion
+
+
 #region Jieqi
 
 class Jieqi(Enum):
@@ -315,6 +365,21 @@ class _JieqiMomentQuery(Structure):
 LIB.query_jieqi_moment.argtypes = [c_int32, c_uint8]
 LIB.query_jieqi_moment.restype = _JieqiMomentQuery
 
+LIB.get_jieqi_name.argtypes = [c_uint8, c_char_p, c_uint32]
+LIB.get_jieqi_name.restype = c_bool
+
+class _Discriminant(Structure):
+  _fields_ = [
+    ("valid", c_bool),
+    ("count", c_uint32),
+  ]
+
+LIB.solar_lon_root_discriminant.argtypes = [c_int32, c_double]
+LIB.solar_lon_root_discriminant.restype = _Discriminant
+
+LIB.solar_lon_roots.argtypes = [c_int32, c_double, POINTER(c_double), c_uint32]
+LIB.solar_lon_roots.restype = c_uint32
+
 
 @dataclass
 class JieqiMoment:
@@ -350,6 +415,9 @@ def jieqi_moment(year: int, jq: Jieqi) -> JieqiMoment:
 LIB.new_moons_in_year.argtypes = [c_int32, POINTER(c_uint32), POINTER(c_double), c_uint32]
 LIB.new_moons_in_year.restype = c_uint32
 
+LIB.new_moons_after_jde.argtypes = [c_double, POINTER(c_double), c_uint32]
+LIB.new_moons_after_jde.restype = c_uint32
+
 @dataclass
 class NewMoons:
   """
@@ -383,8 +451,17 @@ def new_moons_in_year(year: int) -> NewMoons:
   # Call the shared library function to get the new moons in the given year.
   num_written = LIB.new_moons_in_year(year, ctypes.byref(root_count), slots, slot_count)
 
-  # Ensure the number of written slots does not exceed the allocated slot count.
-  assert num_written <= slot_count
+  # The C++ side reports every failure as 0 written, and no year goes without a new moon.
+  if num_written == 0:
+    raise ValueError(f"Error occurred in new_moons_in_year for year {year}.")
+
+  # `root_count` is what it found, `num_written` is what fit - a gap means roots were dropped.
+  # Raised rather than asserted: `python -O` strips asserts.
+  if num_written != root_count.value:
+    raise ValueError(
+      f"new_moons_in_year wrote {num_written} of {root_count.value} roots for year {year}; "
+      f"slot_count is {slot_count}."
+    )
 
   # Return the result as an instance of the NewMoons data class.
   jdes = [slots[i] for i in range(num_written)]

--- a/statistics/common.py
+++ b/statistics/common.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import ctypes
 from ctypes import (
-  c_int32, c_uint32,  c_uint16, c_uint8, c_double, c_bool, c_char_p,
+  c_int32, c_uint32,  c_uint16, c_uint8, c_double, c_bool, c_char, c_char_p,
   POINTER, Structure
 )
 
@@ -365,7 +365,9 @@ class _JieqiMomentQuery(Structure):
 LIB.query_jieqi_moment.argtypes = [c_int32, c_uint8]
 LIB.query_jieqi_moment.restype = _JieqiMomentQuery
 
-LIB.get_jieqi_name.argtypes = [c_uint8, c_char_p, c_uint32]
+# `buf` is an output buffer, so it is typed as a pointer rather than `c_char_p` - the latter
+# reads as "takes a string" and invites passing a `bytes`, which the C side would write into.
+LIB.get_jieqi_name.argtypes = [c_uint8, POINTER(c_char), c_uint32]
 LIB.get_jieqi_name.restype = c_bool
 
 class _Discriminant(Structure):

--- a/statistics/moon_phase_crawler.py
+++ b/statistics/moon_phase_crawler.py
@@ -7,34 +7,46 @@
 # Repo   : https://github.com/0xf3cd/celestial-calendar
 
 
+from pathlib import Path
+
 import requests
 import pandas as pd
 from bs4 import BeautifulSoup
 
 
-url = "https://www.taipeidaniel.idv.tw/articles-astrology-moon-new-full.htm"
-response = requests.get(url)
-soup = BeautifulSoup(response.content, "html.parser")
+URL = "https://www.taipeidaniel.idv.tw/articles-astrology-moon-new-full.htm"
+CSV_PATH = Path(__file__).parent / "moon_phases.csv"
 
-# Find all tables
-tables = soup.find_all("table")
 
-all_data = []
-for table in tables:
-  rows = table.find_all("tr")
-  data = []
-  for row in rows:
-    cols = row.find_all("td")
-    cols = [ele.text.strip() for ele in cols]
-    if cols:
-      data.append(cols)
-  if data:
-    df = pd.DataFrame(data, columns=["日期", "時間", "狀態"])
-    all_data.append(df)
+def main() -> None:
+  response = requests.get(URL, timeout=30)
+  response.raise_for_status() # An error page parses into plausible-looking garbage otherwise.
+  soup = BeautifulSoup(response.content, "html.parser")
 
-# Concatenate all dataframes
-if all_data:
+  # Find all tables
+  tables = soup.find_all("table")
+
+  all_data = []
+  for table in tables:
+    rows = table.find_all("tr")
+    data = []
+    for row in rows:
+      cols = row.find_all("td")
+      cols = [ele.text.strip() for ele in cols]
+      if cols:
+        data.append(cols)
+    if data:
+      df = pd.DataFrame(data, columns=["日期", "時間", "狀態"])
+      all_data.append(df)
+
+  if not all_data:
+    raise RuntimeError(f"No moon phase table found at {URL}")
+
+  # Concatenate all dataframes
   combined_df = pd.concat(all_data, ignore_index=True)
-  combined_df.to_csv("moon_phases.csv", index=False, encoding="utf-8")
+  combined_df.to_csv(CSV_PATH, index=False, encoding="utf-8")
+  print(f"All tables saved to {CSV_PATH}.")
 
-print("All tables saved to moon_phases.csv.")
+
+if __name__ == "__main__":
+  main()

--- a/toolbox/artifact_downloader.py
+++ b/toolbox/artifact_downloader.py
@@ -37,10 +37,10 @@ def artifact_workflow(workflow_name: str = "Build and Test on Multiple Platforms
   ))
 
   if len(multi_platform_workflow) != 1:
-    red_print('Cannot find the workflow "Build and Test on Multiple Platforms"')
+    red_print(f'Cannot find the workflow "{workflow_name}"')
     red_print(f"Found {len(multi_platform_workflow)} workflows:")
     red_print(pprint.pformat(multi_platform_workflow))
-    raise RuntimeError('Cannot find the workflow "Build and Test on Multiple Platforms"')
+    raise RuntimeError(f'Cannot find the workflow "{workflow_name}"')
   
   return multi_platform_workflow[0]
 

--- a/toolbox/build_info.py
+++ b/toolbox/build_info.py
@@ -43,7 +43,7 @@ def silent_run(cmd: Sequence[str], **kwargs) -> ProcReturn:
   """Run a command without printing anything. Also check the return code. """
   proc_ret = run_cmd(cmd, print_cmd=False, print_stdout=False, print_stderr=False, **kwargs)
   if proc_ret.retcode != 0:
-    yellow_print("Command failed:", " ".join(cmd))
+    yellow_print(f"Command failed: {' '.join(cmd)}")
     raise RuntimeError("Command failed")
   return proc_ret
 
@@ -192,7 +192,7 @@ def pack_build_info(docker: Optional[str]) -> BuildInfo:
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()
-  parser.add_argument("--save-to", type=Path, required=True, default=None)
+  parser.add_argument("--save-to", type=Path, required=True)
   parser.add_argument("--docker", type=str, default="")
 
   args = parser.parse_args()


### PR DESCRIPTION
## 内容

按 #85 正文 + 评论逐条修。这一层零测试,所以每条都配了执行式验证(见「验证」)。

**`automation/gtest.py`**

- 按编号查找改为精确匹配 —— 旧写法是子串匹配,请求的编号不在清单里时会**静默跑另一个测试**
- 排序改数值序 —— 旧写法按字符串排,能对只是因为 `ctest -N` 把编号右对齐补了空格
- 传给 `ctest -R` 的测试名做 `re.escape`,名字里的 `.` 不再当通配符

**`project.py`**

- 返回码从 `reduce(or_, ...)` 位或聚合改成「第一个非零」:位或会报出一个谁都没返回过的码(`1 | 2 == 3`)
- `--cores` 的错误消息用已兜底的 `available_cpu_cores`,不再是 `os.cpu_count()` —— 后者为 `None` 时提示会变成 "Must be between 1 and None"

**`automation/env.py`**

- 编译器探测正则两端锚定:旧的没锚尾,把 `gcc-ar-16` / `gcc-nm-16` / `clangd` / `clang-tidy` 一并当成 C 编译器列出来;版本与 `.exe` 尾巴保留,Windows 的 `clang++.exe` 与 `gcc-14.2` 这类命名不受影响
- 两处 `time.sleep(5)`(给用户时间读警告)用 `sys.stdout.isatty()` 门控 —— 警告本身走 stdout,CI 不再白等

**`toolbox/`**

- `artifact_downloader.py`:错误信息用 `workflow_name` 参数,不再硬编码 workflow 名
- `build_info.py`:`yellow_print("Command failed:", " ".join(cmd))` 的第二个位置参数绑到了 `end=`,命令文本被当成行终止符打出去(无着色、无换行);顺带删掉 `--save-to` 里 `required=True` 与 `default=None` 并存的死配置

**`automation/github.py`**

- `Workflow.id` 标注 `str`,API 实际返回 int(同 dataclass 的 `Run.id` 已经是 int);三处 docstring 的 `run_id (str)` 同步改 int

**`statistics/common.py`**

- 补齐 ctypes 镜像:**9 个导出此前完全没有声明**(issue 评论记的是 5 个,v0.4.0 之后又添了 4 个)。没有声明时 ctypes 默认 `restype = c_int`,返回 struct 的函数直接读到垃圾
- `new_moons_in_year` 不再把 C++ 侧的错误(返回 0)当成「该年没有新月」;`assert` 换成显式 raise(`python -O` 会把 assert 整个剥掉);`root_count` 与实际写入数交叉校验

**`statistics/moon_phase_crawler.py`**

- `requests.get` 加 timeout 与 `raise_for_status`(错误页会被解析成一堆看着像数据的垃圾写进 csv)
- 加 `__main__` guard —— 原来 import 即发网络请求
- 输出路径不再依赖 cwd;抓不到表就抛,不再无条件打印成功

## 测试

无新增测试(理由见「范围说明」)。门禁:`project.py --all` → `EXIT=0`,199/199;`ruff check .` 全过。

## 验证

这层没有测试可依靠,所以每条都跑了 before/after 对拍:

1. **编译器探测**:本机 PATH 上旧正则的 C 名单有 10 个,其中 7 个不是 C 编译器(`clang++`、`clang-tidy`、`clangd`、`gcc-ar-16`、`gcc-nm-16`、`gcc-ranlib-16`、`icc_simplify`);新正则只留 `clang` / `gcc` / `gcc-16`,零真实编译器丢失。另对 `clang.exe` / `gcc.exe` / `clang++.exe` / `g++.exe` / `gcc-14.2` / `clang-17.0.6` 逐个断言仍匹配 —— 这条是审阅抓出来的:只锚 `$` 会让 Windows 上的编译器名**全部**落空
2. **crawler**:拿 `origin/main` 的版本 import,探针当场截获 HTTP 请求;本分支 import 干净,timeout 与 `raise_for_status` 在调用路径上
3. **ctypes 镜像**:未声明时 `solar_lon_root_discriminant` 与 `equation_of_time` 都返回整数 `1`(struct 被当 `c_int` 读,payload 全丢);声明后拿到 `Discriminant(valid=True, count=1)` 与 `EquationOfTime(valid=True, value=-3.280745)`。新加的 `delta_t(2026.5) = 69.15649 s`,与 `delta_t_algo5` 逐位一致;`new_moons_in_year(2026)` → 12 个朔
4. **测试选择**:`-k 5` / `-k 55` 各自精确命中 Test #5 / #55;把 `#7` 从清单里抹掉后,旧写法静默选中 `SolarTime.MeeusExample28a`,新写法找不到并抛错
5. `--cores 999` 的错误消息、`build_info` 的失败提示,均已实跑确认

**两条 issue 断言实测不成立,改动保留但口径要说清**:issue 说 `gtest.py:79` 的字符串排序会导致 `"Test #10" < "Test #2"` 错序、`-k 5` 会命中 `#55`。实际 `ctest -N` 的编号是右对齐补空格的(`'Test   #1'` / `'Test  #10'` / `'Test #100'`),空格 `0x20` < `#` `0x23`,所以文本序恰好等于数值序 —— 199 条实测两种排序结果相同;编号连续时子串匹配也总是先命中正确项。**这两处因此是去掉对 ctest 输出格式巧合的依赖,不是修活 bug**;唯一活着的失效路径是「请求的编号不在清单里」(见验证 4)。

同理,`project.py` 的返回码改动**在当前代码下与旧写法等价** —— `run_tasks` 在首个失败处早停,所以至多一个非零码;`(-9) | 0` 也仍是 `-9`(shell 看到的 247 来自 `sys.exit` 取低 8 位,新写法一样)。位或真正会搅浑的是多个失败聚合成第三个码,今天够不着。改动价值是可读性与去掉这个隐患,不是修活 bug。

## 范围说明

- **不改任何数值行为**,不碰 C++ 侧与 C-ABI
- 不碰 `statistics/fk5_correction_dataset.py`(并行分支在飞)
- **验收第 2 条(给 `ctest -N` 解析补 golden 单测)未做**:本仓 Python 层没有任何测试框架(`pytest` / `unittest` 零设施),`AGENTS.md` 又写明不在 `project.py` / `linter.py` 流程之外加依赖或构建步骤。引入 Python 测试栈是独立决策,建议另立 issue,本 PR 用执行式验证顶上
- **另发现一条不属于本 issue 的**:`statistics/` 目录下的脚本**不能以 `python -m statistics.<module>` 方式运行** —— 父包名撞上 stdlib 的 `statistics` 模块,报 `__path__ attribute not found`。以脚本方式(`python statistics/xxx.py`)运行不受影响,`from statistics import median` 也正常(PEP 420:regular module 胜过 namespace portion)。建议另立 issue
- 关联 issue 用 Refs,关闭权留维护者

Refs #85
