### PR TITLE
test(util): seeded RNG with env override + deterministic cache assertions (#69, #117)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -84,6 +84,7 @@ jobs:
           docker buildx build \
             --platform ${{ matrix.platform }} -t $IMAGE_TAG \
             --build-arg DOCKER_PLATFORM=${{ matrix.platform }} \
+            --build-arg CELESTIAL_TEST_SEED=${{ env.CELESTIAL_TEST_SEED }} \
             --load .
 
           # Run the Docker image and copy build artifacts to the output directory

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,6 +5,12 @@ on:
   pull_request:
     branches: [ main ]  # Also triggers on pull requests to the main branch
 
+# Gate track of the #69 dual-track policy: the pinned default seed (the soak workflow
+# random_soak.yml draws a fresh one per run). Must match DEFAULT_SEED in
+# src/util/random.hpp.
+env:
+  CELESTIAL_TEST_SEED: "42"
+
 jobs:
   linux-docker:
     # 2026-07: matrix trimmed from 8 QEMU-emulated platforms to the two real

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [ '**' ]
 
+# Gate track of the #69 dual-track policy: the pinned default seed (the soak workflow
+# random_soak.yml draws a fresh one per run). Must match DEFAULT_SEED in
+# src/util/random.hpp.
+env:
+  CELESTIAL_TEST_SEED: "42"
+
 jobs:
   linters-and-static-analysis:  
     runs-on: ubuntu-24.04

--- a/.github/workflows/random_soak.yml
+++ b/.github/workflows/random_soak.yml
@@ -1,0 +1,121 @@
+name: Random Seed Soak
+
+# Exploration track of the #69 dual-track testing policy: the PR/push gate pins the
+# default seed (42), while this weekly (or manually dispatched) soak draws a fresh seed
+# per run. CELESTIAL_TEST_SEED = github.run_id — unique per run, visible in the run URL,
+# and directly replayable. A soak failure is never dismissed as a flake: replay the
+# failing ctest entry with the same seed (each ctest case starts a fresh process from
+# draw 0), then bake the find into a directed regression test.
+
+on:
+  schedule:
+    - cron: '17 3 * * 0'  # weekly, Sunday 03:17 UTC
+  workflow_dispatch:
+
+env:
+  CELESTIAL_TEST_SEED: ${{ github.run_id }}
+
+jobs:
+  soak-ubuntu-clang:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python Dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          if [ -f Requirements.txt ]; then python3 -m pip install -r Requirements.txt; fi
+
+      - name: Install LLVM and clang++
+        run: |
+          sudo add-apt-repository universe
+          sudo apt update
+          sudo apt install -y llvm-18 clang-18
+
+      - name: Install CMake
+        run: sudo apt install cmake
+
+      - name: Build and Test
+        env:
+          CXX: clang++-18
+          CC:  clang-18
+        run: |
+          chmod +x project.py
+          ./project.py --setup --clean --cmake --build --test -v 1
+
+
+  soak-macos-apple-clang:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Python Dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        if [ -f Requirements.txt ]; then python3 -m pip install -r Requirements.txt; fi
+
+    - name: Build and Test
+      env:
+        CXX: clang++
+        CC:  clang
+      run: |
+        chmod +x project.py
+        ./project.py --setup --clean --cmake --build --test -v 1
+
+
+  soak-windows-clang:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Visual Studio
+        uses: microsoft/setup-msbuild@v2
+        with:
+          vs-version: latest
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if (Test-Path "Requirements.txt") { python -m pip install -r "Requirements.txt" }
+
+          choco install -y make llvm
+
+      - name: Build and Test
+        env:
+          CXX: clang++
+          CC:  clang
+        run: |
+          chcp.com 65001
+          $env:PYTHONIOENCODING = "utf-8"
+          python3 ./project.py --setup --clean --cmake --build --test -v 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,15 @@ $env:CC  = "clang"
 python3 ./project.py --all
 ```
 
+### Test randomness (#69)
+
+Randomized tests draw from a shared, seeded engine (`util/random.hpp`): default seed 42,
+override with the `CELESTIAL_TEST_SEED` env var, effective seed printed once per test
+process (`[ util::random ] seed = ...`). The PR/push gate pins the default;
+`random_soak.yml` (weekly / dispatch) draws a fresh seed per run. A soak failure is never
+a flake: replay the failing ctest entry with the same seed, then bake the find into a
+directed regression test.
+
 ### Direct CMake (optional)
 
 ```sh
@@ -212,7 +221,9 @@ is intentional. Keep it. That buys a discipline:
 
 Every file opens with the full GPL-3.0 block comment (copy from any src file), verbatim except
 the year: `Copyright (C) <year> Ningqi Wang (0xf3cd)`. New files use the current year; never
-change an existing file's year. GPL-3.0 project — keep the header.
+change an existing file's year — except a wholesale rewrite, which may set a
+`<original>-<current>` range (user-directed, e.g. `util/random.hpp` 2024-2026). GPL-3.0
+project — keep the header.
 
 ## Tests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,11 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 # Build and test the project
 # Only run the integration tests, since arm docker env are slow on GitHub CI
+# Gate track of the #69 dual-track policy: pin the seed inside the image too — a docker
+# build layer does not inherit the GitHub Actions env context (default matches
+# DEFAULT_SEED in src/util/random.hpp).
+ARG CELESTIAL_TEST_SEED=42
+ENV CELESTIAL_TEST_SEED=${CELESTIAL_TEST_SEED}
 RUN if [ -f Requirements.txt ]; then /opt/venv/bin/pip install -r Requirements.txt; fi
 RUN /opt/venv/bin/python ./project.py --clean --cores all --all -k integration -v 1
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ chmod +x project.py
 # Run tests
 ./project.py --test
 
+# Randomized tests use a seeded engine (default 42); override to replay or explore
+CELESTIAL_TEST_SEED=123 ./project.py --test
+
 # Or, run all above together to build and test
 ./project.py --all
 

--- a/src/test/jieqi_test.cpp
+++ b/src/test/jieqi_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <ranges>
+#include <vector>
 #include "util.hpp"
 #include "jieqi.hpp"
 
@@ -47,10 +48,11 @@ TEST(JieQi, IsJieOrQi) {
 
 
 TEST(JieQi, JDE) {
-  // Random pick some years, to avoid test time being too long.
-  auto years = std::views::iota(1800, 2034) | std::views::filter([](int32_t) {
-    return util::random(0.0, 1.0) < 0.042;
-  });
+  // ~10 of 234 candidate years — matches the old 4.2% filter's expectation, but the
+  // empty-sample case is structurally impossible (#69).
+  auto candidates = std::views::iota(1800, 2034) | std::ranges::to<std::vector>();
+  std::shuffle(candidates.begin(), candidates.end(), util::detail::engine());
+  const auto years = candidates | std::views::take(10) | std::ranges::to<std::vector>();
 
   for (const auto year : years) {
     for (int32_t jq_idx = 0; jq_idx < to_index(Jieqi::COUNT); jq_idx++) {

--- a/src/test/lunar/algo3_test.cpp
+++ b/src/test/lunar/algo3_test.cpp
@@ -1,9 +1,10 @@
 #include <gtest/gtest.h>
-#include <random>
+#include <algorithm>
 #include <vector>
 #include "lunar/algo1.hpp"
 #include "lunar/algo2.hpp"
 #include "lunar/algo3.hpp"
+#include "random.hpp"
 
 namespace calendar::lunar::algo3::test {
 
@@ -24,7 +25,7 @@ TEST(LunarAlgo3, Correctness) {
   std::vector<int32_t> years = std::views::iota(algo3::START_YEAR, algo3::END_YEAR + 1)
                              | std::ranges::to<std::vector>();
 
-  std::shuffle(years.begin(), years.end(), std::mt19937 { std::random_device()() });
+  std::shuffle(years.begin(), years.end(), util::detail::engine()); // Seeded, reproducible (#69).
   years.resize(32);
 
   for (const auto year : years) {

--- a/src/test/lunar/diff_test.cpp
+++ b/src/test/lunar/diff_test.cpp
@@ -1,8 +1,11 @@
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <ranges>
+#include <vector>
 #include <print>
 #include "lunar/algo1.hpp"
 #include "lunar/algo2.hpp"
+#include "random.hpp"
 
 // In this file, we test that algo1 and algo2 generate the same lunar month data.
 
@@ -26,41 +29,14 @@ auto pick_random_years() -> std::vector<int32_t> {
              | views::filter(filter_year)
              | to<std::vector>();
 
-  // Randomly pick some years.
-  std::shuffle(begin(years), end(years), std::mt19937{ std::random_device{}() });
-  return years 
-       | views::take(10) 
+  // Randomly pick some years. Seeded via util::random's shared engine, so the draw is
+  // reproducible under CELESTIAL_TEST_SEED (#69).
+  std::shuffle(begin(years), end(years), util::detail::engine());
+  return years
+       | views::take(10)
        | to<std::vector>();
 }
 
-
-TEST(LunarAlgoDiff, Perf) {
-  using namespace std::ranges;
-  const auto years = pick_random_years();
-
-  const auto tracked_run = [](const std::function<void()>& f) -> double {
-    const auto start = std::chrono::steady_clock::now();
-    f();
-    const auto end = std::chrono::steady_clock::now();
-    const auto ns_gap = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
-    return static_cast<double>(ns_gap);
-  };
-
-  std::vector<double> algo1_results;
-  std::vector<double> algo2_results;
-
-  for (const auto year : years) {
-    algo1_results.push_back(tracked_run([&] { algo1::calc_lunar_year(year); }));
-    algo2_results.push_back(tracked_run([&] { algo2::get_info_for_year(year); }));
-  }
-
-  const double algo1_sum = std::reduce(cbegin(algo1_results), cend(algo1_results));
-  const double algo2_sum = std::reduce(cbegin(algo2_results), cend(algo2_results));
-
-  std::println("algo1: {} ns", algo1_sum / static_cast<double>(years.size()));
-  std::println("algo2: {} ns", algo2_sum / static_cast<double>(years.size()));
-  std::println("algo1 is {}x faster", algo2_sum / algo1_sum);
-}
 
 TEST(LunarAlgoDiff, Consistency) {
   // This test ensures that algo1 and algo2 have the same result on leap months.

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <print>
 #include <atomic>
+#include <cmath>
 #include <ranges>
 #include <thread>
 #include <unordered_set>
@@ -92,11 +93,35 @@ TEST(Util, OperatorSub) {
 }
 
 TEST(Util, GenRandomValue1) {
+  // #69: full-domain draws must actually show both signs — this doubles as the mutation
+  // guard for the sign branch (drop it and every draw is non-negative).
+  std::size_t neg_count = 0;
+  std::size_t pos_count = 0;
   for (size_t i = 0; i < 5000; i++) {
     const auto random_value = random<double>();
-    ASSERT_GE(random_value, std::numeric_limits<double>::min());
-    ASSERT_LE(random_value, std::numeric_limits<double>::max());
+    ASSERT_TRUE(std::isfinite(random_value));
+    if (random_value < 0.0) {
+      ++neg_count;
+    } else {
+      ++pos_count;
+    }
   }
+  ASSERT_GT(neg_count, 0);
+  ASSERT_GT(pos_count, 0);
+
+  std::size_t f_neg_count = 0;
+  std::size_t f_pos_count = 0;
+  for (size_t i = 0; i < 1000; i++) {
+    const auto random_value = random<float>();
+    ASSERT_TRUE(std::isfinite(random_value));
+    if (random_value < 0.0F) {
+      ++f_neg_count;
+    } else {
+      ++f_pos_count;
+    }
+  }
+  ASSERT_GT(f_neg_count, 0);
+  ASSERT_GT(f_pos_count, 0);
 
   for (size_t i = 0; i < 5000; i++) {
     const auto random_value = random<uint8_t>();
@@ -114,10 +139,10 @@ TEST(Util, GenRandomValue1) {
 
 TEST(Util, GenRandomValue2) {
   for (size_t i = 0; i < 5000; i++) {
-    // Not sure if the subtest of float is 100% correct.
-    // Maybe an epsilon is needed when comparing?
-    const auto random_value1 = random<float>();
-    const auto random_value2 = random<float>();
+    // Modest bounds on purpose: full-domain values would overflow the range version's
+    // (max - min) to inf (#69).
+    const auto random_value1 = random<float>(-1e6F, 1e6F);
+    const auto random_value2 = random<float>(-1e6F, 1e6F);
     if (random_value1 == random_value2) {
       continue;
     }
@@ -221,14 +246,13 @@ TEST(Util, HashCollision) {
 
 
 TEST(Util, MakeCached1) {
-  const auto f = [](int a, int b) {
-    std::this_thread::sleep_for(std::chrono::microseconds(50));
+  std::atomic<int32_t> call_count { 0 };
+  const auto f = [&call_count](int a, int b) {
+    ++call_count;
     return a + b;
   };
   const auto cached_f = util::cache::cache_func(f);
 
-  // Time the original function.
-  const auto original_start_time = std::chrono::steady_clock::now();
   std::vector<int> original_results;
   for (int i = 0; i < 10; i++) {
     for (int j = 0; j < 10; j++) {
@@ -237,11 +261,8 @@ TEST(Util, MakeCached1) {
       original_results.emplace_back(f(i, j));
     }
   }
-  const auto original_end_time = std::chrono::steady_clock::now();
-  const auto original_elapsed_time = std::chrono::duration_cast<std::chrono::milliseconds>(original_end_time - original_start_time).count();
+  ASSERT_EQ(call_count, 300);
 
-  // Time the cached function.
-  const auto cached_start_time = std::chrono::steady_clock::now();
   std::vector<int> cached_results;
   for (int i = 0; i < 10; i++) {
     for (int j = 0; j < 10; j++) {
@@ -250,27 +271,23 @@ TEST(Util, MakeCached1) {
       cached_results.emplace_back(cached_f(i, j));
     }
   }
-  const auto cached_end_time = std::chrono::steady_clock::now();
-  const auto cached_elapsed_time = std::chrono::duration_cast<std::chrono::milliseconds>(cached_end_time - cached_start_time).count();
 
   ASSERT_EQ(original_results, cached_results);
 
-  ASSERT_GT(original_elapsed_time, cached_elapsed_time);
-  std::println("original_elapsed_time = {}ms, cached_elapsed_time = {}ms, {}x faster",
-               original_elapsed_time, cached_elapsed_time, 
-               static_cast<double>(original_elapsed_time) / static_cast<double>(cached_elapsed_time));
+  // #69/#117: determinism over wall-clock — each unique (i, j) is computed exactly once,
+  // so the 300 cached invocations must add exactly 100 underlying calls.
+  ASSERT_EQ(call_count, 400);
 }
 
 
 TEST(Util, MakeCached2) {
-  const auto f = [](int a, double b) {
-    std::this_thread::sleep_for(std::chrono::microseconds(50));
+  std::atomic<int32_t> call_count { 0 };
+  const auto f = [&call_count](int a, double b) {
+    ++call_count;
     return a * b;
   };
   const auto cached_f = util::cache::cache_func(f);
 
-  // Time the original function.
-  const auto original_start_time = std::chrono::steady_clock::now();
   std::vector<double> original_results;
   for (int i = 0; i < 10; i++) {
     for (int j = 0; j < 10; j++) {
@@ -279,11 +296,8 @@ TEST(Util, MakeCached2) {
       original_results.emplace_back(f(i, j));
     }
   }
-  const auto original_end_time = std::chrono::steady_clock::now();
-  const auto original_elapsed_time = std::chrono::duration_cast<std::chrono::milliseconds>(original_end_time - original_start_time).count();
+  ASSERT_EQ(call_count, 300);
 
-  // Time the cached function.
-  const auto cached_start_time = std::chrono::steady_clock::now();
   std::vector<double> cached_results;
   for (int i = 0; i < 10; i++) {
     for (int j = 0; j < 10; j++) {
@@ -292,15 +306,11 @@ TEST(Util, MakeCached2) {
       cached_results.emplace_back(cached_f(i, j));
     }
   }
-  const auto cached_end_time = std::chrono::steady_clock::now();
-  const auto cached_elapsed_time = std::chrono::duration_cast<std::chrono::milliseconds>(cached_end_time - cached_start_time).count();
 
   ASSERT_EQ(original_results, cached_results);
 
-  ASSERT_GT(original_elapsed_time, cached_elapsed_time);
-  std::println("original_elapsed_time = {}ms, cached_elapsed_time = {}ms, {}x faster",
-               original_elapsed_time, cached_elapsed_time,
-               static_cast<double>(original_elapsed_time) / static_cast<double>(cached_elapsed_time));
+  // #69/#117: see MakeCached1 — 300 cached invocations, exactly 100 fresh computations.
+  ASSERT_EQ(call_count, 400);
 }
 
 

--- a/src/util/random.hpp
+++ b/src/util/random.hpp
@@ -47,7 +47,15 @@ inline auto random_seed() -> uint64_t {
   // Only a fully-consumed, non-negative decimal numeral is honored (yes, 0 is a valid
   // seed); anything else — unset, leading whitespace/sign, trailing junk, overflow —
   // falls back to the default.
+#ifdef _WIN32
+  // MSVC/clang-cl deprecate plain getenv as "unsafe"; getenv_s is the blessed form.
+  char env_buf[64] = {};
+  size_t env_len = 0;
+  getenv_s(&env_len, env_buf, sizeof(env_buf), "CELESTIAL_TEST_SEED");
+  const char* const env = env_len > 0 ? env_buf : nullptr;
+#else
   const char* const env = std::getenv("CELESTIAL_TEST_SEED");
+#endif
   if (env == nullptr or *env < '0' or *env > '9') {
     return DEFAULT_SEED;
   }

--- a/src/util/random.hpp
+++ b/src/util/random.hpp
@@ -25,6 +25,7 @@
 
 
 #include <cassert>
+#include <cerrno>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -43,15 +44,17 @@ namespace util::detail {
 inline constexpr uint64_t DEFAULT_SEED = 42;
 
 inline auto random_seed() -> uint64_t {
-  // Only a fully-consumed, non-negative decimal numeral counts; anything else (unset,
-  // non-numeric, zero, trailing junk, negative) falls back to the default.
+  // Only a fully-consumed, non-negative decimal numeral is honored (yes, 0 is a valid
+  // seed); anything else — unset, leading whitespace/sign, trailing junk, overflow —
+  // falls back to the default.
   const char* const env = std::getenv("CELESTIAL_TEST_SEED");
-  if (env == nullptr or *env == '-') {
+  if (env == nullptr or *env < '0' or *env > '9') {
     return DEFAULT_SEED;
   }
+  errno = 0;
   char* end = nullptr;
   const auto parsed = std::strtoull(env, &end, 10);
-  if (end == env or *end != '\0' or parsed == 0) {
+  if (*end != '\0' or errno == ERANGE) {
     return DEFAULT_SEED;
   }
   return parsed;

--- a/src/util/random.hpp
+++ b/src/util/random.hpp
@@ -3,7 +3,7 @@
  *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
  *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
  * 
- * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Copyright (C) 2024-2026 Ningqi Wang (0xf3cd)
  * Email: nq.maigre@gmail.com
  * Repo : https://github.com/0xf3cd/celestial-calendar
  *  
@@ -24,9 +24,61 @@
 #pragma once
 
 
-#include <random>
-#include <limits>
 #include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <mutex>
+#include <print>
+#include <random>
+
+// #69: test draws come from one shared thread_local engine, so every run is reproducible.
+// The seed defaults to 42 and can be overridden via the CELESTIAL_TEST_SEED env var; the
+// effective seed is printed once per process on first use. Note: only the engine sequence
+// is standardized — std::uniform_real_distribution's transform is implementation-defined,
+// so float draws can differ across STL vendors.
+namespace util::detail {
+
+inline constexpr uint64_t DEFAULT_SEED = 42;
+
+inline auto random_seed() -> uint64_t {
+  // Only a fully-consumed, non-negative decimal numeral counts; anything else (unset,
+  // non-numeric, zero, trailing junk, negative) falls back to the default.
+  const char* const env = std::getenv("CELESTIAL_TEST_SEED");
+  if (env == nullptr or *env == '-') {
+    return DEFAULT_SEED;
+  }
+  char* end = nullptr;
+  const auto parsed = std::strtoull(env, &end, 10);
+  if (end == env or *end != '\0' or parsed == 0) {
+    return DEFAULT_SEED;
+  }
+  return parsed;
+}
+
+inline void print_random_seed_once() {
+  static std::once_flag flag;
+  std::call_once(flag, [] {
+    std::println(stderr, "[ util::random ] seed = {} (override: CELESTIAL_TEST_SEED)", random_seed());
+  });
+}
+
+// One engine per thread, all sharing the same seed — per-thread sequences are deterministic
+// and identical, which keeps multi-threaded tests reproducible without locking.
+inline auto engine() -> std::mt19937_64& {
+  static thread_local auto eng = [] {
+    print_random_seed_once();
+    // Two-step (not brace-init): clang-tidy's narrowing check misresolves the ctor's
+    // parameter type here and fires on a cast that is identity in practice.
+    auto e = std::mt19937_64 {};
+    e.seed(static_cast<std::mt19937_64::result_type>(random_seed()));
+    return e;
+  }();
+  return eng;
+}
+
+} // namespace util::detail
 
 namespace util {
 
@@ -34,23 +86,23 @@ namespace util {
  * @fn random
  * @brief Generate a random value of type T.
  * @return a random value of type T.
+ * @note For floating-point T the semantics are full-domain (#69): a magnitude in
+ *       [0, max] with a random sign. (Drawing from [lowest(), max()] directly instead
+ *       would overflow the distribution's range.)
  */
 template <typename T>
   requires std::integral<T> || std::floating_point<T>
 inline auto random() -> T {
-  std::random_device rd;
-  std::mt19937 gen(rd());
-
-  constexpr auto min = std::numeric_limits<T>::min();
-  constexpr auto max = std::numeric_limits<T>::max();
+  auto& gen = detail::engine();
 
   if constexpr (std::integral<T>) {
-    std::uniform_int_distribution<T> dist { min, max };
+    std::uniform_int_distribution<T> dist { std::numeric_limits<T>::min(), std::numeric_limits<T>::max() };
     return dist(gen);
   } else {
     static_assert(std::floating_point<T>);
-    std::uniform_real_distribution<T> dist { min, max };
-    return dist(gen);
+    std::uniform_real_distribution<T> dist { T { 0 }, std::numeric_limits<T>::max() };
+    std::bernoulli_distribution sign;
+    return sign(gen) ? dist(gen) : -dist(gen);
   }
 }
 
@@ -65,8 +117,7 @@ template <typename T>
   requires std::integral<T> || std::floating_point<T>
 inline auto random(const T& min, const T& max) -> T {
   assert(min < max);
-  std::random_device rd;
-  std::mt19937 gen(rd());
+  auto& gen = detail::engine();
 
   if constexpr (std::integral<T>) {
     std::uniform_int_distribution<T> dist { min, max };
@@ -83,8 +134,7 @@ inline auto random(const T& min, const T& max) -> T {
 
 template <>
 inline auto random() -> uint8_t {
-  std::random_device rd;
-  std::mt19937 gen(rd());
+  auto& gen = detail::engine();
   std::uniform_int_distribution<uint32_t> dist { 0, 255 };
   return static_cast<uint8_t>(dist(gen));
 }
@@ -92,8 +142,7 @@ inline auto random() -> uint8_t {
 template <>
 inline auto random(const uint8_t& min, const uint8_t& max) -> uint8_t {
   assert(min < max);
-  std::random_device rd;
-  std::mt19937 gen(rd());
+  auto& gen = detail::engine();
   std::uniform_int_distribution<uint32_t> dist { min, max };
   return static_cast<uint8_t>(dist(gen));
 }


### PR DESCRIPTION
Closes #69. Closes #117.

## 内容

测试确定性双轨制(用户拍板):**PR/push 门禁 = 显式固定种子 42,新增周跑 soak CI = 随机种子探索**。

- `src/util/random.hpp` 重写(#69):测试抽样改走共享 `thread_local` mt19937_64 引擎——默认种子 42(`DEFAULT_SEED` 常量),`CELESTIAL_TEST_SEED` 覆盖(endptr 全串校验+拒负号,非法输入回退默认),首次使用经 `std::println` 打印一次有效种子(仿 `--gtest_random_seed`);浮点无参版从 `min()`(最小正规数,永不产生负数/零、分布堆在 ~1e308)改为全域语义([0,max] 幅值 + bernoulli 符号);版权头随重写更新为 2024-2026(用户指示,AGENTS.md 版权节已补区间写法适用条件)。
- 测试同步:`GenRandomValue1` 改 `std::isfinite` + **双符号计数断言**(double/float 各数千抽,双符号必现——同时是符号分支的突变闸);`GenRandomValue2` 浮点边界改有界区间(全域边界会让区间版 `max-min` 溢出为 inf);`MakeCached1/2` 的墙钟断言(#117 在 CI macOS 格偶发失败的根因)改为**确定性调用计数断言**(300 原始 + 恰好 100 新增 = 400,沿用 MakeCachedCopyShares 的 call_count 先例),摘除为计时而生的 `sleep_for`;`jieqi_test` 抽样改 shuffle+take(10)(空样本结构性不可能,且与 diff_test 同构);`algo3_test` 全仓最后一处未播种 shuffle 收编;`diff_test` 删 `LunarAlgoDiff.Perf`(无断言、永不失败)+ shuffle 收编。
- CI 双轨:`core_tests.yml` / `build_and_test.yml` 顶层 `env: CELESTIAL_TEST_SEED: "42"`(门禁轨钉成字面事实);新增 `.github/workflows/random_soak.yml`(探索轨):每周日 03:17 UTC + dispatch,三平台镜像 core_tests 构建步骤,`CELESTIAL_TEST_SEED=${{ github.run_id }}`——种子唯一、可从 run URL 复读;soak 失败按仓规落定向回归测试,不作 flake 抹掉。
- 文档:AGENTS.md 新增「Test randomness」节(含 soak 失败处置纪律)、README 测试块补一行。

## 测试

- 本地门禁 `project.py --all` 全绿:**198/198**(预期 −1 = 删 Perf)。
- 种子机制探针:同种子同序列、异种子异序列;打印行实测。
- **检出率实测两条**:①`cache_func` 直通突变(无缓存)→ MakeCached 4/4 红;②删浮点符号分支 → GenRandomValue1 必红(neg_count=0)。文件快照还原,均回绿。
- **钉版 clang-tidy 拼合环境**(sparse libc++ 18.1.8 + isysroot,cpp-dev skill 配方)复验:本 PR 触及的 src 文件零告警(vararg/use-std-print/拼合命名空间/指针算术/小写字面量后缀五处真实命中已修;main 既有告警按噪音规则不计)。
- **ASan 事故与修正**:中途的 `views::filter | ranges::to<std::vector>` 写法被 ASan 检出堆越界写(谓词带副作用 × libc++ `to` 的两遍扫描),改单遍写法(后又经审阅收敛为 shuffle+take)并 ASan 复验零报告。

## 验证

- **#69 验收逐条**:①共享 thread_local 引擎+固定默认种子+env 覆盖+打印 ✅;②浮点全域语义(幅值+符号)✅ 文档/测试同步 ✅;③jieqi 空过滤 ✅(以 shuffle+take 结构性达成),无断言(Perf 删)/墙钟(MakeCached 改计数)✅——`LunarAlgo1.CachePerf` 子项此前已被 #109 删除(issue 描述过时),全仓 `random_device` 检索仅剩 leap_second_test 的 `mt19937{42}`(固定种子)。
- **#117**:墙钟断言已除,等价计数断言突变检出 1/1。
- 无生产代码消费 `util::random`(grep 验证):纯测试面 + CI,零数值行为变化。
- **审阅双轮**:R1 = grok 正确性(0 P1;P2×2:algo3 未播种、符号零检出;P3×2:种子解析、门禁未钉)× opus 风格(P1×1:fprintf 打挂门禁〔坐实〕;P2×5:GPL 改词/叙事住错层/验尸注释/命令式写法/文档缺失;P3×7)→ 修复批全落(详见各文件;mt19937_64 收窄诊断系拼合环境 misfire,改默认构造+`.seed()` 规避并注 why)→ **R2 双 FIXES VERIFIED**。

## 范围说明

- 跨平台复现边界:引擎序列严格确定,但 `std::uniform_real_distribution` 的变换各 STL 实现不保证一致——Windows 的罕见失败可能需在 Windows replay;已记档于 random.hpp 头注释(自研分布函数不在本期)。
- soak workflow 生效于下个周日/dispatch,不挂 PR、不影响门禁时长;复制 core_tests 三 job 为既有形态,第四份拷贝出现时再抽 `workflow_call`。
- 每线程同种子同序列(免锁确定性);ctest 每用例独立进程,复现以「重跑失败 ctest 条目」为准。
