### PR TITLE
fix(headers): 自包含性与 ODR 地基 —— 系数表外部链接、IWYU、多平台闸门 (#71)

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -223,6 +223,14 @@ jobs:
         with:
           python-version: "3.12"
 
+      # `linter.py` imports the `automation` package, whose __init__ pulls in
+      # `automation.github` and therefore `requests` -- needed even though this
+      # check never touches the network.
+      - name: Install Python Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r Requirements.txt
+
       - name: Install clang (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -238,4 +246,4 @@ jobs:
       - name: Check every header compiles alone (${{ matrix.stdlib }})
         env:
           CXX: clang++
-        run: python3 ./linter.py --self-contained
+        run: python ./linter.py --self-contained

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -195,3 +195,47 @@ jobs:
           chcp.com 65001
           $env:PYTHONIOENCODING = "utf-8"
           python3 ./project.py --setup --clean --cmake --build --test -v 1
+
+
+  # Header self-containment (#71). Deliberately a matrix, not a single job: whether a
+  # header is self-contained depends on the standard library, because each one includes
+  # a different set of things transitively. `converter.hpp` used `assert` with no
+  # <cassert> and was green on MSVC STL for months while broken on libc++. One leg
+  # would have kept missing it, so run all three.
+  self-contained-headers:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04     # libstdc++
+            stdlib: libstdc++
+          - runner: macos-latest     # libc++
+            stdlib: libc++
+          - runner: windows-latest   # MSVC STL
+            stdlib: MSVC STL
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install clang (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo add-apt-repository universe
+          sudo apt update
+          sudo apt install -y clang-18
+          echo "CXX=clang++-18" >> $GITHUB_ENV
+
+      - name: Install clang (Windows)
+        if: runner.os == 'Windows'
+        run: choco install -y llvm
+
+      - name: Check every header compiles alone (${{ matrix.stdlib }})
+        env:
+          CXX: clang++
+        run: python3 ./linter.py --self-contained

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -210,10 +210,13 @@ jobs:
         include:
           - runner: ubuntu-24.04     # libstdc++
             stdlib: libstdc++
+            cxx: clang++-18
           - runner: macos-latest     # libc++
             stdlib: libc++
+            cxx: clang++
           - runner: windows-latest   # MSVC STL
             stdlib: MSVC STL
+            cxx: clang++
 
     steps:
       - uses: actions/checkout@v7
@@ -237,13 +240,15 @@ jobs:
           sudo add-apt-repository universe
           sudo apt update
           sudo apt install -y clang-18
-          echo "CXX=clang++-18" >> $GITHUB_ENV
 
       - name: Install clang (Windows)
         if: runner.os == 'Windows'
         run: choco install -y llvm
 
+      # The compiler comes from the matrix, not from $GITHUB_ENV: a step-level `env:`
+      # outranks anything written to $GITHUB_ENV, so setting CXX in the install step
+      # above and again here would silently pin nothing.
       - name: Check every header compiles alone (${{ matrix.stdlib }})
         env:
-          CXX: clang++
+          CXX: ${{ matrix.cxx }}
         run: python ./linter.py --self-contained

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 test_pymeeus.py
 check_platform_arch.py
 
+# Review/audit scratch space. Untracked by design, but it must also be invisible to the
+# linters: `linter.py` runs `ruff check <repo root>` and clang-tidy over the tree, so a
+# stray .py/.cpp probe left here would turn the gate red (#102).
+.review/
+
 artifacts/
 release/
 run-clang-tidy.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,8 +114,13 @@ directed regression test.
 ```sh
 cmake -S src -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build --parallel
-ctest --test-dir build
+ctest --test-dir build/test
 ```
+
+`build/test`, not `build`: the tests register in the subdirectory, so
+`ctest --test-dir build` runs **zero** tests and still exits 0 — a green light
+that checked nothing. (The root cause, a missing top-level `enable_testing()`,
+is tracked in #72.)
 
 ### Lint
 
@@ -151,6 +156,15 @@ is intentional. Keep it. That buys a discipline:
 
 - All logic in `src/**/*.hpp` with `#pragma once`; every function `inline`, shared constants
   `inline constexpr`. `.cpp` exists only in `shared_lib/` for the C-ABI exports. New logic → a header.
+  `inline` on namespace-scope constants is not cosmetic: plain `constexpr` has internal linkage,
+  so an external-linkage inline entity that odr-uses it (binds a reference, takes a span,
+  subscripts an array, range-for's over it) is IFNDR (#71).
+- **Every header compiles alone**, and CI enforces it per-header with `-fsyntax-only`.
+  Self-containment is a property of the *standard library*, not of the code: a header that
+  leans on a transitive include passes on the implementation that happens to provide it and
+  fails on one that doesn't. `converter.hpp` used `assert` with no `<cassert>` and compiled
+  fine on MSVC STL for months while failing outright on libc++ (#71). **The gate therefore
+  has to run on more than one leg — a single green platform proves nothing.**
 - **No `using namespace` and no namespace-scope `using` declarations in headers** — they leak
   into every including TU and cause conflicts / ambiguity. Put `using` inside function bodies
   (as `sun.hpp` already does with `using namespace astro::toolbox::literals;`) or fully-qualify.
@@ -275,8 +289,9 @@ toolbox/        Helper scripts for artifacts, releases, build info
    from `lib*.cpp`. Version is injected via the `BUILD_VERSION` environment variable
    (defaults to `0.0.0`).
 4. **CI produces cross-platform artifacts:** GitHub Actions builds on macOS, Windows, and
-   many Linux architectures via Docker+QEMU. Do not change compiler or Docker base images
-   without checking matrix impact.
+   two Linux architectures (x86_64 and arm64), each in Docker on a *native* runner — the
+   8-platform QEMU matrix was retired in 2026-07 (#46). Do not change compiler or Docker
+   base images without checking matrix impact.
 5. **Sensitive files:** Do not read or surface `.env`, `credentials.json`, or any file
    containing tokens/keys.
 6. **`build/` is gitignored.** Generated artifacts and `compile_commands.json` live there;
@@ -286,7 +301,7 @@ toolbox/        Helper scripts for artifacts, releases, build info
 8. **Assertions:** the default build is `Release` (`automation/build.py`), so `assert` is dead
    code in production. Test targets strip `NDEBUG` (`src/test/CMakeLists.txt`, #89), so asserts
    ARE live inside test binaries — `build_integrity_test.cpp` guards this. The error contract
-   (target state; legacy violations are being migrated in #77, #67, #64, #70): public input
+   (target state; #77, #67 and #64 are closed, #70 is the last one open): public input
    validation must `throw` (fail-fast, independent of build type); `assert` is only
    for internal invariants, never as an input guard.
 

--- a/automation/__init__.py
+++ b/automation/__init__.py
@@ -26,6 +26,7 @@ from .paths import (
 )
 from .github import GitHub
 from .linter import run_ruff, run_clang_tidy
+from .self_contained import check_self_contained
 
 __all__ = [
   "Tool", "CompilerArgs", "check_c_support", "check_cpp_support", "make_compiler_args",
@@ -35,5 +36,5 @@ __all__ = [
   "green_print", "red_print", "yellow_print", "blue_print",
   "run_cmd", "ProcReturn", "time_execution",
   "proj_root", "build_dir", "cpp_src_dir", "python_requirements", "cpp_test_dir",
-  "GitHub", "run_ruff", "run_clang_tidy"
+  "GitHub", "run_ruff", "run_clang_tidy", "check_self_contained"
 ]

--- a/automation/self_contained.py
+++ b/automation/self_contained.py
@@ -10,23 +10,35 @@
 # See <https://www.gnu.org/licenses/> for more details.
 
 import os
+import re
 
+from pathlib import Path
 from typing import List, Final
 
 from . import paths
 from .utils import run_cmd, green_print, red_print, yellow_print, blue_print
 
 
-# Mirrors the include_directories() calls in src/CMakeLists.txt. Kept in sync by hand:
-# if a new include root shows up there, add it here or headers under it stop being checkable.
-INCLUDE_SUBDIRS: Final[List[str]] = [
-  "astro",
-  "calendar",
-  "util",
-  "astro/vsop87d",
-  "calendar/lunar",
-  "shared_lib",
-]
+INCLUDE_DIR_RE: Final[re.Pattern] = re.compile(
+  r"^\s*include_directories\(\$\{PROJECT_SOURCE_DIR\}/([^)]+)\)", re.MULTILINE
+)
+
+
+def include_roots(src_dir: Path) -> List[Path]:
+  """Read the include roots straight out of src/CMakeLists.txt.
+
+  Deliberately derived rather than copied. The gate is only meaningful if it compiles
+  headers under the *same* search path the real build gives them: a wider path lets a
+  header get away with an include that only resolves for the gate (e.g. "defines.hpp",
+  reachable only via -Iastro/vsop87d), and the gate would wave through something the
+  build rejects. A narrower one flags includes that are actually fine. Either way a
+  hand-copied list drifts silently, so there is no second list to drift.
+  """
+  cmakelists = src_dir / "CMakeLists.txt"
+  roots = [src_dir / name.strip() for name in INCLUDE_DIR_RE.findall(cmakelists.read_text())]
+  # src/CMakeLists.txt still names `common`, which no longer exists (tracked in #72).
+  # Passing -I for a missing directory is harmless but pointless, so drop it.
+  return [r for r in roots if r.is_dir()]
 
 
 def check_self_contained() -> int:
@@ -53,8 +65,14 @@ def check_self_contained() -> int:
     red_print(f"No headers found under {src_dir}")
     return 1
 
-  includes = [f"-I{src_dir / sub}" for sub in INCLUDE_SUBDIRS]
+  roots = include_roots(src_dir)
+  if not roots:
+    red_print(f"No include_directories() found in {src_dir / 'CMakeLists.txt'}")
+    return 1
+
+  includes = [f"-I{r}" for r in roots]
   blue_print(f"# Compiler: {cxx} | {len(headers)} header(s) under {src_dir}")
+  blue_print(f"# Include roots (from CMakeLists.txt): {', '.join(r.name for r in roots)}")
 
   failed: List[str] = []
   for header in headers:

--- a/automation/self_contained.py
+++ b/automation/self_contained.py
@@ -1,0 +1,89 @@
+# CelestialCalendar Automation:
+#   Python automation scripts for building and testing the CelestialCalendar C++ project.
+#
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+# License: GNU General Public License v3.0
+#
+# This software is distributed without any warranty.
+# See <https://www.gnu.org/licenses/> for more details.
+
+import os
+
+from typing import List, Final
+
+from . import paths
+from .utils import run_cmd, green_print, red_print, yellow_print, blue_print
+
+
+# Mirrors the include_directories() calls in src/CMakeLists.txt. Kept in sync by hand:
+# if a new include root shows up there, add it here or headers under it stop being checkable.
+INCLUDE_SUBDIRS: Final[List[str]] = [
+  "astro",
+  "calendar",
+  "util",
+  "astro/vsop87d",
+  "calendar/lunar",
+  "shared_lib",
+]
+
+
+def check_self_contained() -> int:
+  """Compile every header on its own to prove it is self-contained.
+
+  A header-only library ships its headers as the product, so each one must compile
+  as the first thing a translation unit sees. `-fsyntax-only` gives us that check
+  for the cost of a parse, with no object files produced.
+
+  This must run on more than one standard library to be worth anything. Standard
+  libraries differ in what they include transitively, so a header that forgets an
+  include rides on its neighbours wherever that neighbour happens to provide the
+  symbol, and fails elsewhere. `converter.hpp` used `assert` with no <cassert> and
+  passed on MSVC STL while failing on libc++ (#71).
+  """
+  print("#" * 60)
+  yellow_print("Checking that every header is self-contained...")
+
+  cxx = os.environ.get("CXX", "clang++")
+  src_dir = paths.cpp_src_dir()
+  headers = sorted(p for p in src_dir.rglob("*.hpp"))
+
+  if not headers:
+    red_print(f"No headers found under {src_dir}")
+    return 1
+
+  includes = [f"-I{src_dir / sub}" for sub in INCLUDE_SUBDIRS]
+  blue_print(f"# Compiler: {cxx} | {len(headers)} header(s) under {src_dir}")
+
+  failed: List[str] = []
+  for header in headers:
+    rel = header.relative_to(paths.proj_root())
+    ret = run_cmd(
+      # -Wno-pragma-once-outside-header: compiling a header as the main file is the
+      # whole point here, so that warning is an artefact of the check, not a finding.
+      [cxx, "-std=c++23", "-fsyntax-only", "-Wno-pragma-once-outside-header",
+       *includes, "-x", "c++", str(header)],
+      print_cmd=False,
+      print_stdout=False,
+      print_stderr=False,
+    )
+    if ret.retcode == 0:
+      green_print(f"PASS  {rel}")
+    else:
+      red_print(f"FAIL  {rel}")
+      # The diagnostic is the actionable part -- print it, do not just count the failure.
+      for line in (ret.stderr or ret.stdout).splitlines()[:8]:
+        print(f"        {line}")
+      failed.append(str(rel))
+
+  print("#" * 60)
+  if failed:
+    red_print(f"{len(failed)} of {len(headers)} header(s) are not self-contained:")
+    for f in failed:
+      red_print(f"  - {f}")
+    yellow_print("Add the missing #include to the header itself; do not rely on a transitive one.")
+    return 1
+
+  green_print(f"All {len(headers)} header(s) are self-contained")
+  return 0

--- a/linter.py
+++ b/linter.py
@@ -34,7 +34,7 @@ import sys
 import argparse
 
 from automation import (
-  run_ruff, run_clang_tidy,
+  run_ruff, run_clang_tidy, check_self_contained,
 )
 
 
@@ -48,6 +48,8 @@ def parse_args() -> argparse.Namespace:
       "    ./linter.py --ruff\n\n"
       "  To run clang-tidy to check C++ codes:\n"
       "    ./linter.py --clang-tidy\n\n"
+      "  To check that every header is self-contained:\n"
+      "    ./linter.py --self-contained\n\n"
       "  To run both linters:\n"
       "    ./linter.py -a/--all\n\n"
     ),
@@ -57,6 +59,8 @@ def parse_args() -> argparse.Namespace:
   parser.add_argument("-a", "--all", action="store_true", help="Clean the project")
   parser.add_argument("--ruff", action="store_true", help="Run ruff")
   parser.add_argument("--clang-tidy", action="store_true", help="Run clang-tidy")
+  parser.add_argument("--self-contained", action="store_true",
+                      help="Compile every header alone to prove it is self-contained")
 
   return parser.parse_args()
 
@@ -71,6 +75,11 @@ if __name__ == "__main__":
 
   if args.clang_tidy or args.all:
     ret_code = run_clang_tidy()
+    if ret_code != 0:
+      sys.exit(ret_code)
+
+  if args.self_contained or args.all:
+    ret_code = check_self_contained()
     if ret_code != 0:
       sys.exit(ret_code)
 

--- a/linter.py
+++ b/linter.py
@@ -50,7 +50,7 @@ def parse_args() -> argparse.Namespace:
       "    ./linter.py --clang-tidy\n\n"
       "  To check that every header is self-contained:\n"
       "    ./linter.py --self-contained\n\n"
-      "  To run both linters:\n"
+      "  To run every check (ruff, clang-tidy, self-containment):\n"
       "    ./linter.py -a/--all\n\n"
     ),
     formatter_class=argparse.RawTextHelpFormatter

--- a/linter.py
+++ b/linter.py
@@ -56,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     formatter_class=argparse.RawTextHelpFormatter
   )
 
-  parser.add_argument("-a", "--all", action="store_true", help="Clean the project")
+  parser.add_argument("-a", "--all", action="store_true", help="Run every check")
   parser.add_argument("--ruff", action="store_true", help="Run ruff")
   parser.add_argument("--clang-tidy", action="store_true", help="Run clang-tidy")
   parser.add_argument("--self-contained", action="store_true",

--- a/src/astro/delta_t.hpp
+++ b/src/astro/delta_t.hpp
@@ -28,7 +28,10 @@
 #include <format>
 #include <ranges>
 #include <cassert>
+#include <cstdint>
+#include <utility>
 #include <optional>
+#include <iterator>
 
 #include "ymd.hpp"
 #include "datetime.hpp"

--- a/src/astro/delta_t.hpp
+++ b/src/astro/delta_t.hpp
@@ -401,7 +401,7 @@ namespace algo5 {
 
 /** @brief The decimal year of the last Bulletin A observation in the training data;
  *         also the boundary between the fitted and the extrapolated segments. */
-constexpr double LAST_OBSERVATION_YEAR = 2026.4135844748857;
+inline constexpr double LAST_OBSERVATION_YEAR = 2026.4135844748857;
 
 /**
  * @brief The function to compute △T of a given gregorian year, using algorithm 5.

--- a/src/astro/delta_t.hpp
+++ b/src/astro/delta_t.hpp
@@ -67,7 +67,7 @@ struct Algo1Coefficients {
   double a, b, c, d; 
 };
 
-constexpr std::array<Algo1Coefficients, 20> ALGO1_COEFFICIENTS = {{
+inline constexpr std::array<Algo1Coefficients, 20> ALGO1_COEFFICIENTS = {{
   { -4000, 108371.7, -13036.80, 392.000,  0.0000 },
   {  -500,  17201.0,   -627.82,  16.170, -0.3413 },
   {  -150,  12200.6,   -346.41,   5.403, -0.1593 },

--- a/src/astro/earth.hpp
+++ b/src/astro/earth.hpp
@@ -25,12 +25,16 @@
 
 #include <span>
 #include <array>
+#include <cmath>
 #include <ranges>
+#include <cstdint>
+#include <numeric>
 #include <functional>
 
 #include "toolbox.hpp"
 #include "julian_day.hpp"
 #include "vsop87d/vsop87d.hpp"
+#include "vsop87d/defines.hpp"
 
 
 namespace astro::earth {

--- a/src/astro/earth.hpp
+++ b/src/astro/earth.hpp
@@ -101,7 +101,7 @@ struct NutationCoeffs {
 
 // The following data was collected from Jean Meeus, "Astronomical Algorithms", 2nd ed, Table 22.A in Ch. 22.
 // This table is based on IAU 1980 nutation model, and some terms are omitted.
-constexpr std::array<NutationCoeffs, 63> MEEUS_NUTATION_COEFFS {{
+inline constexpr std::array<NutationCoeffs, 63> MEEUS_NUTATION_COEFFS {{
   { {  0,  0,  0,  0,  1 }, { -171996.0, -174.2 }, { 92025.0,  8.9 } },
   { { -2,  0,  0,  2,  2 }, {  -13187.0,   -1.6 }, {  5736.0, -3.1 } },
   { {  0,  0,  0,  2,  2 }, {   -2274.0,   -0.2 }, {   977.0, -0.5 } },
@@ -170,7 +170,7 @@ constexpr std::array<NutationCoeffs, 63> MEEUS_NUTATION_COEFFS {{
 
 // The following IAU 1980 Nutation Model data was collected from https://www.iausofa.org/2021_0512_C/sofa/nut80.c.
 // Compared to Meeus's omitted version, this table contains all terms.
-constexpr std::array<NutationCoeffs, 106> IAU1980_NUTATION_COEFFS {{
+inline constexpr std::array<NutationCoeffs, 106> IAU1980_NUTATION_COEFFS {{
   { {  0,  0,  0,  0,  1 }, { -171996.0, -174.2 }, { 92025.0,  8.9 } },
   { {  0,  0,  0,  0,  2 }, {    2062.0,    0.2 }, {  -895.0,  0.5 } },
   { {  0,  0, -2,  2,  1 }, {      46.0,    0.0 }, {   -24.0,  0.0 } },
@@ -452,7 +452,7 @@ struct DailyVariationTerm {
  * @note Terms with rate 359993/719987/1079981 are due to the eccentricity, 4452671/9224659/4092677
  *       to the Moon, 450368/225184/315559/675553 to Venus, 329644/659289/299295 to Jupiter, 337181 to Mars.
  */
-constexpr std::array<DailyVariationTerm, 21> MEEUS_DAILY_VARIATION_TERMS {{
+inline constexpr std::array<DailyVariationTerm, 21> MEEUS_DAILY_VARIATION_TERMS {{
   { 118.568,  87.5287,  359993.7286, 0 },
   {   2.476,  85.0561,  719987.4571, 0 },
   {   1.376,  27.8502, 4452671.1152, 0 },

--- a/src/astro/earth.hpp
+++ b/src/astro/earth.hpp
@@ -496,7 +496,7 @@ inline auto daily_λ_variation(const double jde) -> double {
 
 /** @brief The light-time for unit distance, in days per AU (= 499.00478 s ≈ 8.3 min).
  *  @note (25.11) prints 0.005775518; the 8th significant digit here is from τ_A = 499.004784 s / 86400. */
-constexpr double LIGHT_TIME_DAYS_PER_AU = 0.0057755183;
+inline constexpr double LIGHT_TIME_DAYS_PER_AU = 0.0057755183;
 
 /**
  * @brief Compute the aberration correction to the Sun's geometric longitude, Meeus (25.11).

--- a/src/astro/elp2000_82b.hpp
+++ b/src/astro/elp2000_82b.hpp
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <ranges>
 #include <numeric>
+#include <cstdint>
 
 #include "toolbox.hpp"
 

--- a/src/astro/elp2000_82b.hpp
+++ b/src/astro/elp2000_82b.hpp
@@ -59,7 +59,7 @@ struct BCoefficients {
 };
 
 /** @brief Represents coefficients of the LR table. */
-constexpr std::array<LRCoefficients, 60> LR {{
+inline constexpr std::array<LRCoefficients, 60> LR {{
   { 0,  0,  1,  0, 6288774, -20905355 },
   { 2,  0, -1,  0, 1274027,  -3699111 },
   { 2,  0,  0,  0,  658314,  -2955968 },
@@ -123,7 +123,7 @@ constexpr std::array<LRCoefficients, 60> LR {{
 }};
 
 /** @brief Represents coefficients of the B table. */
-constexpr std::array<BCoefficients, 60> B {{
+inline constexpr std::array<BCoefficients, 60> B {{
   { 0,  0,  0,  1, 5128122 },
   { 0,  0,  1,  1,  280602 },
   { 0,  0,  1, -1,  277693 },

--- a/src/astro/elp2000_82b.hpp
+++ b/src/astro/elp2000_82b.hpp
@@ -203,13 +203,13 @@ using toolbox::AngleUnit::RAD;
  * @brief The scaling factor used in the Jean Meeus's Astronomical Algorithms, for the longitude and latitude.
  *        The unit of the raw evaluation result of longitude and latitude is 0.000001 degree.
  */
-constexpr double LON_LAT_SCALING_FACTOR = 1e6;
+inline constexpr double LON_LAT_SCALING_FACTOR = 1e6;
 
 /**
  * @brief The scaling factor used in the Jean Meeus's Astronomical Algorithms, for the radius/distance.
  *        The unit of the raw evaluation result of radius/distance is 0.001 kilometer.
  */
-constexpr double RADIUS_SCALING_FACTOR = 1e3;
+inline constexpr double RADIUS_SCALING_FACTOR = 1e3;
 
 /**
  * @struct The context (arguments) for a given julian century.

--- a/src/astro/julian_day.hpp
+++ b/src/astro/julian_day.hpp
@@ -46,7 +46,7 @@ namespace astro::julian_day {
 /**
  * @brief The julian day number of 2000-01-01, 12:00:00.0 (noon).
  */
-constexpr double J2000 = 2451545.0;
+inline constexpr double J2000 = 2451545.0;
 
 
 /**

--- a/src/astro/moon.hpp
+++ b/src/astro/moon.hpp
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <cmath>
+
 #include "earth.hpp"
 #include "julian_day.hpp"
 #include "toolbox.hpp"

--- a/src/astro/moon_phase.hpp
+++ b/src/astro/moon_phase.hpp
@@ -23,8 +23,12 @@
 
 #pragma once
 
+#include <cmath>
 #include <vector>
 #include <format>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
 
 #include "toolbox.hpp"
 #include "ymd.hpp"

--- a/src/astro/moon_phase.hpp
+++ b/src/astro/moon_phase.hpp
@@ -61,7 +61,7 @@ inline auto longitude_diff(const double jde) -> double {
  * @note The same figure sets where `f` is unwrapped below, so the bracket that Newton's method
  *       accepts and the interval on which `f` is smooth are one and the same by construction.
  */
-constexpr double BRACKET_TOLERANCE_DEG = 15.0;
+inline constexpr double BRACKET_TOLERANCE_DEG = 15.0;
 
 /**
  * @brief Apply Newton's method to find the jde, when the Sun and Moon are at the same apparent longitude.
@@ -116,7 +116,7 @@ inline auto newton_method(
  *       about `30 / 12.19 * 0.19` = 0.47 day short of the root — which is what makes
  *       `BRACKET_HALF_WIDTH_DAYS` the binding constraint on how large this may be.
  */
-constexpr double ESTIMATE_TOLERANCE_DEG = 30.0;
+inline constexpr double ESTIMATE_TOLERANCE_DEG = 30.0;
 
 /**
  * @brief Half the width of the bracket handed to Newton's method, in days.
@@ -125,7 +125,7 @@ constexpr double ESTIMATE_TOLERANCE_DEG = 30.0;
  *       endpoints drift past `BRACKET_TOLERANCE_DEG`: at the Moon's fastest, 14.5 deg/day, an
  *       endpoint 0.67 day out already sits 9.7 deg from conjunction.
  */
-constexpr double BRACKET_HALF_WIDTH_DAYS = 0.5;
+inline constexpr double BRACKET_HALF_WIDTH_DAYS = 0.5;
 
 /**
  * @brief Approximate the range of the first root after the given jde, when the Sun and Moon are at the same apparent longitude.

--- a/src/astro/sun.hpp
+++ b/src/astro/sun.hpp
@@ -23,10 +23,17 @@
 
 #pragma once
 
+#include <cmath>
+#include <ranges>
+#include <vector>
+#include <cstdint>
+#include <functional>
+
 #include "toolbox.hpp"
 #include "julian_day.hpp"
 #include "earth.hpp"
 #include "coord_transform.hpp"
+#include "ymd.hpp"
 
 namespace astro::sun::geocentric_coord {
 
@@ -85,8 +92,8 @@ inline auto fk5_correction(const double jde, const SphericalCoordinate& vsop87d_
   const Angle λ_dash = vsop_λ - Angle<DEG> { (1.397 + 0.00031 * jc) * jc };
   const double λ_dash_rad = λ_dash.rad();
 
-  const double delta_λ_arcsec = -0.09033 + 0.03916 * (cos(λ_dash_rad) + sin(λ_dash_rad)) * tan(vsop_β.rad());
-  const double delta_β_arcsec = 0.03916 * (cos(λ_dash_rad) - sin(λ_dash_rad));
+  const double delta_λ_arcsec = -0.09033 + 0.03916 * (std::cos(λ_dash_rad) + std::sin(λ_dash_rad)) * std::tan(vsop_β.rad());
+  const double delta_β_arcsec = 0.03916 * (std::cos(λ_dash_rad) - std::sin(λ_dash_rad));
 
   return {
     .Δλ = Angle<DEG>::from_arcsec(delta_λ_arcsec),

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -27,6 +27,7 @@
 #include <limits>
 #include <cstddef>
 #include <numbers>
+#include <cstdint>
 #include <concepts>
 #include <algorithm>
 #include <stdexcept>

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -55,7 +55,7 @@ constexpr auto normalize_pm180(const double deg) -> double {
 }
 
 /** @brief The number of degrees in a radian. */
-constexpr double DEG_PER_RAD = 180.0 / std::numbers::pi;
+inline constexpr double DEG_PER_RAD = 180.0 / std::numbers::pi;
 
 /** @brief Convert degree to radian. */
 constexpr auto deg_to_rad(const double deg) -> double {
@@ -72,7 +72,7 @@ constexpr auto rad_to_deg(const double rad) -> double {
  *        Used to convert between time offsets and hour angle offsets.
  * @ref Jean Meeus, "Astronomical Algorithms", Ch.12.
  */
-constexpr double SIDEREAL_RATE_DEG_PER_DAY = 360.98564736629;
+inline constexpr double SIDEREAL_RATE_DEG_PER_DAY = 360.98564736629;
 
 /**
  * @brief The Sun's mean apparent motion along the ecliptic, in degrees per day.
@@ -80,23 +80,23 @@ constexpr double SIDEREAL_RATE_DEG_PER_DAY = 360.98564736629;
  * @note This is a mean rate — the true rate varies by about ±1.7% over a year, since Earth's
  *       orbit is an ellipse and perihelion passage is faster than aphelion passage.
  */
-constexpr double SOLAR_MEAN_MOTION_DEG_PER_DAY = 360.0 / 365.2422;
+inline constexpr double SOLAR_MEAN_MOTION_DEG_PER_DAY = 360.0 / 365.2422;
 
 /**
  * @brief The mean rate at which the Moon's apparent longitude pulls away from the Sun's,
  *        in degrees per day. A synodic month of 29.530588853 days closes a full 360°.
  * @note This is a mean rate — near perigee the Moon runs at roughly 1.2× this value.
  */
-constexpr double MOON_ELONGATION_RATE_DEG_PER_DAY = 360.0 / 29.530588853;
+inline constexpr double MOON_ELONGATION_RATE_DEG_PER_DAY = 360.0 / 29.530588853;
 
 /** @brief The number of minutes in a degree. */
-constexpr uint32_t MIN_PER_DEG = 60;
+inline constexpr uint32_t MIN_PER_DEG = 60;
 
 /** @brief The number of seconds in a minute. */
-constexpr uint32_t SEC_PER_MIN = 60;
+inline constexpr uint32_t SEC_PER_MIN = 60;
 
 /** @brief The number of seconds in a degree. */
-constexpr uint32_t SEC_PER_DEG = SEC_PER_MIN * MIN_PER_DEG;
+inline constexpr uint32_t SEC_PER_DEG = SEC_PER_MIN * MIN_PER_DEG;
 
 /** @brief Convert minutes to degrees. */
 constexpr auto arcmin_to_deg(const double arcmin) -> double {
@@ -242,7 +242,7 @@ inline auto operator""_rad(const long double value) -> Angle<AngleUnit::RAD> {
 enum class DistanceUnit : uint8_t { AU, KM };
 
 /** @brief The scaling factor from AU to KM. */
-constexpr double au_km_scale = 149597870.691; 
+inline constexpr double au_km_scale = 149597870.691; 
 
 /** @brief Convert from AU to KM. */
 constexpr auto au_to_km(const double au) -> double { 

--- a/src/astro/vsop87d/defines.hpp
+++ b/src/astro/vsop87d/defines.hpp
@@ -53,7 +53,7 @@ using Vsop87dTables = std::span<const Vsop87dTable>;
  * @note In this project, the coefficient "A"s in the tables are multiplied by 1e8.
  *       So before getting the correct radians, we need to divide them by 1e8. 
  */
-constexpr double SCALING_FACTOR = 1e8;
+inline constexpr double SCALING_FACTOR = 1e8;
 
 
 /** 

--- a/src/astro/vsop87d/defines.hpp
+++ b/src/astro/vsop87d/defines.hpp
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <ranges>
 #include <numeric>
+#include <cstdint>
 
 namespace astro::vsop87d {
 

--- a/src/astro/vsop87d/earth_coeff.hpp
+++ b/src/astro/vsop87d/earth_coeff.hpp
@@ -35,7 +35,7 @@ using Vsop87dTables = astro::vsop87d::Vsop87dTables;
 
 #pragma region L0-L5
 
-constexpr std::array<Coefficients, 559> L0 {{
+inline constexpr std::array<Coefficients, 559> L0 {{
   {    175347045.673,            0.0,                0.0, },
   {      3341656.456,  4.66925680417,    6283.0758499914, },
   {        34894.275,  4.62610241759,   12566.1516999828, },
@@ -597,7 +597,7 @@ constexpr std::array<Coefficients, 559> L0 {{
   {            0.049,  2.44790934886,    13613.804277336, },
 }};
 
-constexpr std::array<Coefficients, 341> L1 {{
+inline constexpr std::array<Coefficients, 341> L1 {{
   { 628331966747.491,            0.0,                0.0, },
   {       206058.863,  2.67823455584,    6283.0758499914, },
   {          4303.43,  2.63512650414,   12566.1516999828, },
@@ -941,7 +941,7 @@ constexpr std::array<Coefficients, 341> L1 {{
   {            0.025,  5.71466092822,   25934.1243310894, },
 }};
 
-constexpr std::array<Coefficients, 142> L2 {{
+inline constexpr std::array<Coefficients, 142> L2 {{
   {         52918.87,            0.0,                0.0, },
   {         8719.837,  1.07209665242,    6283.0758499914, },
   {          309.125,  0.86728818832,   12566.1516999828, },
@@ -1086,7 +1086,7 @@ constexpr std::array<Coefficients, 142> L2 {{
   {             0.01,  4.93364992366,   12352.8526045448, },
 }};
 
-constexpr std::array<Coefficients, 22> L3 {{
+inline constexpr std::array<Coefficients, 22> L3 {{
   {          289.226,  5.84384198723,    6283.0758499914, },
   {           34.955,            0.0,                0.0, },
   {           16.819,  5.48766912348,   12566.1516999828, },
@@ -1111,7 +1111,7 @@ constexpr std::array<Coefficients, 22> L3 {{
   {            0.005,  4.28412873331,    6275.9623029906, },
 }};
 
-constexpr std::array<Coefficients, 11> L4 {{
+inline constexpr std::array<Coefficients, 11> L4 {{
   {          114.084,  3.14159265359,                0.0, },
   {            7.717,  4.13446589358,    6283.0758499914, },
   {            0.765,  3.83803776214,   12566.1516999828, },
@@ -1125,7 +1125,7 @@ constexpr std::array<Coefficients, 11> L4 {{
   {            0.002,  0.54912904658,    6438.4962494256, },
 }};
 
-constexpr std::array<Coefficients, 5> L5 {{
+inline constexpr std::array<Coefficients, 5> L5 {{
   {            0.878,  3.14159265359,                0.0, },
   {            0.172,   2.7657906951,    6283.0758499914, },
   {             0.05,  2.01353298182,     155.4203994342, },
@@ -1134,16 +1134,16 @@ constexpr std::array<Coefficients, 5> L5 {{
 }};
 
 /** @brief Simply put all L tables together. */
-constexpr std::array<Vsop87dTable, 6> L_array { L0, L1, L2, L3, L4, L5, };
+inline constexpr std::array<Vsop87dTable, 6> L_array { L0, L1, L2, L3, L4, L5, };
 
-constexpr Vsop87dTables L { L_array };
+inline constexpr Vsop87dTables L { L_array };
 
 #pragma endregion
 
 
 #pragma region B0-B4
 
-constexpr std::array<Coefficients, 184> B0 {{
+inline constexpr std::array<Coefficients, 184> B0 {{
   {           279.62,  3.19870156017,  84334.66158130829, },
   {          101.643,  5.42248619256,    5507.5532386674, },
   {           80.445,  3.88013204458,    5223.6939198022, },
@@ -1330,7 +1330,7 @@ constexpr std::array<Coefficients, 184> B0 {{
   {            0.039,   3.1123991069,  96900.81328129109, },
 }};
 
-constexpr std::array<Coefficients, 99> B1 {{
+inline constexpr std::array<Coefficients, 99> B1 {{
   {             9.03,   3.8972906189,    5507.5532386674, },
   {            6.177,  1.73038850355,    5223.6939198022, },
   {              3.8,  5.24404145734,    2352.8661537718, },
@@ -1432,7 +1432,7 @@ constexpr std::array<Coefficients, 99> B1 {{
   {            0.019,  0.85407021371,    14712.317116458, },
 }};
 
-constexpr std::array<Coefficients, 49> B2 {{
+inline constexpr std::array<Coefficients, 49> B2 {{
   {            1.662,  1.62703209173,  84334.66158130829, },
   {            0.492,  2.41382223971,    1047.7473117547, },
   {            0.344,  2.24353004539,    5507.5532386674, },
@@ -1484,7 +1484,7 @@ constexpr std::array<Coefficients, 49> B2 {{
   {            0.009,  5.94191743597,    7632.9432596502, },
 }};
 
-constexpr std::array<Coefficients, 11> B3 {{
+inline constexpr std::array<Coefficients, 11> B3 {{
   {            0.011,  0.23877262399,    7860.4193924392, },
   {            0.009,  1.16069982609,    5507.5532386674, },
   {            0.008,  1.65357552925,    5884.9268465832, },
@@ -1498,7 +1498,7 @@ constexpr std::array<Coefficients, 11> B3 {{
   {            0.007,  2.73399865247,    6309.3741697912, },
 }};
 
-constexpr std::array<Coefficients, 5> B4 {{
+inline constexpr std::array<Coefficients, 5> B4 {{
   {            0.004,  0.79662198849,    6438.4962494256, },
   {            0.005,  0.84308705203,    1047.7473117547, },
   {            0.005,  0.05711572303,  84334.66158130829, },
@@ -1507,9 +1507,9 @@ constexpr std::array<Coefficients, 5> B4 {{
 }};
 
 /** @brief Simply put all B tables together. */
-constexpr std::array<Vsop87dTable, 5> B_array { B0, B1, B2, B3, B4, };
+inline constexpr std::array<Vsop87dTable, 5> B_array { B0, B1, B2, B3, B4, };
 
-constexpr Vsop87dTables B { B_array };
+inline constexpr Vsop87dTables B { B_array };
 
 
 #pragma endregion
@@ -1517,7 +1517,7 @@ constexpr Vsop87dTables B { B_array };
 
 #pragma region R0-R5
 
-constexpr std::array<Coefficients, 526> R0 {{
+inline constexpr std::array<Coefficients, 526> R0 {{
   {    100013988.799,            0.0,                0.0, },
   {      1670699.626,  3.09846350771,    6283.0758499914, },
   {        13956.023,   3.0552460962,   12566.1516999828, },
@@ -2046,7 +2046,7 @@ constexpr std::array<Coefficients, 526> R0 {{
   {             0.05,  6.15760345261,  78051.34191383338, },
 }};
 
-constexpr std::array<Coefficients, 292> R1 {{
+inline constexpr std::array<Coefficients, 292> R1 {{
   {       103018.608,  1.10748969588,    6283.0758499914, },
   {         1721.238,  1.06442301418,   12566.1516999828, },
   {          702.215,  3.14159265359,                0.0, },
@@ -2341,7 +2341,7 @@ constexpr std::array<Coefficients, 292> R1 {{
   {             0.02,  5.91915117116,    48739.859897083, },
 }};
 
-constexpr std::array<Coefficients, 139> R2 {{
+inline constexpr std::array<Coefficients, 139> R2 {{
   {         4359.385,  5.78455133738,    6283.0758499914, },
   {          123.633,  5.57934722157,   12566.1516999828, },
   {           12.341,  3.14159265359,                0.0, },
@@ -2483,7 +2483,7 @@ constexpr std::array<Coefficients, 139> R2 {{
   {            0.009,  4.91488110218,      213.299095438, },
 }};
 
-constexpr std::array<Coefficients, 27> R3 {{
+inline constexpr std::array<Coefficients, 27> R3 {{
   {          144.595,  4.27319435148,    6283.0758499914, },
   {            6.729,  3.91697608662,   12566.1516999828, },
   {            0.774,            0.0,                0.0, },
@@ -2513,7 +2513,7 @@ constexpr std::array<Coefficients, 27> R3 {{
   {            0.005,  3.71102966917,    6290.1893969922, },
 }};
 
-constexpr std::array<Coefficients, 10> R4 {{
+inline constexpr std::array<Coefficients, 10> R4 {{
   {            3.858,  2.56384387339,    6283.0758499914, },
   {            0.306,   2.2676950123,   12566.1516999828, },
   {            0.053,  3.44031471924,    5573.1428014331, },
@@ -2526,16 +2526,16 @@ constexpr std::array<Coefficients, 10> R4 {{
   {            0.003,  1.28175749811,    6286.5989683404, },
 }};
 
-constexpr std::array<Coefficients, 3> R5 {{
+inline constexpr std::array<Coefficients, 3> R5 {{
   {            0.086,  1.21579741687,    6283.0758499914, },
   {            0.012,  0.65617264033,   12566.1516999828, },
   {            0.001,  0.38068797142,   18849.2275499742, },
 }};
 
 /** @brief Simply put all R tables together. */
-constexpr std::array<Vsop87dTable, 6> R_array { R0, R1, R2, R3, R4, R5, };
+inline constexpr std::array<Vsop87dTable, 6> R_array { R0, R1, R2, R3, R4, R5, };
 
-constexpr Vsop87dTables R { R_array };
+inline constexpr Vsop87dTables R { R_array };
 
 
 #pragma endregion

--- a/src/astro/vsop87d/vsop87d.hpp
+++ b/src/astro/vsop87d/vsop87d.hpp
@@ -21,5 +21,7 @@
  * along with this project. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "defines.hpp"
 #include "earth_coeff.hpp"

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -27,6 +27,10 @@
 #include <chrono>
 #include <format>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <concepts>
+#include <functional>
 
 #include "ymd.hpp"
 #include "hash.hpp"

--- a/src/calendar/jieqi.hpp
+++ b/src/calendar/jieqi.hpp
@@ -46,7 +46,7 @@ enum class Jieqi : uint8_t {
   LIDONG = 立冬, XIAOXUE = 小雪, DAXUE = 大雪, DONGZHI = 冬至, XIAOHAN = 小寒, DAHAN = 大寒,
 };
 
-constexpr uint8_t JIEQI_COUNT = static_cast<uint8_t>(Jieqi::COUNT);
+inline constexpr uint8_t JIEQI_COUNT = static_cast<uint8_t>(Jieqi::COUNT);
 static_assert(24U == JIEQI_COUNT);
 
 
@@ -96,13 +96,13 @@ constexpr auto from_index(const uint8_t index) -> Jieqi {
 
 
 /** @brief A view of all enum values of `Jieqi`. */
-constexpr auto JIEQI_LIST = std::views::iota(0, static_cast<int8_t>(JIEQI_COUNT)) 
+inline constexpr auto JIEQI_LIST = std::views::iota(0, static_cast<int8_t>(JIEQI_COUNT)) 
                           | std::views::transform([](const auto i) { return from_index(i); });
 
 /** @brief A view of all enum values of `Jieqi`, but ordered by their occurrence in a gregorian year.
  *         That means the first value is "小寒", since it is the first Jieqi in any gregorian year.
  */
-constexpr auto GREGORIAN_YEAR_JIEQI_LIST = std::views::iota(0, static_cast<int8_t>(JIEQI_COUNT)) 
+inline constexpr auto GREGORIAN_YEAR_JIEQI_LIST = std::views::iota(0, static_cast<int8_t>(JIEQI_COUNT)) 
                                          | std::views::transform([](const auto i) { return (i + to_index(Jieqi::小寒)) % JIEQI_COUNT; })
                                          | std::views::transform([](const auto i) { return from_index(i); });
 

--- a/src/calendar/jieqi.hpp
+++ b/src/calendar/jieqi.hpp
@@ -23,11 +23,18 @@
 
 #pragma once
 
+#include <format>
+#include <ranges>
+#include <cstdint>
+#include <string_view>
 #include <unordered_map>
 
+#include "sun.hpp"
 #include "util.hpp"
 #include "astro.hpp"
+#include "cache.hpp"
 #include "datetime.hpp"
+#include "julian_day.hpp"
 
 
 namespace calendar::jieqi {

--- a/src/calendar/lunar/algo1.hpp
+++ b/src/calendar/lunar/algo1.hpp
@@ -25,6 +25,7 @@
 
 #include <array>
 #include <format>
+#include <cstdint>
 
 #include "util.hpp"
 #include "common.hpp"

--- a/src/calendar/lunar/algo1.hpp
+++ b/src/calendar/lunar/algo1.hpp
@@ -45,7 +45,7 @@ constexpr int32_t END_YEAR = 2099;
  * @ref https://www.hko.gov.hk/sc/gts/time/conversion.htm
  * @details Data collected from Hong Kong Observatory.
  */
-constexpr std::array<uint32_t, (END_YEAR - START_YEAR + 1)> LUNAR_DATA = {
+inline constexpr std::array<uint32_t, (END_YEAR - START_YEAR + 1)> LUNAR_DATA = {
   0x620752, 0x4c0ea5, 0x38b64a, 0x5c064b, 0x440a9b, 0x309556, 0x56056a, 0x400b59, 0x2a5752, 0x500752, 
   0x3adb25, 0x600b25, 0x480a4b, 0x32b4ab, 0x5802ad, 0x42056b, 0x2c4b69, 0x520da9, 0x3efd92, 0x640e92, 
   0x4c0d25, 0x36ba4d, 0x5c0a56, 0x4602b6, 0x2e95b5, 0x5606d4, 0x400ea9, 0x2c5e92, 0x500e92, 0x3acd26, 

--- a/src/calendar/lunar/algo1.hpp
+++ b/src/calendar/lunar/algo1.hpp
@@ -35,10 +35,10 @@ namespace calendar::lunar::algo1 {
 using namespace calendar::lunar::common;
 
 /** @brief The first supported lunar year. */
-constexpr int32_t START_YEAR = 1901;
+inline constexpr int32_t START_YEAR = 1901;
 
 /** @brief The last supported lunar year. */
-constexpr int32_t END_YEAR = 2099;
+inline constexpr int32_t END_YEAR = 2099;
 
 /** 
  * @brief The encoded binary data for each lunar year. Info for a year is stored in a uint32_t. 

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -440,10 +440,10 @@ const inline auto get_info_for_year = util::cache::cache_func(calc_lunar_year);
 
 
 /** @brief The first supported lunar year. */
-constexpr int32_t START_YEAR = 410; // Algo2 actually has no limit on year. Simply use 410 here.
+inline constexpr int32_t START_YEAR = 410; // Algo2 actually has no limit on year. Simply use 410 here.
 
 /** @brief The last supported lunar year. */
-constexpr int32_t END_YEAR = 5000; // Algo2 actually has no limit on year. Simply use 5000 here.
+inline constexpr int32_t END_YEAR = 5000; // Algo2 actually has no limit on year. Simply use 5000 here.
 
 /**
  * @brief The bounds of the algorithm, i.e. the supported range of lunar and Gregorian dates.

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -23,12 +23,21 @@
 
 #pragma once
 
+#include <format>
+#include <ranges>
+#include <vector>
+#include <cassert>
+#include <cstdint>
+#include <utility>
 #include <optional>
+#include <iterator>
 #include <algorithm>
+#include <functional>
 
 #include "cache.hpp"
 
 #include "common.hpp"
+#include "datetime.hpp"
 #include "jieqi.hpp"
 #include "moon_phase.hpp"
 #include "julian_day.hpp"

--- a/src/calendar/lunar/algo3.hpp
+++ b/src/calendar/lunar/algo3.hpp
@@ -25,6 +25,7 @@
 
 #include <array>
 #include <format>
+#include <cstdint>
 
 #include "util.hpp"
 #include "common.hpp"

--- a/src/calendar/lunar/algo3.hpp
+++ b/src/calendar/lunar/algo3.hpp
@@ -35,10 +35,10 @@ namespace calendar::lunar::algo3 {
 using namespace calendar::lunar::common;
 
 /** @brief The first supported lunar year. */
-constexpr int32_t START_YEAR = 1600;
+inline constexpr int32_t START_YEAR = 1600;
 
 /** @brief The last supported lunar year. */
-constexpr int32_t END_YEAR = 2199;
+inline constexpr int32_t END_YEAR = 2199;
 
 /** 
  * @brief The encoded binary data for each lunar year. Info for a year is stored in a uint32_t.

--- a/src/calendar/lunar/algo3.hpp
+++ b/src/calendar/lunar/algo3.hpp
@@ -49,7 +49,7 @@ constexpr int32_t END_YEAR = 2199;
  * @details #64: entries for 2133/2165/2172 re-baked with algo5's ΔT — regenerate the
  *          non-HKO entries (statistics/lunar_calendar.ipynb) whenever the default ΔT model changes.
  */
-constexpr std::array<uint32_t, (END_YEAR - START_YEAR + 1)> LUNAR_DATA = {
+inline constexpr std::array<uint32_t, (END_YEAR - START_YEAR + 1)> LUNAR_DATA = {
   0x5a0ba4, 0x420b49, 0x2c7a93, 0x520a95, 0x3cf52d, 0x600556, 0x4a0ab5, 0x36d5aa, 0x5c05d2, 0x440da5,
   0x309d4a, 0x560d4a, 0x400a96, 0x28552e, 0x4e0556, 0x38cab5, 0x5e0ad5, 0x4806d2, 0x328ea5, 0x580f25,
   0x44064a, 0x2a6c97, 0x500a9b, 0x3d155a, 0x62056a, 0x4a0b69, 0x36b752, 0x5c0b52, 0x460b25, 0x2e964b,

--- a/src/calendar/lunar/common.hpp
+++ b/src/calendar/lunar/common.hpp
@@ -27,6 +27,7 @@
 #include <vector>
 #include <ranges>
 #include <numeric>
+#include <cstdint>
 #include <functional>
 
 #include "ymd.hpp"

--- a/src/calendar/lunar/converter.hpp
+++ b/src/calendar/lunar/converter.hpp
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <numeric>
 #include <optional>
 

--- a/src/calendar/lunar/converter.hpp
+++ b/src/calendar/lunar/converter.hpp
@@ -23,10 +23,13 @@
 
 #pragma once
 
+#include <chrono>
 #include <cassert>
 #include <numeric>
+#include <cstdint>
 #include <optional>
 
+#include "ymd.hpp"
 #include "common.hpp"
 
 

--- a/src/shared_lib/lib.hpp
+++ b/src/shared_lib/lib.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
 #include <format>
 #include <print>
 #include <string>

--- a/src/test/astro/delta_t_test.cpp
+++ b/src/test/astro/delta_t_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <numeric>
 #include "util.hpp"

--- a/src/test/astro/delta_t_test_helper.hpp
+++ b/src/test/astro/delta_t_test_helper.hpp
@@ -128,7 +128,7 @@ auto join_with(
   return str.substr(0, str.size() - separator.size());
 }
 
-constexpr int32_t PAD_WIDTH = 10;
+inline constexpr int32_t PAD_WIDTH = 10;
 
 /** @brief Pad the string with spaces. Use generic lambda here
  *         since template function cannot be implicitly instantiated

--- a/src/test/astro/delta_t_test_helper.hpp
+++ b/src/test/astro/delta_t_test_helper.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <vector>
 #include <map>
 #include <unordered_map>
@@ -90,7 +92,7 @@ namespace operation {
 using namespace std::ranges;
 
 /** @brief Evaluate the ΔT values for the given year on all algorithms. */
-auto evaluate(const double year) {
+inline auto evaluate(const double year) {
   return algo_info::DELTA_T_ALGO_FUNCS | views::transform([year](auto func) {
     return func(year);
   });
@@ -99,7 +101,7 @@ auto evaluate(const double year) {
 /** @brief Calculate the differences between:
  *         - the expected ΔT value of the given year 
  *         - and the calculated ΔT values of all algorithms of the given year */
-auto calc_diff(const double year, const double expected_delta_t) {
+inline auto calc_diff(const double year, const double expected_delta_t) {
   return evaluate(year) | views::transform([expected_delta_t](auto delta_t) {
     return delta_t - expected_delta_t;
   });
@@ -113,7 +115,7 @@ auto calc_diff(const double year, const double expected_delta_t) {
 #pragma region Other Helper Functions
 
 // TODO: Use `std::views::join_with` when it gets supported.
-auto join_with(
+inline auto join_with(
   const std::ranges::range auto& view, 
   const std::string& separator
 ) -> std::string {
@@ -141,7 +143,7 @@ const auto pad = []<typename T>(T result) -> std::string {
   return std::vformat("{:^{}}", std::make_format_args(result, PAD_WIDTH));
 };
 
-auto make_line(
+inline auto make_line(
   const std::ranges::range auto& range1, 
   const std::ranges::range auto& range2
 ) -> std::string {

--- a/src/test/astro/delta_t_test_helper.hpp
+++ b/src/test/astro/delta_t_test_helper.hpp
@@ -55,7 +55,7 @@ using DatasetType = std::map<double, double>; // { year, ΔT }
 // Recent values of ΔT from direct observations.
 // 2015+ entries: IERS Bulletin A final values (AstroTime-Analysis @ ddf3be1),
 // median of ±15 days around each year boundary.
-const DatasetType ACCURATE_DELTA_T_TABLE {
+const inline DatasetType ACCURATE_DELTA_T_TABLE {
   { 1955.0, 31.1 },
   { 1960.0, 33.2 },
   { 1965.0, 35.7 },
@@ -95,11 +95,11 @@ namespace algo_info {
 // #64: was `double(int32_t)`, which truncated fractional years.
 using delta_t_func = std::function<double(double)>;
 
-const std::array<std::string, 5> DELTA_T_ALGO_NAMES {
+const inline std::array<std::string, 5> DELTA_T_ALGO_NAMES {
   "algo1", "algo2", "algo3", "algo4", "algo5"
 };
 
-const std::array<delta_t_func, 5> DELTA_T_ALGO_FUNCS {
+const inline std::array<delta_t_func, 5> DELTA_T_ALGO_FUNCS {
   algo1::compute,
   algo2::compute,
   algo3::compute,
@@ -163,7 +163,7 @@ inline constexpr int32_t PAD_WIDTH = 10;
  *         since template function cannot be implicitly instantiated
  *         when using with views/ranges.
  */
-const auto pad = []<typename T>(T result) -> std::string {
+const inline auto pad = []<typename T>(T result) -> std::string {
   if constexpr (std::floating_point<T>) {
     return std::format("{:^{}.3f}", result, PAD_WIDTH);
   }

--- a/src/test/astro/delta_t_test_helper.hpp
+++ b/src/test/astro/delta_t_test_helper.hpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <vector>

--- a/src/test/astro/delta_t_test_helper.hpp
+++ b/src/test/astro/delta_t_test_helper.hpp
@@ -23,6 +23,10 @@
 
 #pragma once
 
+#include <array>
+#include <concepts>
+#include <cstdint>
+#include <string>
 #include <vector>
 #include <map>
 #include <unordered_map>

--- a/src/test/astro/earth_test.cpp
+++ b/src/test/astro/earth_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <tuple>
 #include <unordered_map>

--- a/src/test/astro/elp2000_82b_test.cpp
+++ b/src/test/astro/elp2000_82b_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <tuple>
 #include <unordered_map>

--- a/src/test/astro/julian_day_test.cpp
+++ b/src/test/astro/julian_day_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <limits>
 #include <unordered_map>

--- a/src/test/astro/leap_second_test.cpp
+++ b/src/test/astro/leap_second_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2026 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <chrono>
 #include <cstdlib>

--- a/src/test/astro/moon_phase_test.cpp
+++ b/src/test/astro/moon_phase_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <print>
 #include <vector>

--- a/src/test/astro/moon_test.cpp
+++ b/src/test/astro/moon_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <tuple>
 #include <unordered_map>

--- a/src/test/astro/sun_test.cpp
+++ b/src/test/astro/sun_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <chrono>
 #include "util.hpp"

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <cmath>
 #include "toolbox.hpp"

--- a/src/test/astro/vsop87d_test.cpp
+++ b/src/test/astro/vsop87d_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include "julian_day.hpp"
 #include "vsop87d/vsop87d.hpp"

--- a/src/test/datetime_test.cpp
+++ b/src/test/datetime_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <print>
 #include <limits>

--- a/src/test/jieqi_test.cpp
+++ b/src/test/jieqi_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <ranges>

--- a/src/test/lunar/algo1_test.cpp
+++ b/src/test/lunar/algo1_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <vector>
 #include "random.hpp"

--- a/src/test/lunar/algo2_test.cpp
+++ b/src/test/lunar/algo2_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <algorithm>
 #include "lunar/algo2.hpp"

--- a/src/test/lunar/algo3_test.cpp
+++ b/src/test/lunar/algo3_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <vector>

--- a/src/test/lunar/converter_test.cpp
+++ b/src/test/lunar/converter_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include "lunar/converter.hpp"
 #include "lunar/algo1.hpp"

--- a/src/test/lunar/diff_test.cpp
+++ b/src/test/lunar/diff_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <ranges>

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -1,3 +1,26 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2024 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <gtest/gtest.h>
 #include <print>
 #include <atomic>

--- a/src/util/random.hpp
+++ b/src/util/random.hpp
@@ -26,6 +26,7 @@
 
 #include <cassert>
 #include <cerrno>
+#include <concepts>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>

--- a/src/util/util.hpp
+++ b/src/util/util.hpp
@@ -21,6 +21,8 @@
  * along with this project. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "ymd.hpp"
 #include "hash.hpp"
 #include "cache.hpp"

--- a/src/util/ymd.hpp
+++ b/src/util/ymd.hpp
@@ -23,7 +23,10 @@
 
 #pragma once
 
+#include <tuple>
 #include <chrono>
+#include <cstdint>
+#include <concepts>
 
 namespace util {
 

--- a/statistics/common.py
+++ b/statistics/common.py
@@ -1,3 +1,15 @@
+# CelestialCalendar Statistics:
+#   Golden-dataset crawlers and evaluation notebooks for the CelestialCalendar C++ project.
+#   No model training happens here (see AGENTS.md).
+# 
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+# License: GNU General Public License v3.0
+# 
+# This software is distributed without any warranty.
+# See <https://www.gnu.org/licenses/> for more details.
+
 import sys
 from enum import Enum
 from pathlib import Path

--- a/statistics/fk5_correction_dataset.py
+++ b/statistics/fk5_correction_dataset.py
@@ -1,3 +1,15 @@
+# CelestialCalendar Statistics:
+#   Golden-dataset crawlers and evaluation notebooks for the CelestialCalendar C++ project.
+#   No model training happens here (see AGENTS.md).
+# 
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+# License: GNU General Public License v3.0
+# 
+# This software is distributed without any warranty.
+# See <https://www.gnu.org/licenses/> for more details.
+
 # This file regenerates the FK5-correction dataset in src/test/astro/sun_test.cpp (#68):
 # it evaluates Meeus (25.9) with mpmath at 50-digit precision,
 #   λ' = λ − (1.397 + 0.00031·T)·T                          [deg; T = Julian century from J2000.0]

--- a/statistics/moon_horizons_crawler.py
+++ b/statistics/moon_horizons_crawler.py
@@ -1,3 +1,15 @@
+# CelestialCalendar Statistics:
+#   Golden-dataset crawlers and evaluation notebooks for the CelestialCalendar C++ project.
+#   No model training happens here (see AGENTS.md).
+# 
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+# License: GNU General Public License v3.0
+# 
+# This software is distributed without any warranty.
+# See <https://www.gnu.org/licenses/> for more details.
+
 # This file downloads the golden dataset for the Moon geocentric-position tests (#94 / #65):
 # - Primary source: JPL Horizons API (ssd.jpl.nasa.gov/api/horizons.api), Moon (301) seen from
 #   the geocenter (500@399), ephemeris DE441. Times are given and returned in TT (TIME_TYPE=TT),

--- a/statistics/moon_phase_crawler.py
+++ b/statistics/moon_phase_crawler.py
@@ -1,3 +1,15 @@
+# CelestialCalendar Statistics:
+#   Golden-dataset crawlers and evaluation notebooks for the CelestialCalendar C++ project.
+#   No model training happens here (see AGENTS.md).
+# 
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+# License: GNU General Public License v3.0
+# 
+# This software is distributed without any warranty.
+# See <https://www.gnu.org/licenses/> for more details.
+
 # This file is used to download:
 # - the Moon Phases from "丹尼爾的神祕學世界"（The Secret World of Daniel）
 # Ref: https://www.taipeidaniel.idv.tw/articles-astrology-moon-new-full.htm

--- a/statistics/sun_jieqi_golden_crawler.py
+++ b/statistics/sun_jieqi_golden_crawler.py
@@ -1,3 +1,15 @@
+# CelestialCalendar Statistics:
+#   Golden-dataset crawlers and evaluation notebooks for the CelestialCalendar C++ project.
+#   No model training happens here (see AGENTS.md).
+# 
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+# License: GNU General Public License v3.0
+# 
+# This software is distributed without any warranty.
+# See <https://www.gnu.org/licenses/> for more details.
+
 # This file downloads the golden datasets for the Sun-position and jieqi tests (#94 / #68):
 # - Axis 1, Sun apparent position: JPL Horizons API, Sun (10) from the geocenter (500@399),
 #   DE441, TT in and out. Quantity 31 = IAU76/80 true-ecliptic-of-date apparent lon/lat —

--- a/statistics/sunrise_golden_crawler.py
+++ b/statistics/sunrise_golden_crawler.py
@@ -1,3 +1,15 @@
+# CelestialCalendar Statistics:
+#   Golden-dataset crawlers and evaluation notebooks for the CelestialCalendar C++ project.
+#   No model training happens here (see AGENTS.md).
+# 
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+# License: GNU General Public License v3.0
+# 
+# This software is distributed without any warranty.
+# See <https://www.gnu.org/licenses/> for more details.
+
 # This file is used to download the golden dataset for sunrise/sunset tests (#44):
 # - Primary source: USNO "Complete Sun and Moon Data for One Day" API (aa.usno.navy.mil/api/rstt/oneday),
 #   queried per site at its fixed standard-time offset (no DST), so each response lists the


### PR DESCRIPTION
Closes #71.

风格架构批 P1(地基)。九个提交,每个门禁独立全绿,顺序可逐个回滚。

## 内容

| 提交 | 做了什么 |
|---|---|
| `844bdf2` | `.gitignore` 加 `.review/` —— 该目录未跟踪但 `linter.py` 是 `ruff check <仓根>`,里面一个 `.py` 探针就能弄红门禁(#102 教训) |
| `fd37361` | **ODR/IFNDR 修复**:31 张系数表裸 `constexpr` → `inline constexpr` |
| `a662c3a` | 其余 27 个 header 常量补 `inline`,对齐 AGENTS.md |
| `3513c2b` | `converter.hpp` 补 `<cassert>` |
| `d3800fd` | 3 个缺失的 `#pragma once`;`delta_t_test_helper.hpp` 的四个自由函数改 `inline` |
| `b6443db` | 25 个文件补 GPL 头(19 测试 + 6 `statistics/*.py`) |
| `3f03150` | IWYU:56 个缺失 include;`fk5_correction` 的裸 `cos/sin/tan` 加 `std::` |
| `0f42820` | AGENTS.md 三处失真修正 + 写下本 PR 落实的两条规则 |
| `d24f51c` | **自包含闸门进 CI**,三个标准库并跑 |

## 验证

**ODR 是 31 张表不是 26 张。** 审计只扫了 `earth_coeff.hpp`(23)与 `earth.hpp`(3)—— 那是引爆点最显眼的地方。同一模式还在五处,且全部被外部链接的 `inline`/`constexpr` 函数 odr-use:`delta_t.hpp` 的 `ALGO1_COEFFICIENTS`(`pairwise`)、`elp2000_82b.hpp` 的 `LR`/`B`(`views::transform`)、`algo1.hpp` 与 `algo3.hpp` 的 `LUNAR_DATA`(下标)。只修看得见的 26 张会把同一个潜伏 bug 留在剩下五处。另有 `jieqi.hpp` 的 `GREGORIAN_YEAR_JIEQI_LIST`,被 `JieqiGenerator` 构造函数里的 range-for 绑 `auto&&`,藏在常量堆里的同一个缺陷。

**数值零影响是测出来的。** hexfloat 探针打 `delta_t::algo1`、`elp2000_82b::evaluate`、两个 `calc_lunar_year`,改动前后**逐位相同**。

**ODR 修复是有效的,也测了。** 两个 TU 同时 include `delta_t_test_helper.hpp`,改前:

```
duplicate symbol 'astro::delta_t::operation::calc_diff(double, double)'
ld: 2 duplicate symbols
```

改后正常链接。

**「31/31 PASS ⇒ #71 四条全部证伪」这个结论本身是错的。** 逐头 `-fsyntax-only` 在 MSVC STL 上是 31/31,在 libc++ 上是 **30/31** —— `converter.hpp` 用 `assert` 却没 include `<cassert>`,MSVC STL 传递泄漏了它,libc++ 没有。**自包含性是标准库的属性,不是代码的属性**,所以 CI 闸门做成三条腿(libstdc++ / libc++ / MSVC STL),单腿绿等于没跑。

**IWYU 106 → 2。** `misc-include-cleaner` 原报 106 处(注意那是 use site 数且含项目内符号,不是 106 个缺失 include)。剩下 2 处是误报:`leap_second.hpp` 的 `ranges::upper_bound` 来自已 include 的 `<algorithm>`、`ymd.hpp` 的 `chrono::days` 来自已 include 的 `<chrono>`,include-cleaner 把它们归给了 libc++ 内部细节头。实际为 0。

**闸门验证过会红,不只是会绿。** 删掉那行 `<cassert>`,`linter.py --self-contained` exit 1 并打印该补什么。

## 测试

`./project.py --all` 全程 **198/198,exit 0**;`linter.py --self-contained` 31/31;ruff clean。每个提交都单独跑过门禁。

## 范围说明

- **#71 验收里「`astro.hpp` 补 `sidereal_time.hpp` / `coord_transform.hpp`」已经是 no-op** —— 两个 include 早被后续 PR 加上了,本 PR 无改动。
- **`enable_testing()` 的根因留在 #72**,本 PR 只改 `AGENTS.md:117` 那行错误指令(它让每个新接手者第一步就拿到假绿)。
- AGENTS.md 三处失真修正是**从 #127 前移**过来的(用户 2026-08-02 裁决),3 行文字不抬审阅档位。
- 本 PR **不含**任何数值或行为改动。

审阅档:单轮正确性快扫 + CI 全绿即可。