### PR TITLE
test(sunrise)+build: margin 论证与「等编译器」TODO 做成机器闸门 (#126, #131, #99)

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -259,11 +259,13 @@ jobs:
   # gate fails when someone breaks a header, this one fails when the world moves and a waiting
   # TODO becomes actionable. Sharing a job would let either verdict hide the other.
   #
-  # clang++ on the Linux leg rather than g++-14, even though the project builds with both: the
-  # two share libstdc++'s headers, and clang is the stricter consumer of them, so it gives the
-  # conservative answer. The Docker arm64/x86_64 legs are not probed -- they track the same
-  # libstdc++ family as this one, and a per-image toolchain difference would surface there as a
-  # build failure rather than as a missed unlock here.
+  # clang++-18 on the Linux leg, which pairs it with the runner's default libstdc++ -- exactly
+  # what `test-ubuntu-clang` builds against. That is deliberately NOT the same standard library
+  # as `test-ubuntu-gcc14`, which installs g++-14 and gets libstdc++-14: `<generator>` landed in
+  # libstdc++ 14, and this leg measures it as gated, which is the difference showing through.
+  # Probing the weaker of the two is the useful answer, since adoption has to wait for it either
+  # way. The Docker arm64/x86_64 legs are not probed -- a toolchain difference in those images
+  # surfaces there as a build failure rather than as a missed unlock here.
   cxx-feature-probe:
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -282,6 +284,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+
+      # Same Xcode the macOS build leg pins. Without it this job reads the image default, and
+      # the baseline would record a toolchain the project never actually compiles with.
+      - uses: maxim-lobanov/setup-xcode@v1
+        if: runner.os == 'macOS'
+        with:
+          xcode-version: latest-stable
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -252,3 +252,62 @@ jobs:
         env:
           CXX: ${{ matrix.cxx }}
         run: python ./linter.py --self-contained
+
+
+  # Which of the C++ features the codebase is waiting on each standard library can actually
+  # compile (#131, #99). Deliberately a separate job from the self-containment one above: that
+  # gate fails when someone breaks a header, this one fails when the world moves and a waiting
+  # TODO becomes actionable. Sharing a job would let either verdict hide the other.
+  #
+  # clang++ on the Linux leg rather than g++-14, even though the project builds with both: the
+  # two share libstdc++'s headers, and clang is the stricter consumer of them, so it gives the
+  # conservative answer. The Docker arm64/x86_64 legs are not probed -- they track the same
+  # libstdc++ family as this one, and a per-image toolchain difference would surface there as a
+  # build failure rather than as a missed unlock here.
+  cxx-feature-probe:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04     # libstdc++
+            leg: libstdc++
+            cxx: clang++-18
+          - runner: macos-latest     # libc++
+            leg: libc++
+            cxx: clang++
+          - runner: windows-latest   # MSVC STL
+            leg: msvc-stl
+            cxx: clang++
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install Python Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r Requirements.txt
+
+      - name: Install clang (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo add-apt-repository universe
+          sudo apt update
+          sudo apt install -y clang-18
+
+      - name: Install clang (Windows)
+        if: runner.os == 'Windows'
+        run: choco install -y llvm
+
+      # Report only for now: this run is what supplies the numbers for `EXPECTED` in
+      # automation/feature_probe.py, and a baseline asserted before it was measured would be
+      # exactly the kind of claim this batch exists to delete.
+      - name: Probe awaited C++ features (${{ matrix.leg }})
+        env:
+          CXX: ${{ matrix.cxx }}
+        run: python ./linter.py --features

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -304,10 +304,7 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install -y llvm
 
-      # Report only for now: this run is what supplies the numbers for `EXPECTED` in
-      # automation/feature_probe.py, and a baseline asserted before it was measured would be
-      # exactly the kind of claim this batch exists to delete.
       - name: Probe awaited C++ features (${{ matrix.leg }})
         env:
           CXX: ${{ matrix.cxx }}
-        run: python ./linter.py --features
+        run: python ./linter.py --features ${{ matrix.leg }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,11 +283,10 @@ toolbox/        Helper scripts for artifacts, releases, build info
    **modules**, `std::generator`, and C++23 ranges additions like `std::views::enumerate` /
    `pairwise` — wait for compiler support, then get adopted (README §7 tracks the wishlist).
    **Availability is settled by compiling a real use of the feature, never by reading a
-   feature-test macro:** libc++ implements `std::ranges::fold_left` and does not define
-   `__cpp_lib_ranges_fold`, so a macro scan reported a usable feature as missing (#131). That
-   is what `./linter.py --features` does, once per standard library; CI holds each leg to the
-   state recorded in `automation/feature_probe.py`, so the day a leg gains one of these the
-   gate says so and names the sites still hand-rolling around it.
+   feature-test macro** (#131: libc++ ships `std::ranges::fold_left` without defining
+   `__cpp_lib_ranges_fold`). `./linter.py --features LEG` holds each CI leg to the state in
+   `automation/feature_probe.py`; an unlock fails CI, and names the waiting sites it can see --
+   which means the ones tagged `TODO` with the feature's name, not untagged hand-rolling.
 3. **Shared library target:** `src/shared_lib/CMakeLists.txt` builds `libcelestial_calendar`
    from `lib*.cpp`. Version is injected via the `BUILD_VERSION` environment variable
    (defaults to `0.0.0`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,11 +280,14 @@ toolbox/        Helper scripts for artifacts, releases, build info
    extend this one.
 2. **C++23 features — "not yet", not "never":** basic C++20 ranges/views are in active use
    (`std::views::transform` etc.). Features the weakest CI toolchain doesn't support yet —
-   currently **modules**, `std::generator`, and C++23 ranges additions like
-   `std::views::cartesian_product` / `pairwise` — wait for compiler support, then get adopted
-   (README §7 tracks the wishlist). Before using one, check support across the whole CI matrix
-   (Apple Clang / clang 18 / gcc 14 / MSVC STL / Docker ARM) and drop a note when graduating
-   a feature off this list.
+   **modules**, `std::generator`, and C++23 ranges additions like `std::views::enumerate` /
+   `pairwise` — wait for compiler support, then get adopted (README §7 tracks the wishlist).
+   **Availability is settled by compiling a real use of the feature, never by reading a
+   feature-test macro:** libc++ implements `std::ranges::fold_left` and does not define
+   `__cpp_lib_ranges_fold`, so a macro scan reported a usable feature as missing (#131). That
+   is what `./linter.py --features` does, once per standard library; CI holds each leg to the
+   state recorded in `automation/feature_probe.py`, so the day a leg gains one of these the
+   gate says so and names the sites still hand-rolling around it.
 3. **Shared library target:** `src/shared_lib/CMakeLists.txt` builds `libcelestial_calendar`
    from `lib*.cpp`. Version is injected via the `BUILD_VERSION` environment variable
    (defaults to `0.0.0`).

--- a/README.md
+++ b/README.md
@@ -203,8 +203,11 @@ There are basically two ways to download:
 
 * C++20/23 features are not fully supported by the compilers...
   * Modules
-  * Ranges and views (e.g. cartesian_product...)
-  * Use `std::generator` in Newton's method (moon_phase and jiqei).
+  * Ranges and views (e.g. `std::views::enumerate`, `pairwise`, `join_with`...)
+  * Use `std::generator` in Newton's method (moon_phase and jieqi).
+  * Which of these a toolchain can actually compile: `./linter.py --features`. CI runs the same
+    probe on libstdc++ / libc++ / MSVC STL and fails when a leg gains a feature the code is
+    still hand-rolling around, so the list above cannot go quietly stale.
 * DUT1 (i.e. UT1 - UTC) is not modelled
   * UTC became a first-class time scale in v0.4.0 (leap-second aware, `utc_to_tt` / `tt_to_utc`), but UT1 and UTC are still treated as interchangeable — the gap stays below 0.9 s while leap seconds are in force.
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ There are basically two ways to download:
 
 * C++20/23 features are not fully supported by the compilers...
   * Modules
-  * Ranges and views (e.g. `std::views::enumerate`, `pairwise`, `join_with`...)
+  * Ranges and views (e.g. `std::views::enumerate`, `pairwise`...)
   * Use `std::generator` in Newton's method (moon_phase and jieqi).
   * Which of these a toolchain can actually compile: `./linter.py --features`. CI runs the same
     probe on libstdc++ / libc++ / MSVC STL and fails when a leg gains a feature the code is

--- a/automation/__init__.py
+++ b/automation/__init__.py
@@ -27,6 +27,7 @@ from .paths import (
 from .github import GitHub
 from .linter import run_ruff, run_clang_tidy
 from .self_contained import check_self_contained
+from .feature_probe import probe_features
 
 __all__ = [
   "Tool", "CompilerArgs", "check_c_support", "check_cpp_support", "make_compiler_args",
@@ -36,5 +37,5 @@ __all__ = [
   "green_print", "red_print", "yellow_print", "blue_print",
   "run_cmd", "ProcReturn", "time_execution",
   "proj_root", "build_dir", "cpp_src_dir", "python_requirements", "cpp_test_dir",
-  "GitHub", "run_ruff", "run_clang_tidy", "check_self_contained"
+  "GitHub", "run_ruff", "run_clang_tidy", "check_self_contained", "probe_features"
 ]

--- a/automation/feature_probe.py
+++ b/automation/feature_probe.py
@@ -29,10 +29,11 @@ CXX_STANDARD: Final[str] = "c++23"
 class Feature:
   """A library feature the codebase is waiting on, and a program that really uses it."""
 
-  name: str      # As written in the code, e.g. "std::views::enumerate".
-  token: str     # Substring that identifies this feature in a TODO comment.
-  issue: str     # Where the adoption work is tracked.
-  program: str   # Must *use* the feature -- a feature-test macro is not evidence (see below).
+  name: str        # As written in the code, e.g. "std::views::enumerate".
+  token: str       # Substring that identifies this feature in a TODO comment.
+  issue: str       # Where the adoption work is tracked.
+  program: str     # Must *use* the feature -- a feature-test macro is not evidence (see below).
+  deferred: str = ""  # Why it stays hand-rolled even where it compiles. Empty means adopt on sight.
 
 
 # Every probe compiles a real use of the feature. Reading `__cpp_lib_*` is not enough: libc++
@@ -56,6 +57,8 @@ FEATURES: Final[List[Feature]] = [
     name="std::ranges::fold_left",
     token="fold_left",
     issue="#131",
+    deferred=("compiles everywhere, but MS STL's result drifts 1-3 ulp from the hand-rolled sum "
+              "from n~63 up, which would fork the golden data per platform (#131)"),
     program="""
       #include <algorithm>
       #include <functional>
@@ -150,12 +153,17 @@ FEATURES: Final[List[Feature]] = [
 ]
 
 
-# What each CI leg is known to support today. A mismatch is the point of this gate: it fires
-# the day a runner's toolchain gains one of these, which is the day the waiting TODOs become
-# actionable -- and nothing else in the repo would ever notice.
+# What each CI leg supports, measured by this probe on 2026-08-02 -- not inferred from release
+# notes, and not guessed. A mismatch is the point of the gate: it fires the day a runner's
+# toolchain gains one of these, which is the day the waiting TODOs become actionable, and
+# nothing else in the repo would ever notice.
+#
+#   libstdc++  clang 18.1.3 on ubuntu-24.04
+#   libc++     Apple clang 21.0.0 on macos-latest
+#   msvc-stl   clang 20.1.8 on windows-latest
 EXPECTED: Final[Dict[str, Dict[str, bool]]] = {
   "libstdc++": {
-    "std::generator": True,
+    "std::generator": False,
     "std::ranges::fold_left": True,
     "std::views::enumerate": True,
     "std::views::pairwise": True,
@@ -170,7 +178,7 @@ EXPECTED: Final[Dict[str, Dict[str, bool]]] = {
     "std::views::enumerate": False,
     "std::views::pairwise": False,
     "std::views::slide": False,
-    "std::views::join_with": False,
+    "std::views::join_with": True,
     "std::views::concat": False,
     "std::function_ref": False,
   },
@@ -208,6 +216,19 @@ def todo_sites(token: str) -> List[str]:
   return sites
 
 
+def adoptable(feature: Feature) -> List[str]:
+  """The sites that could stop hand-rolling `feature` today, if any.
+
+  Detecting *changes* is not enough on its own. Once a feature is recorded as usable everywhere
+  the comparison above goes quiet forever, and the TODOs it unblocked would sit there unread --
+  the exact failure mode this gate replaces. So the recorded state is also read forwards: usable
+  on every leg, nothing recorded holding it back, and sites still working around it.
+  """
+  if feature.deferred or not all(EXPECTED[leg][feature.name] for leg in EXPECTED):
+    return []
+  return todo_sites(feature.token)
+
+
 def probe(cxx: str, feature: Feature) -> bool:
   """Compile a program that uses `feature`, and report whether it built."""
   with tempfile.TemporaryDirectory() as tmp:
@@ -236,9 +257,17 @@ def probe_features(leg: Optional[str] = None) -> int:
   blue_print(f"# Compiler: {cxx} -std={CXX_STANDARD}")
   blue_print(f"# {(version.stdout or '').splitlines()[0] if version.stdout else 'version unknown'}")
 
-  if leg is not None and leg not in EXPECTED:
-    red_print(f"Unknown CI leg '{leg}'. Known legs: {', '.join(sorted(EXPECTED))}")
-    return 1
+  if leg is not None:
+    if leg not in EXPECTED:
+      red_print(f"Unknown CI leg '{leg}'. Known legs: {', '.join(sorted(EXPECTED))}")
+      return 1
+    # A feature added to FEATURES but not to EXPECTED would otherwise read as "just unlocked"
+    # on every leg forever, which is a gate that cries wolf rather than one that has a baseline.
+    unrecorded = [f.name for f in FEATURES if f.name not in EXPECTED[leg]]
+    if unrecorded:
+      red_print(f"No recorded state on '{leg}' for: {', '.join(unrecorded)}")
+      yellow_print(f"Run `./linter.py --features` on that toolchain and add the result to EXPECTED['{leg}'].")
+      return 1
 
   actual: Dict[str, bool] = {}
   for feature in FEATURES:
@@ -252,16 +281,26 @@ def probe_features(leg: Optional[str] = None) -> int:
     green_print(f"{sum(actual.values())} of {len(FEATURES)} probed feature(s) usable here (report only)")
     return 0
 
-  changed = [f for f in FEATURES if actual[f.name] != EXPECTED[leg].get(f.name)]
+  changed = [f for f in FEATURES if actual[f.name] != EXPECTED[leg][f.name]]
   if not changed:
     green_print(f"All {len(FEATURES)} feature(s) match the recorded state of '{leg}'")
-    return 0
+
+    ready = {f: sites for f in FEATURES if (sites := adoptable(f))}
+    if not ready:
+      return 0
+
+    red_print("These compile on every leg, and the code is still working around them:")
+    for feature, sites in ready.items():
+      red_print(f"  {feature.name} ({feature.issue}) -- {len(sites)} site(s):")
+      for site in sites:
+        red_print(f"    {site}")
+    yellow_print("Adopt them and drop the TODO, or record why not in that Feature's `deferred` field.")
+    return 1
 
   red_print(f"The toolchain on '{leg}' no longer matches what this repo recorded:")
   for feature in changed:
-    was = EXPECTED[leg].get(feature.name)
     if actual[feature.name]:
-      green_print(f"  + {feature.name} is now USABLE (was recorded as {'usable' if was else 'gated'})")
+      green_print(f"  + {feature.name} is now USABLE (recorded as gated)")
       sites = todo_sites(feature.token)
       if sites:
         yellow_print(f"    Adopt it at {len(sites)} waiting site(s), then delete the TODO:")

--- a/automation/feature_probe.py
+++ b/automation/feature_probe.py
@@ -188,6 +188,10 @@ def todo_sites(token: str) -> List[str]:
   Derived, not listed: a hand-maintained site list would go stale between the day a feature
   unlocks and the day someone reads this file -- which is the whole interval this gate exists
   to cover.
+
+  Both words have to land on one line, so a TODO that wraps its feature name onto the next one
+  goes unseen here. That blind spot is covered where it would matter: the feature reaches
+  `monuments()` instead, which refuses to let it sit in the table with nothing to point at.
   """
   src_dir = paths.cpp_src_dir()
   root = paths.proj_root()

--- a/automation/feature_probe.py
+++ b/automation/feature_probe.py
@@ -1,0 +1,276 @@
+# CelestialCalendar Automation:
+#   Python automation scripts for building and testing the CelestialCalendar C++ project.
+#
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+# License: GNU General Public License v3.0
+#
+# This software is distributed without any warranty.
+# See <https://www.gnu.org/licenses/> for more details.
+
+import os
+import tempfile
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Final, List, Optional
+
+from . import paths
+from .utils import run_cmd, green_print, red_print, yellow_print, blue_print
+
+
+# The standard the project builds with. A feature reachable only under a later -std is not
+# usable here, so probing under anything else would report a capability we cannot spend.
+CXX_STANDARD: Final[str] = "c++23"
+
+
+@dataclass(frozen=True)
+class Feature:
+  """A library feature the codebase is waiting on, and a program that really uses it."""
+
+  name: str      # As written in the code, e.g. "std::views::enumerate".
+  token: str     # Substring that identifies this feature in a TODO comment.
+  issue: str     # Where the adoption work is tracked.
+  program: str   # Must *use* the feature -- a feature-test macro is not evidence (see below).
+
+
+# Every probe compiles a real use of the feature. Reading `__cpp_lib_*` is not enough: libc++
+# 210106 implements `std::ranges::fold_left` and does not define `__cpp_lib_ranges_fold`, so a
+# macro scan reports a usable feature as missing -- which is exactly how #131 came to be filed
+# as "blocked on Apple Clang" when it was not.
+FEATURES: Final[List[Feature]] = [
+  Feature(
+    name="std::generator",
+    token="generator",
+    issue="#99",
+    program="""
+      #include <generator>
+      auto gen() -> std::generator<int> { co_yield 1; }
+      auto main() -> int {
+        for (const int v : gen()) { (void) v; }
+      }
+    """,
+  ),
+  Feature(
+    name="std::ranges::fold_left",
+    token="fold_left",
+    issue="#131",
+    program="""
+      #include <algorithm>
+      #include <functional>
+      #include <vector>
+      auto main() -> int {
+        const std::vector<int> v { 1, 2, 3 };
+        return std::ranges::fold_left(v, 0, std::plus {}) == 6 ? 0 : 1;
+      }
+    """,
+  ),
+  Feature(
+    name="std::views::enumerate",
+    token="enumerate",
+    issue="#131",
+    program="""
+      #include <ranges>
+      #include <vector>
+      auto main() -> int {
+        const std::vector<int> v { 1, 2, 3 };
+        for (const auto& [i, x] : std::views::enumerate(v)) { (void) i; (void) x; }
+      }
+    """,
+  ),
+  Feature(
+    name="std::views::pairwise",
+    token="pairwise",
+    issue="#131",
+    program="""
+      #include <ranges>
+      #include <vector>
+      auto main() -> int {
+        const std::vector<int> v { 1, 2, 3 };
+        for (const auto& pair : v | std::views::pairwise) { (void) pair; }
+      }
+    """,
+  ),
+  Feature(
+    name="std::views::slide",
+    token="slide",
+    issue="#131",
+    program="""
+      #include <ranges>
+      #include <vector>
+      auto main() -> int {
+        const std::vector<int> v { 1, 2, 3 };
+        for (const auto& window : v | std::views::slide(2)) { (void) window; }
+      }
+    """,
+  ),
+  Feature(
+    name="std::views::join_with",
+    token="join_with",
+    issue="#131",
+    program="""
+      #include <ranges>
+      #include <string>
+      #include <vector>
+      auto main() -> int {
+        const std::vector<std::string> parts { "a", "b" };
+        for (const char c : parts | std::views::join_with(std::string { ", " })) { (void) c; }
+      }
+    """,
+  ),
+  Feature(
+    # C++26, so it stays unavailable until the project's own -std moves too. Kept in the table
+    # because two sites already hand-roll around it and this is where they will find out.
+    name="std::views::concat",
+    token="concat",
+    issue="#131",
+    program="""
+      #include <ranges>
+      #include <vector>
+      auto main() -> int {
+        const std::vector<int> a { 1 };
+        const std::vector<int> b { 2 };
+        for (const int x : std::views::concat(a, b)) { (void) x; }
+      }
+    """,
+  ),
+  Feature(
+    # C++26. Wanted by the type-erasure cleanup (#98): `std::function` allocates where a
+    # non-owning callable reference would not.
+    name="std::function_ref",
+    token="function_ref",
+    issue="#98",
+    program="""
+      #include <functional>
+      auto twice(std::function_ref<int(int)> f) -> int { return f(1) + f(2); }
+      auto main() -> int { return twice([](const int x) { return x; }); }
+    """,
+  ),
+]
+
+
+# What each CI leg is known to support today. A mismatch is the point of this gate: it fires
+# the day a runner's toolchain gains one of these, which is the day the waiting TODOs become
+# actionable -- and nothing else in the repo would ever notice.
+EXPECTED: Final[Dict[str, Dict[str, bool]]] = {
+  "libstdc++": {
+    "std::generator": True,
+    "std::ranges::fold_left": True,
+    "std::views::enumerate": True,
+    "std::views::pairwise": True,
+    "std::views::slide": True,
+    "std::views::join_with": True,
+    "std::views::concat": False,
+    "std::function_ref": False,
+  },
+  "libc++": {
+    "std::generator": False,
+    "std::ranges::fold_left": True,
+    "std::views::enumerate": False,
+    "std::views::pairwise": False,
+    "std::views::slide": False,
+    "std::views::join_with": False,
+    "std::views::concat": False,
+    "std::function_ref": False,
+  },
+  "msvc-stl": {
+    "std::generator": True,
+    "std::ranges::fold_left": True,
+    "std::views::enumerate": True,
+    "std::views::pairwise": True,
+    "std::views::slide": True,
+    "std::views::join_with": True,
+    "std::views::concat": False,
+    "std::function_ref": False,
+  },
+}
+
+
+def todo_sites(token: str) -> List[str]:
+  """Find the TODO comments waiting on `token`, with their current line numbers.
+
+  Derived, not listed: a hand-maintained site list would go stale between the day a feature
+  unlocks and the day someone reads this file -- which is the whole interval this gate exists
+  to cover.
+  """
+  src_dir = paths.cpp_src_dir()
+  root = paths.proj_root()
+  sites: List[str] = []
+
+  for source in sorted(src_dir.rglob("*")):
+    if source.suffix not in {".hpp", ".cpp", ".h"}:
+      continue
+    for number, line in enumerate(source.read_text(encoding="utf-8").splitlines(), start=1):
+      if "TODO" in line and token in line:
+        sites.append(f"{source.relative_to(root)}:{number}")
+
+  return sites
+
+
+def probe(cxx: str, feature: Feature) -> bool:
+  """Compile a program that uses `feature`, and report whether it built."""
+  with tempfile.TemporaryDirectory() as tmp:
+    source = Path(tmp) / "probe.cpp"
+    source.write_text(feature.program, encoding="utf-8")
+    ret = run_cmd(
+      [cxx, f"-std={CXX_STANDARD}", "-fsyntax-only", str(source)],
+      print_cmd=False,
+      print_stdout=False,
+      print_stderr=False,
+    )
+    return ret.retcode == 0
+
+
+def probe_features(leg: Optional[str] = None) -> int:
+  """Report which awaited C++ features this toolchain can actually compile.
+
+  With `leg` naming a CI leg, the result is compared against `EXPECTED` and a difference is
+  an error. Without one, the probe only reports -- a local toolchain is nobody's baseline.
+  """
+  print("#" * 60)
+  yellow_print("Probing C++ features the codebase is waiting on...")
+
+  cxx = os.environ.get("CXX", "clang++")
+  version = run_cmd([cxx, "--version"], print_cmd=False, print_stdout=False, print_stderr=False)
+  blue_print(f"# Compiler: {cxx} -std={CXX_STANDARD}")
+  blue_print(f"# {(version.stdout or '').splitlines()[0] if version.stdout else 'version unknown'}")
+
+  if leg is not None and leg not in EXPECTED:
+    red_print(f"Unknown CI leg '{leg}'. Known legs: {', '.join(sorted(EXPECTED))}")
+    return 1
+
+  actual: Dict[str, bool] = {}
+  for feature in FEATURES:
+    actual[feature.name] = probe(cxx, feature)
+    (green_print if actual[feature.name] else yellow_print)(
+      f"{'USABLE  ' if actual[feature.name] else 'GATED   '}{feature.name}"
+    )
+
+  print("#" * 60)
+  if leg is None:
+    green_print(f"{sum(actual.values())} of {len(FEATURES)} probed feature(s) usable here (report only)")
+    return 0
+
+  changed = [f for f in FEATURES if actual[f.name] != EXPECTED[leg].get(f.name)]
+  if not changed:
+    green_print(f"All {len(FEATURES)} feature(s) match the recorded state of '{leg}'")
+    return 0
+
+  red_print(f"The toolchain on '{leg}' no longer matches what this repo recorded:")
+  for feature in changed:
+    was = EXPECTED[leg].get(feature.name)
+    if actual[feature.name]:
+      green_print(f"  + {feature.name} is now USABLE (was recorded as {'usable' if was else 'gated'})")
+      sites = todo_sites(feature.token)
+      if sites:
+        yellow_print(f"    Adopt it at {len(sites)} waiting site(s), then delete the TODO:")
+        for site in sites:
+          yellow_print(f"      {site}")
+      else:
+        yellow_print(f"    Adoption is tracked in {feature.issue}.")
+    else:
+      red_print(f"  - {feature.name} is GATED but was recorded as usable -- the toolchain regressed.")
+
+  yellow_print("Then set the new state in EXPECTED['%s'] in automation/feature_probe.py." % leg)
+  return 1

--- a/automation/feature_probe.py
+++ b/automation/feature_probe.py
@@ -109,20 +109,6 @@ FEATURES: Final[List[Feature]] = [
     """,
   ),
   Feature(
-    name="std::views::join_with",
-    token="join_with",
-    issue="#131",
-    program="""
-      #include <ranges>
-      #include <string>
-      #include <vector>
-      auto main() -> int {
-        const std::vector<std::string> parts { "a", "b" };
-        for (const char c : parts | std::views::join_with(std::string { ", " })) { (void) c; }
-      }
-    """,
-  ),
-  Feature(
     # C++26, so it stays unavailable until the project's own -std moves too. Kept in the table
     # because two sites already hand-roll around it and this is where they will find out.
     name="std::views::concat",
@@ -158,9 +144,13 @@ FEATURES: Final[List[Feature]] = [
 # toolchain gains one of these, which is the day the waiting TODOs become actionable, and
 # nothing else in the repo would ever notice.
 #
-#   libstdc++  clang 18.1.3 on ubuntu-24.04
-#   libc++     Apple clang 21.0.0 on macos-latest
-#   msvc-stl   clang 20.1.8 on windows-latest
+# The compiler is only half of what decides a row -- the standard library is the other half,
+# and on Linux the two ship separately. Record both, or a runner image bumping its default GCC
+# leaves a flipped row with nothing to explain it.
+#
+#   libstdc++  clang 18.1.3 + ubuntu-24.04's default libstdc++ (GCC 13)
+#   libc++     Apple clang 21.0.0 + its bundled libc++
+#   msvc-stl   clang 20.1.8 + the MSVC STL on the runner image
 EXPECTED: Final[Dict[str, Dict[str, bool]]] = {
   "libstdc++": {
     "std::generator": False,
@@ -168,7 +158,6 @@ EXPECTED: Final[Dict[str, Dict[str, bool]]] = {
     "std::views::enumerate": True,
     "std::views::pairwise": True,
     "std::views::slide": True,
-    "std::views::join_with": True,
     "std::views::concat": False,
     "std::function_ref": False,
   },
@@ -178,7 +167,6 @@ EXPECTED: Final[Dict[str, Dict[str, bool]]] = {
     "std::views::enumerate": False,
     "std::views::pairwise": False,
     "std::views::slide": False,
-    "std::views::join_with": True,
     "std::views::concat": False,
     "std::function_ref": False,
   },
@@ -188,7 +176,6 @@ EXPECTED: Final[Dict[str, Dict[str, bool]]] = {
     "std::views::enumerate": True,
     "std::views::pairwise": True,
     "std::views::slide": True,
-    "std::views::join_with": True,
     "std::views::concat": False,
     "std::function_ref": False,
   },
@@ -223,17 +210,44 @@ def adoptable(feature: Feature) -> List[str]:
   the comparison above goes quiet forever, and the TODOs it unblocked would sit there unread --
   the exact failure mode this gate replaces. So the recorded state is also read forwards: usable
   on every leg, nothing recorded holding it back, and sites still working around it.
+
+  Reach: only hand-rolling that carries a `TODO` naming the feature is visible here. Workarounds
+  with no such marker -- `fold_left`'s eleven `std::reduce`/`std::accumulate` sums, for one --
+  cannot be named, which is why `monuments()` below refuses to let a feature sit in the table
+  with nothing to point at.
   """
   if feature.deferred or not all(EXPECTED[leg][feature.name] for leg in EXPECTED):
     return []
   return todo_sites(feature.token)
 
 
-def probe(cxx: str, feature: Feature) -> bool:
-  """Compile a program that uses `feature`, and report whether it built."""
+def monuments() -> List[Feature]:
+  """Features that are usable everywhere with nothing left waiting on them.
+
+  Such a row can never speak again: `adoptable` finds no sites, and the per-leg comparison only
+  fires on a regression the build would catch first. Either it was adopted -- then it belongs in
+  the git history, not in this table -- or its workarounds carry no TODO and the gate is blind
+  to them. Both need a person, so say so rather than keeping a decoration.
+  """
+  return [f for f in FEATURES
+          if not f.deferred
+          and all(EXPECTED[leg][f.name] for leg in EXPECTED)
+          and not todo_sites(f.token)]
+
+
+# Nothing exotic -- if this will not compile, the toolchain is broken and every `False` below
+# means "the compiler did not run", not "the feature is missing".
+CANARY: Final[str] = """
+  #include <vector>
+  auto main() -> int { const std::vector<int> v { 1 }; return v.empty() ? 1 : 0; }
+"""
+
+
+def compiles(cxx: str, program: str) -> bool:
+  """Compile `program` on its own, and report whether the front end accepted it."""
   with tempfile.TemporaryDirectory() as tmp:
     source = Path(tmp) / "probe.cpp"
-    source.write_text(feature.program, encoding="utf-8")
+    source.write_text(program, encoding="utf-8")
     ret = run_cmd(
       [cxx, f"-std={CXX_STANDARD}", "-fsyntax-only", str(source)],
       print_cmd=False,
@@ -241,6 +255,11 @@ def probe(cxx: str, feature: Feature) -> bool:
       print_stderr=False,
     )
     return ret.retcode == 0
+
+
+def probe(cxx: str, feature: Feature) -> bool:
+  """Compile a program that uses `feature`, and report whether it built."""
+  return compiles(cxx, feature.program)
 
 
 def probe_features(leg: Optional[str] = None) -> int:
@@ -263,11 +282,23 @@ def probe_features(leg: Optional[str] = None) -> int:
       return 1
     # A feature added to FEATURES but not to EXPECTED would otherwise read as "just unlocked"
     # on every leg forever, which is a gate that cries wolf rather than one that has a baseline.
+    probed = {f.name for f in FEATURES}
     unrecorded = [f.name for f in FEATURES if f.name not in EXPECTED[leg]]
     if unrecorded:
       red_print(f"No recorded state on '{leg}' for: {', '.join(unrecorded)}")
       yellow_print(f"Run `./linter.py --features` on that toolchain and add the result to EXPECTED['{leg}'].")
       return 1
+    stale = [name for name in EXPECTED[leg] if name not in probed]
+    if stale:
+      red_print(f"EXPECTED['{leg}'] still records features nobody probes: {', '.join(stale)}")
+      yellow_print("Drop them -- a baseline for a feature that is no longer measured records nothing.")
+      return 1
+
+  if not compiles(cxx, CANARY):
+    red_print(f"{cxx} cannot compile a trivial -std={CXX_STANDARD} program.")
+    yellow_print("Fix the toolchain first. Every probe below would report GATED for the same")
+    yellow_print("reason, and on a leg whose baseline is mostly False that reads as a pass.")
+    return 1
 
   actual: Dict[str, bool] = {}
   for feature in FEATURES:
@@ -286,16 +317,25 @@ def probe_features(leg: Optional[str] = None) -> int:
     green_print(f"All {len(FEATURES)} feature(s) match the recorded state of '{leg}'")
 
     ready = {f: sites for f in FEATURES if (sites := adoptable(f))}
-    if not ready:
-      return 0
+    if ready:
+      red_print("These compile on every leg, and the code is still working around them:")
+      for feature, sites in ready.items():
+        red_print(f"  {feature.name} ({feature.issue}) -- {len(sites)} site(s):")
+        for site in sites:
+          red_print(f"    {site}")
+      yellow_print("Adopt them and drop the TODO, or record why not in that Feature's `deferred` field.")
+      return 1
 
-    red_print("These compile on every leg, and the code is still working around them:")
-    for feature, sites in ready.items():
-      red_print(f"  {feature.name} ({feature.issue}) -- {len(sites)} site(s):")
-      for site in sites:
-        red_print(f"    {site}")
-    yellow_print("Adopt them and drop the TODO, or record why not in that Feature's `deferred` field.")
-    return 1
+    idle = monuments()
+    if idle:
+      red_print("These are usable everywhere with nothing left waiting on them:")
+      for feature in idle:
+        red_print(f"  {feature.name} ({feature.issue})")
+      yellow_print("Drop the row if it was adopted; tag the remaining hand-rolled sites with a")
+      yellow_print("TODO naming the feature if it was not. A row that can never speak is decoration.")
+      return 1
+
+    return 0
 
   red_print(f"The toolchain on '{leg}' no longer matches what this repo recorded:")
   for feature in changed:
@@ -303,7 +343,9 @@ def probe_features(leg: Optional[str] = None) -> int:
       green_print(f"  + {feature.name} is now USABLE (recorded as gated)")
       sites = todo_sites(feature.token)
       if sites:
-        yellow_print(f"    Adopt it at {len(sites)} waiting site(s), then delete the TODO:")
+        # Not "go adopt it": this leg says nothing about the other two, and adopting on one
+        # leg's word breaks the others' build. Record the state; `adoptable` calls the moment.
+        yellow_print(f"    {len(sites)} site(s) are waiting on it, unlocked once every leg agrees:")
         for site in sites:
           yellow_print(f"      {site}")
       else:
@@ -311,5 +353,5 @@ def probe_features(leg: Optional[str] = None) -> int:
     else:
       red_print(f"  - {feature.name} is GATED but was recorded as usable -- the toolchain regressed.")
 
-  yellow_print("Then set the new state in EXPECTED['%s'] in automation/feature_probe.py." % leg)
+  yellow_print(f"Record the new state in EXPECTED['{leg}'] in automation/feature_probe.py.")
   return 1

--- a/linter.py
+++ b/linter.py
@@ -34,7 +34,7 @@ import sys
 import argparse
 
 from automation import (
-  run_ruff, run_clang_tidy, check_self_contained,
+  run_ruff, run_clang_tidy, check_self_contained, probe_features,
 )
 
 
@@ -50,7 +50,11 @@ def parse_args() -> argparse.Namespace:
       "    ./linter.py --clang-tidy\n\n"
       "  To check that every header is self-contained:\n"
       "    ./linter.py --self-contained\n\n"
-      "  To run every check (ruff, clang-tidy, self-containment):\n"
+      "  To report which awaited C++ features this toolchain can compile:\n"
+      "    ./linter.py --features\n\n"
+      "  To hold a CI leg to the feature state this repo recorded for it:\n"
+      "    ./linter.py --features libc++\n\n"
+      "  To run every check (ruff, clang-tidy, self-containment, feature report):\n"
       "    ./linter.py -a/--all\n\n"
     ),
     formatter_class=argparse.RawTextHelpFormatter
@@ -61,6 +65,8 @@ def parse_args() -> argparse.Namespace:
   parser.add_argument("--clang-tidy", action="store_true", help="Run clang-tidy")
   parser.add_argument("--self-contained", action="store_true",
                       help="Compile every header alone to prove it is self-contained")
+  parser.add_argument("--features", nargs="?", const="", default=None, metavar="LEG",
+                      help="Probe the awaited C++ features; with a CI leg name, hold it to the recorded state")
 
   return parser.parse_args()
 
@@ -80,6 +86,12 @@ if __name__ == "__main__":
 
   if args.self_contained or args.all:
     ret_code = check_self_contained()
+    if ret_code != 0:
+      sys.exit(ret_code)
+
+  if args.features is not None or args.all:
+    # `--all` reports without judging: only a CI leg has a recorded state to be held to.
+    ret_code = probe_features(args.features or None)
     if ret_code != 0:
       sys.exit(ret_code)
 

--- a/src/astro/delta_t.hpp
+++ b/src/astro/delta_t.hpp
@@ -99,7 +99,7 @@ constexpr auto
 find_coefficients(const int32_t year) -> std::optional<
   std::pair<Algo1Coefficients, Algo1Coefficients>
 > {
-  // TODO: Use `std::views::pairwise` when supported.
+  // TODO: Use `std::views::pairwise` once every CI leg has it (./linter.py --features).
   const auto pairwise = [](const auto& range) {
     using namespace std::ranges;
     return views::iota(0, distance(range) - 1) | views::transform([&range](auto i) {

--- a/src/astro/moon_phase.hpp
+++ b/src/astro/moon_phase.hpp
@@ -193,7 +193,7 @@ inline auto next_root(const double jde) -> double {
 /**
  * @brief Generator for finding the roots (i.e. conjunction moments of the Sun and Moon).
  */
-// TODO: Use `std::generator` when supported.
+// TODO: Use `std::generator` once every CI leg has it (./linter.py --features).
 struct RootGenerator {
 private:
   double _root;

--- a/src/astro/sunrise_sunset.hpp
+++ b/src/astro/sunrise_sunset.hpp
@@ -76,19 +76,21 @@ inline constexpr double POLAR_DENOMINATOR_EPSILON = 1e-10;
 /**
  * @brief The half-width of the root bracket around the transit estimate, in days.
  * @note The estimate is local mean noon; the true transit deviates from it by the equation of
- *       time only, |EoT| ≤ 16.5 min ≈ 0.0115 day — a 8.7x margin. The hour angle sweeps
- *       ±36° across this bracket, well clear of the ±180° wrap.
+ *       time only. |EoT| ≤ 16.5 min today, but the orbital elements drift: across the supported
+ *       span (years 402-9050) it reaches 20.4 min ≈ 0.0142 day — still a 7.1x margin. The hour
+ *       angle sweeps ±36° across this bracket, well clear of the ±180° wrap.
+ *       Held by `SunriseSunset.TransitBracketCoversTheEquationOfTime` (#126).
  */
 inline constexpr double TRANSIT_BRACKET_HALF_WIDTH_DAYS = 0.1;
 
 /**
  * @brief The half-width of the first-try root bracket around the rise/set estimate, in days.
- * @note The estimate extrapolates H₀ computed from the declination at transit; away from the
- *       polar boundary the δ drift between transit and the event (≤ ~0.2°) moves the true root
- *       by a few minutes at most, so ±72 min is a comfortable margin. Near the polar boundary
- *       the extrapolation degrades without bound — which is why this bracket is only an
- *       accelerator: the decider is the sign check at the bracket ends, with the
- *       transit-to-lower-culmination bracket as fallback (see `rise_set_jde`).
+ * @note The estimate extrapolates H₀ computed from the declination at transit; out to |φ| = 65°
+ *       the δ drift between transit and the event moves the true root by ≤ 3.5 min, so ±72 min
+ *       is a comfortable margin. Near the polar boundary the extrapolation degrades without
+ *       bound — which is why this bracket is only an accelerator: the decider is the sign check
+ *       at the bracket ends, with the transit-to-lower-culmination bracket as fallback (see
+ *       `rise_set_jde`). Held out to |φ| = 65° by `SunriseSunset.RiseSetBracketRetainsMargin` (#126).
  */
 inline constexpr double RISE_SET_BRACKET_HALF_WIDTH_DAYS = 0.05;
 
@@ -107,6 +109,7 @@ inline constexpr double HALF_SOLAR_DAY_DAYS = 0.5;
  * @note The estimate is transit ± `HALF_SOLAR_DAY_DAYS`; the true lower culmination deviates
  *       by ≤ ~15 s ≈ 1.8e-4 day — a 500x margin. The unwrapped H−180° sweeps ±36° across
  *       this bracket, well clear of its wrap (which sits at the upper culminations).
+ *       Held by `SunriseSunset.LowerCulminationBracketRetainsMargin` (#126).
  */
 inline constexpr double LOWER_CULMINATION_BRACKET_HALF_WIDTH_DAYS = 0.1;
 

--- a/src/calendar/jieqi.hpp
+++ b/src/calendar/jieqi.hpp
@@ -183,7 +183,7 @@ inline auto jieqi_ut1_moment(const int32_t year, const Jieqi jq) -> calendar::Da
 
 /** @brief A generator that generates consecutive Jieqis and their moments (in JDE), 
  *         starting from a given JDE (exclusive). */
-// TODO: Use `std::generator` when supported.
+// TODO: Use `std::generator` once every CI leg has it (./linter.py --features).
 struct JieqiGenerator {
 private:
   int32_t _year;

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -265,7 +265,7 @@ inline auto leap_month_in_chunk(const LunarMonthChunk& chunk) -> std::optional<i
   }
 
   // As per the rules, the leap month is the first month where Qi (气/中气) does not appear.
-  // TODO: Use `std::enumerate` instead when supported.
+  // TODO: Use `std::views::enumerate` once every CI leg has it (./linter.py --features).
   for (const auto& [index, month] : std::views::zip(std::views::iota(0), chunk)) {
     const auto& jq_pairs = month.contained_jieqis;
     const bool has_qi = std::any_of(cbegin(jq_pairs), cend(jq_pairs), [](const auto& pair) {
@@ -364,7 +364,7 @@ inline auto create_lunar_year_context(int32_t year) -> LunarYearContext {
   }
 
   // Figure out the months in the lunar year.
-  // TODO: Use `std::concat` when it gets supported.
+  // TODO: Use `std::views::concat` once C++26 is in reach (./linter.py --features).
   std::vector<LunarMonth> months;
 
   for (const auto& m : chunk1) {

--- a/src/shared_lib/lib_lunar.cpp
+++ b/src/shared_lib/lib_lunar.cpp
@@ -74,7 +74,8 @@ auto get_lunar_year_info(const uint8_t algo, const int32_t year) -> LunarYearInf
     const auto [y, m, d] = util::from_ymd(raw.date_of_first_day);
 
     uint16_t month_len = 0;
-    for (const auto& [i, days] : zip(iota(0), raw.month_lengths)) { // TODO: Use `std::views::enumerate` once every CI leg has it (./linter.py --features).
+    // TODO: Use `std::views::enumerate` once every CI leg has it (./linter.py --features).
+    for (const auto& [i, days] : zip(iota(0), raw.month_lengths)) {
       assert(days == 29 or days == 30);
       const uint16_t bit = (days == 29) ? 0 : 1;
       month_len |= (bit << i);

--- a/src/shared_lib/lib_lunar.cpp
+++ b/src/shared_lib/lib_lunar.cpp
@@ -74,7 +74,7 @@ auto get_lunar_year_info(const uint8_t algo, const int32_t year) -> LunarYearInf
     const auto [y, m, d] = util::from_ymd(raw.date_of_first_day);
 
     uint16_t month_len = 0;
-    for (const auto& [i, days] : zip(iota(0), raw.month_lengths)) { // TODO: Use `views::enumerate` when supported.
+    for (const auto& [i, days] : zip(iota(0), raw.month_lengths)) { // TODO: Use `std::views::enumerate` once every CI leg has it (./linter.py --features).
       assert(days == 29 or days == 30);
       const uint16_t bit = (days == 29) ? 0 : 1;
       month_len |= (bit << i);

--- a/src/test/astro/delta_t_test_helper.hpp
+++ b/src/test/astro/delta_t_test_helper.hpp
@@ -23,9 +23,11 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <concepts>
 #include <cstdint>
+#include <iterator>
 #include <string>
 #include <vector>
 #include <map>
@@ -141,21 +143,15 @@ inline auto calc_diff(const double year, const double expected_delta_t) {
 
 #pragma region Other Helper Functions
 
-// TODO: Use `std::views::join_with` once every CI leg has it (./linter.py --features).
-//       libc++ already does -- this one is waiting on the other two legs, not on all three.
+// Graduated off the wishlist 2026-08-02: `std::views::join_with` compiles on all three standard
+// libraries, which `./linter.py --features` is what told us.
 inline auto join_with(
-  const std::ranges::range auto& view, 
+  const std::ranges::range auto& view,
   const std::string& separator
 ) -> std::string {
-  // Low performance implementation...
   std::string str;
-  for (const auto& substr : view) {
-    str += substr + separator;
-  }
-  if (view.empty()) {
-    return str;
-  }
-  return str.substr(0, str.size() - separator.size());
+  std::ranges::copy(view | std::views::join_with(separator), std::back_inserter(str));
+  return str;
 }
 
 inline constexpr int32_t PAD_WIDTH = 10;

--- a/src/test/astro/delta_t_test_helper.hpp
+++ b/src/test/astro/delta_t_test_helper.hpp
@@ -23,11 +23,9 @@
 
 #pragma once
 
-#include <algorithm>
 #include <array>
 #include <concepts>
 #include <cstdint>
-#include <iterator>
 #include <string>
 #include <vector>
 #include <map>
@@ -143,15 +141,6 @@ inline auto calc_diff(const double year, const double expected_delta_t) {
 
 #pragma region Other Helper Functions
 
-inline auto join_with(
-  const std::ranges::range auto& view,
-  const std::string& separator
-) -> std::string {
-  std::string str;
-  std::ranges::copy(view | std::views::join_with(separator), std::back_inserter(str));
-  return str;
-}
-
 inline constexpr int32_t PAD_WIDTH = 10;
 
 /** @brief Pad the string with spaces. Use generic lambda here
@@ -173,9 +162,9 @@ inline auto make_line(
 
   // TODO: Use `std::views::concat` once C++26 is in reach (./linter.py --features).
   using namespace std::views;
-  return join_with(range1 | transform(pad), separator)
+  return (range1 | transform(pad) | join_with(separator) | std::ranges::to<std::string>())
        + separator
-       + join_with(range2 | transform(pad), separator);
+       + (range2 | transform(pad) | join_with(separator) | std::ranges::to<std::string>());
 }
 
 #pragma endregion

--- a/src/test/astro/delta_t_test_helper.hpp
+++ b/src/test/astro/delta_t_test_helper.hpp
@@ -143,8 +143,6 @@ inline auto calc_diff(const double year, const double expected_delta_t) {
 
 #pragma region Other Helper Functions
 
-// Graduated off the wishlist 2026-08-02: `std::views::join_with` compiles on all three standard
-// libraries, which `./linter.py --features` is what told us.
 inline auto join_with(
   const std::ranges::range auto& view,
   const std::string& separator

--- a/src/test/astro/delta_t_test_helper.hpp
+++ b/src/test/astro/delta_t_test_helper.hpp
@@ -141,7 +141,8 @@ inline auto calc_diff(const double year, const double expected_delta_t) {
 
 #pragma region Other Helper Functions
 
-// TODO: Use `std::views::join_with` when it gets supported.
+// TODO: Use `std::views::join_with` once every CI leg has it (./linter.py --features).
+//       libc++ already does -- this one is waiting on the other two legs, not on all three.
 inline auto join_with(
   const std::ranges::range auto& view, 
   const std::string& separator
@@ -176,7 +177,7 @@ inline auto make_line(
 ) -> std::string {
   const std::string separator { " | " };
 
-  // TODO: Use `std::views::concat` when it gets supported.
+  // TODO: Use `std::views::concat` once C++26 is in reach (./linter.py --features).
   using namespace std::views;
   return join_with(range1 | transform(pad), separator)
        + separator

--- a/src/test/astro/moon_phase_test.cpp
+++ b/src/test/astro/moon_phase_test.cpp
@@ -56,7 +56,7 @@ TEST(NewMoon, RootGenerator) {
     ASSERT_TRUE(diff < epsilon or diff > 360.0 - epsilon);
   }
 
-  // TODO: Use `std::views::pairwise` when it gets supported.
+  // TODO: Use `std::views::pairwise` once every CI leg has it (./linter.py --features).
   for (auto it = cbegin(roots); it != cend(roots); ++it) {
     const auto next = std::next(it);
     if (next == cend(roots)) {

--- a/src/test/astro/sunrise_sunset_test.cpp
+++ b/src/test/astro/sunrise_sunset_test.cpp
@@ -445,8 +445,13 @@ struct Sample {
   std::string at;
 };
 
-/** @brief The sample that came closest to escaping the bracket. */
+/** @brief The sample that came closest to escaping the bracket. Throws rather than dereferencing
+ *         `end()` if a sweep ever silently produces nothing — an empty sweep would otherwise read
+ *         as a passing gate. */
 auto worst_of(const std::vector<Sample>& samples) -> const Sample& {
+  if (samples.empty()) {
+    throw std::logic_error { "sweep produced no samples" };
+  }
   return *std::ranges::max_element(samples, {}, &Sample::deviation_days);
 }
 
@@ -530,13 +535,21 @@ const GeoLocation SUBPOLAR_S = loc(-65.0, 0.0);
 } // anonymous namespace
 
 
+// The three gates below fail through `FAIL() <<` rather than `ASSERT_LE(...) <<`. Streaming a
+// std::string into gtest's comparison helpers makes gcc 14 emit a false `-Wnull-dereference`
+// inside `CmpHelperLE` once it inlines at -O2, and the build takes warnings as errors. Do not
+// "simplify" these back: the reports already carry both sides of the comparison.
+
+
 TEST(SunriseSunset, TransitBracketCoversTheEquationOfTime) {
   constexpr BracketClaim CLAIM {
     .constant     = "TRANSIT_BRACKET_HALF_WIDTH_DAYS",
     .bracket_days = TRANSIT_BRACKET_HALF_WIDTH_DAYS,
     .bound_days   = 0.0145, // 20.9 min. Measured worst over the sweep: 0.014157 day (20.39 min).
   };
-  ASSERT_GE(CLAIM.bracket_days, CLAIM.bound_days * MIN_BRACKET_MARGIN) << narrowed_report(CLAIM);
+  if (CLAIM.bracket_days < CLAIM.bound_days * MIN_BRACKET_MARGIN) {
+    FAIL() << narrowed_report(CLAIM);
+  }
 
   // Longitude is left out of the sweep on purpose: it shifts only the instant at which the
   // equation of time is evaluated, worth ≤ 0.3% here, and `TransitNearLocalMeanNoon` already
@@ -553,7 +566,9 @@ TEST(SunriseSunset, TransitBracketCoversTheEquationOfTime) {
   }
 
   const auto& measured = worst_of(samples);
-  ASSERT_LE(measured.deviation_days, CLAIM.bound_days) << margin_report(CLAIM, measured);
+  if (measured.deviation_days > CLAIM.bound_days) {
+    FAIL() << margin_report(CLAIM, measured);
+  }
 }
 
 TEST(SunriseSunset, LowerCulminationBracketRetainsMargin) {
@@ -562,7 +577,9 @@ TEST(SunriseSunset, LowerCulminationBracketRetainsMargin) {
     .bracket_days = LOWER_CULMINATION_BRACKET_HALF_WIDTH_DAYS,
     .bound_days   = 1.85e-4, // 16.0 s. Measured worst over the sweep: 1.7631e-4 day (15.23 s).
   };
-  ASSERT_GE(CLAIM.bracket_days, CLAIM.bound_days * MIN_BRACKET_MARGIN) << narrowed_report(CLAIM);
+  if (CLAIM.bracket_days < CLAIM.bound_days * MIN_BRACKET_MARGIN) {
+    FAIL() << narrowed_report(CLAIM);
+  }
 
   std::vector<Sample> samples;
   for (const int year : sampled_years(500)) {
@@ -580,7 +597,9 @@ TEST(SunriseSunset, LowerCulminationBracketRetainsMargin) {
   }
 
   const auto& measured = worst_of(samples);
-  ASSERT_LE(measured.deviation_days, CLAIM.bound_days) << margin_report(CLAIM, measured);
+  if (measured.deviation_days > CLAIM.bound_days) {
+    FAIL() << margin_report(CLAIM, measured);
+  }
 }
 
 TEST(SunriseSunset, RiseSetBracketRetainsMargin) {
@@ -589,7 +608,9 @@ TEST(SunriseSunset, RiseSetBracketRetainsMargin) {
     .bracket_days = RISE_SET_BRACKET_HALF_WIDTH_DAYS,
     .bound_days   = 2.6e-3, // 3.74 min. Measured worst over the sweep: 2.4058e-3 day (3.46 min).
   };
-  ASSERT_GE(CLAIM.bracket_days, CLAIM.bound_days * MIN_BRACKET_MARGIN) << narrowed_report(CLAIM);
+  if (CLAIM.bracket_days < CLAIM.bound_days * MIN_BRACKET_MARGIN) {
+    FAIL() << narrowed_report(CLAIM);
+  }
 
   // The deviation grows with |φ| (1.1 min at the equator against 3.5 min here), so the domain
   // edge is the binding case; sweeping it densely beats sweeping every latitude thinly.
@@ -623,7 +644,9 @@ TEST(SunriseSunset, RiseSetBracketRetainsMargin) {
   }
 
   const auto& measured = worst_of(samples);
-  ASSERT_LE(measured.deviation_days, CLAIM.bound_days) << margin_report(CLAIM, measured);
+  if (measured.deviation_days > CLAIM.bound_days) {
+    FAIL() << margin_report(CLAIM, measured);
+  }
 }
 
 } // namespace astro::sunrise_sunset::test

--- a/src/test/astro/sunrise_sunset_test.cpp
+++ b/src/test/astro/sunrise_sunset_test.cpp
@@ -21,10 +21,16 @@
  * along with this project. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <algorithm>
 #include <chrono>
+#include <cmath>
+#include <format>
+#include <functional>
 #include <limits>
 #include <optional>
 #include <stdexcept>
+#include <string>
+#include <string_view>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -396,6 +402,228 @@ TEST(SunriseSunset, InvalidInputsThrow) {
                std::invalid_argument);
   ASSERT_THROW((void) hour_angle_at_altitude(Angle<DEG> { 0.0 }, Angle<DEG> { 0.0 }, Angle<DEG> { 100.0 }),
                std::invalid_argument);
+}
+
+
+// Each bracket constant in `sunrise_sunset.hpp` carries a note arguing why it is wide enough:
+// "|EoT| ≤ 16.5 min — a 8.7x margin", and so on. Those arguments were maintained by attention —
+// shrink a bracket, widen the supported span, or swap a model, and the number beside it does not
+// object. The three tests below sweep the span, measure the deviation each bracket actually has
+// to cover, and hold it to what its note claims (#126).
+//
+// Measuring also settled one of them: 16.5 min is today's |EoT|, but the orbital elements drift,
+// and over years 402-9050 it reaches 20.4 min. The bracket was always wide enough; the note was
+// quoting the wrong era.
+
+namespace {
+
+// The span the solver chain supports. `jd_to_ut1` rejects below year 401, and 401-01-01's
+// adjacent lower culmination reaches back past that floor, so 402 is the first fully usable
+// year. The ceiling is the one the rest of the suite already works to (`moon_phase_test.cpp`,
+// and `newton_method`'s iteration-count note).
+constexpr int FIRST_YEAR = 402;
+constexpr int LAST_YEAR  = 9050;
+
+/** @brief What a bracket constant's note claims: the deviation it covers. The margin is the
+ *         quotient, so there is no third number to drift out of step with the other two. */
+struct BracketClaim {
+  std::string_view constant;
+  double bracket_days;
+  double bound_days;
+};
+
+// A bracket may not be merely wide enough. Newton needs the root strictly inside, and the
+// deviations below are measurements on a grid, not proofs of the true extreme. This floor is
+// also the only half of the check a narrowed bracket cannot fool: shrink the constant and the
+// solver's root gets pinned near the bracket edge, so the swept deviation shrinks with it and
+// would otherwise stay obediently under its bound.
+constexpr double MIN_BRACKET_MARGIN = 2.0;
+
+/** @brief One measured deviation, and the case that produced it. */
+struct Sample {
+  double deviation_days;
+  std::string at;
+};
+
+/** @brief The sample that came closest to escaping the bracket. */
+auto worst_of(const std::vector<Sample>& samples) -> const Sample& {
+  return *std::ranges::max_element(samples, {}, &Sample::deviation_days);
+}
+
+auto date_str(const std::chrono::year_month_day& ymd) -> std::string {
+  return std::format("{:04}-{:02}-{:02}", static_cast<int>(ymd.year()),
+                     static_cast<unsigned>(ymd.month()), static_cast<unsigned>(ymd.day()));
+}
+
+/** @brief Years to sweep: every `stride`th, plus the far end — the elements drift monotonically
+ *         away from today's, so the end of the span is always a candidate for the extreme. */
+auto sampled_years(const int stride) -> std::vector<int> {
+  std::vector<int> years;
+  years.reserve(static_cast<std::size_t>((LAST_YEAR - FIRST_YEAR) / stride) + 2);
+  for (int year = FIRST_YEAR; year <= LAST_YEAR; year += stride) {
+    years.push_back(year);
+  }
+  if (years.back() != LAST_YEAR) {
+    years.push_back(LAST_YEAR);
+  }
+  return years;
+}
+
+// All three deviations are smooth annual curves, so a fortnightly-ish net loses well under a
+// percent of the peak — cheaper than a two-pass coarse-then-refine sweep, and the bounds below
+// carry more headroom than that. Measured against a daily sweep: within 0.6% on all three.
+constexpr std::chrono::days SWEEP_STRIDE { 5 };
+
+/** @brief The days of `year` the sweeps visit. */
+auto sampled_days(const int year) -> std::vector<std::chrono::year_month_day> {
+  const auto first = std::chrono::sys_days { util::to_ymd(year, 1, 1) };
+  const auto past_last = std::chrono::sys_days { util::to_ymd(year + 1, 1, 1) };
+
+  std::vector<std::chrono::year_month_day> days;
+  days.reserve(static_cast<std::size_t>((past_last - first) / SWEEP_STRIDE) + 1);
+  for (auto day = first; day < past_last; day += SWEEP_STRIDE) {
+    days.emplace_back(day);
+  }
+  return days;
+}
+
+/** @brief A day count in whichever of minutes or seconds reads naturally — these three
+ *         deviations span three orders of magnitude. */
+auto human(const double days) -> std::string {
+  const double minutes = days * 24 * 60;
+  return minutes >= 1.0 ? std::format("{:.2f} min", minutes) : std::format("{:.2f} s", minutes * 60);
+}
+
+/** @brief What to say when a bracket has been narrowed past what its note says it covers. */
+auto narrowed_report(const BracketClaim& claim) -> std::string {
+  return std::format(
+    "\n  {} = {:g} day no longer clears the {:g} day ({}) it must cover by {:g}x."
+    "\n  Fix: widen the constant back. If the deviation genuinely shrank instead, re-measure and"
+    "\n       lower the bound in this test together with the @note on the constant.",
+    claim.constant, claim.bracket_days, claim.bound_days, human(claim.bound_days), MIN_BRACKET_MARGIN
+  );
+}
+
+/** @brief What to say when the deviation a bracket must cover has outgrown its note. */
+auto margin_report(const BracketClaim& claim, const Sample& measured) -> std::string {
+  return std::format(
+    "\n  {} = {:g} day"
+    "\n    claimed to cover : deviation ≤ {:g} day ({}) — a {:.1f}x margin"
+    "\n    measured worst   : {:.6e} day ({}) at {}"
+    "\n    margin left      : {:.1f}x"
+    "\n  Fix: if the model or the swept span changed, re-measure and update BOTH the bound in"
+    "\n       this test and the @note on {} in src/astro/sunrise_sunset.hpp.",
+    claim.constant, claim.bracket_days,
+    claim.bound_days, human(claim.bound_days), claim.bracket_days / claim.bound_days,
+    measured.deviation_days, human(measured.deviation_days), measured.at,
+    claim.bracket_days / measured.deviation_days,
+    claim.constant
+  );
+}
+
+// The edge of the domain where the rise/set first-try bracket is meant to be sufficient. Past
+// the polar circle the H₀ extrapolation degrades without bound and the fallback takes over, so
+// 65° is where a margin claim still means something.
+const GeoLocation SUBPOLAR_N = loc( 65.0, 0.0);
+const GeoLocation SUBPOLAR_S = loc(-65.0, 0.0);
+
+} // anonymous namespace
+
+
+TEST(SunriseSunset, TransitBracketCoversTheEquationOfTime) {
+  constexpr BracketClaim CLAIM {
+    .constant     = "TRANSIT_BRACKET_HALF_WIDTH_DAYS",
+    .bracket_days = TRANSIT_BRACKET_HALF_WIDTH_DAYS,
+    .bound_days   = 0.0145, // 20.9 min. Measured worst over the sweep: 0.014157 day (20.39 min).
+  };
+  ASSERT_GE(CLAIM.bracket_days, CLAIM.bound_days * MIN_BRACKET_MARGIN) << narrowed_report(CLAIM);
+
+  // Longitude is left out of the sweep on purpose: it shifts only the instant at which the
+  // equation of time is evaluated, worth ≤ 0.3% here, and `TransitNearLocalMeanNoon` already
+  // pins the sign of the longitude term. Latitude does not move a transit at all.
+  std::vector<Sample> samples;
+  for (const int year : sampled_years(250)) {
+    for (const auto& ymd : sampled_days(year)) {
+      const double transit = transit_jde(ymd, EQUATOR);
+      samples.push_back({
+        .deviation_days = std::fabs(transit - local_mean_noon_jde(ymd, EQUATOR)),
+        .at = date_str(ymd),
+      });
+    }
+  }
+
+  const auto& measured = worst_of(samples);
+  ASSERT_LE(measured.deviation_days, CLAIM.bound_days) << margin_report(CLAIM, measured);
+}
+
+TEST(SunriseSunset, LowerCulminationBracketRetainsMargin) {
+  constexpr BracketClaim CLAIM {
+    .constant     = "LOWER_CULMINATION_BRACKET_HALF_WIDTH_DAYS",
+    .bracket_days = LOWER_CULMINATION_BRACKET_HALF_WIDTH_DAYS,
+    .bound_days   = 1.85e-4, // 16.0 s. Measured worst over the sweep: 1.7631e-4 day (15.23 s).
+  };
+  ASSERT_GE(CLAIM.bracket_days, CLAIM.bound_days * MIN_BRACKET_MARGIN) << narrowed_report(CLAIM);
+
+  std::vector<Sample> samples;
+  for (const int year : sampled_years(500)) {
+    for (const auto& ymd : sampled_days(year)) {
+      const double transit = transit_jde(ymd, EQUATOR);
+      for (const bool before : { true, false }) {
+        const double culmination = detail::lower_culmination_jde(transit, before, EQUATOR);
+        const double estimate = before ? transit - HALF_SOLAR_DAY_DAYS : transit + HALF_SOLAR_DAY_DAYS;
+        samples.push_back({
+          .deviation_days = std::fabs(culmination - estimate),
+          .at = std::format("{} ({})", date_str(ymd), before ? "before transit" : "after transit"),
+        });
+      }
+    }
+  }
+
+  const auto& measured = worst_of(samples);
+  ASSERT_LE(measured.deviation_days, CLAIM.bound_days) << margin_report(CLAIM, measured);
+}
+
+TEST(SunriseSunset, RiseSetBracketRetainsMargin) {
+  constexpr BracketClaim CLAIM {
+    .constant     = "RISE_SET_BRACKET_HALF_WIDTH_DAYS",
+    .bracket_days = RISE_SET_BRACKET_HALF_WIDTH_DAYS,
+    .bound_days   = 2.6e-3, // 3.74 min. Measured worst over the sweep: 2.4058e-3 day (3.46 min).
+  };
+  ASSERT_GE(CLAIM.bracket_days, CLAIM.bound_days * MIN_BRACKET_MARGIN) << narrowed_report(CLAIM);
+
+  // The deviation grows with |φ| (1.1 min at the equator against 3.5 min here), so the domain
+  // edge is the binding case; sweeping it densely beats sweeping every latitude thinly.
+  std::vector<Sample> samples;
+  for (const int year : { FIRST_YEAR, 2026, 5000, LAST_YEAR }) {
+    for (const auto& ymd : sampled_days(year)) {
+      for (const auto& location : { SUBPOLAR_N, SUBPOLAR_S }) {
+        const double transit = transit_jde(ymd, location);
+        const auto eq = astro::sun::equatorial_coord::apparent(transit);
+        const auto H0 = hour_angle_at_altitude(eq.δ, location.latitude, STANDARD_ALTITUDE);
+        if (not H0.has_value()) {
+          continue; // Polar day or night: no crossing to bracket.
+        }
+
+        for (const bool is_sunrise : { true, false }) {
+          const auto root = rise_set_jde(transit, is_sunrise, location, STANDARD_ALTITUDE);
+          if (not root.has_value()) {
+            continue;
+          }
+          const double sign = is_sunrise ? -1.0 : 1.0;
+          const double estimate =
+            transit + sign * (req(H0).deg() / astro::toolbox::SIDEREAL_RATE_DEG_PER_DAY);
+          samples.push_back({
+            .deviation_days = std::fabs(req(root) - estimate),
+            .at = std::format("{} at latitude {:+.0f}° ({})", date_str(ymd),
+                              location.latitude.deg(), is_sunrise ? "sunrise" : "sunset"),
+          });
+        }
+      }
+    }
+  }
+
+  const auto& measured = worst_of(samples);
+  ASSERT_LE(measured.deviation_days, CLAIM.bound_days) << margin_report(CLAIM, measured);
 }
 
 } // namespace astro::sunrise_sunset::test

--- a/src/test/astro/sunrise_sunset_test.cpp
+++ b/src/test/astro/sunrise_sunset_test.cpp
@@ -410,10 +410,6 @@ TEST(SunriseSunset, InvalidInputsThrow) {
 // shrink a bracket, widen the supported span, or swap a model, and the number beside it does not
 // object. The three tests below sweep the span, measure the deviation each bracket actually has
 // to cover, and hold it to what its note claims (#126).
-//
-// Measuring also settled one of them: 16.5 min is today's |EoT|, but the orbital elements drift,
-// and over years 402-9050 it reaches 20.4 min. The bracket was always wide enough; the note was
-// quoting the wrong era.
 
 namespace {
 
@@ -460,8 +456,13 @@ auto date_str(const std::chrono::year_month_day& ymd) -> std::string {
                      static_cast<unsigned>(ymd.month()), static_cast<unsigned>(ymd.day()));
 }
 
-/** @brief Years to sweep: every `stride`th, plus the far end — the elements drift monotonically
- *         away from today's, so the end of the span is always a candidate for the extreme. */
+/** @brief Years to sweep: every `stride`th, plus the far end — appended because that is where
+ *         |EoT| peaks, and dropping it costs the transit sweep 0.6% of its worst case. The drift
+ *         is not monotone: |EoT| dips near year 5000 before climbing again, while the lower
+ *         culmination peaks near year 600, so neither end predicts the other's extreme.
+ *         What the stride buys is blind-spot width, not accuracy — across years these curves are
+ *         flat enough that halving it moves the measured worst by ~0.01%. It is sized so that a
+ *         peak displaced by a model change still lands on the grid. */
 auto sampled_years(const int stride) -> std::vector<int> {
   std::vector<int> years;
   years.reserve(static_cast<std::size_t>((LAST_YEAR - FIRST_YEAR) / stride) + 2);
@@ -545,7 +546,7 @@ TEST(SunriseSunset, TransitBracketCoversTheEquationOfTime) {
   constexpr BracketClaim CLAIM {
     .constant     = "TRANSIT_BRACKET_HALF_WIDTH_DAYS",
     .bracket_days = TRANSIT_BRACKET_HALF_WIDTH_DAYS,
-    .bound_days   = 0.0145, // 20.9 min. Measured worst over the sweep: 0.014157 day (20.39 min).
+    .bound_days   = 0.0145, // 20.9 min; this sweep peaks at 0.014157 day (20.39 min).
   };
   if (CLAIM.bracket_days < CLAIM.bound_days * MIN_BRACKET_MARGIN) {
     FAIL() << narrowed_report(CLAIM);
@@ -575,14 +576,14 @@ TEST(SunriseSunset, LowerCulminationBracketRetainsMargin) {
   constexpr BracketClaim CLAIM {
     .constant     = "LOWER_CULMINATION_BRACKET_HALF_WIDTH_DAYS",
     .bracket_days = LOWER_CULMINATION_BRACKET_HALF_WIDTH_DAYS,
-    .bound_days   = 1.85e-4, // 16.0 s. Measured worst over the sweep: 1.7631e-4 day (15.23 s).
+    .bound_days   = 1.85e-4, // 16.0 s; this sweep peaks at 1.7632e-4 day (15.23 s).
   };
   if (CLAIM.bracket_days < CLAIM.bound_days * MIN_BRACKET_MARGIN) {
     FAIL() << narrowed_report(CLAIM);
   }
 
   std::vector<Sample> samples;
-  for (const int year : sampled_years(500)) {
+  for (const int year : sampled_years(250)) {
     for (const auto& ymd : sampled_days(year)) {
       const double transit = transit_jde(ymd, EQUATOR);
       for (const bool before : { true, false }) {
@@ -606,7 +607,7 @@ TEST(SunriseSunset, RiseSetBracketRetainsMargin) {
   constexpr BracketClaim CLAIM {
     .constant     = "RISE_SET_BRACKET_HALF_WIDTH_DAYS",
     .bracket_days = RISE_SET_BRACKET_HALF_WIDTH_DAYS,
-    .bound_days   = 2.6e-3, // 3.74 min. Measured worst over the sweep: 2.4058e-3 day (3.46 min).
+    .bound_days   = 2.6e-3, // 3.74 min; this sweep peaks at 2.4058e-3 day (3.46 min).
   };
   if (CLAIM.bracket_days < CLAIM.bound_days * MIN_BRACKET_MARGIN) {
     FAIL() << narrowed_report(CLAIM);

--- a/src/test/astro/sunrise_sunset_test.cpp
+++ b/src/test/astro/sunrise_sunset_test.cpp
@@ -458,8 +458,8 @@ auto date_str(const std::chrono::year_month_day& ymd) -> std::string {
 
 /** @brief Years to sweep: every `stride`th, plus the far end — appended because that is where
  *         |EoT| peaks, and dropping it costs the transit sweep 0.6% of its worst case. The drift
- *         is not monotone: |EoT| dips near year 5000 before climbing again, while the lower
- *         culmination peaks near year 600, so neither end predicts the other's extreme.
+ *         is not monotone: |EoT| sags through the middle of the span before climbing again,
+ *         while the lower culmination peaks early in it — neither end predicts the other's.
  *         What the stride buys is blind-spot width, not accuracy — across years these curves are
  *         flat enough that halving it moves the measured worst by ~0.01%. It is sized so that a
  *         peak displaced by a model change still lands on the grid. */

--- a/src/test/lunar/algo2_test.cpp
+++ b/src/test/lunar/algo2_test.cpp
@@ -224,7 +224,7 @@ TEST(LunarAlgo2, LunarContext) {
 
     // Ensure the months are in order.
     // TODO: Use `std::views::pairwise` or `std::views::slide` once every CI leg has one (./linter.py --features).
-    const auto month_pairs = std::views::zip(context.months,context.months | std::views::drop(1));
+    const auto month_pairs = std::views::zip(context.months, context.months | std::views::drop(1));
     for (const auto& [a, b] : month_pairs) {
       ASSERT_LE(a.start_moment_utc8, b.start_moment_utc8);
       ASSERT_EQ(a.end_moment_utc8, b.start_moment_utc8);

--- a/src/test/lunar/algo2_test.cpp
+++ b/src/test/lunar/algo2_test.cpp
@@ -40,7 +40,7 @@ TEST(LunarAlgo2, LunarMonthGenerator) {
   std::vector<LunarMonth> lunar_months;
   std::generate_n(std::back_inserter(lunar_months), 200, [&]() { return lunar_gen.next(); });
 
-  // TODO: Use `std::views::pairwise` when supported.
+  // TODO: Use `std::views::pairwise` once every CI leg has it (./linter.py --features).
   const auto lunar_month_pairs = std::views::zip(lunar_months, lunar_months | std::views::drop(1));
 
   std::vector<JieqiGenerator::JieqiPair> jieqi_pairs;
@@ -223,7 +223,7 @@ TEST(LunarAlgo2, LunarContext) {
     ASSERT_EQ(context.months.back().end_moment_utc8, context.end_moment_utc8);
 
     // Ensure the months are in order.
-    // TODO: Use `std::views::pairwise` or `std::views::slide` when supported.
+    // TODO: Use `std::views::pairwise` or `std::views::slide` once every CI leg has one (./linter.py --features).
     const auto month_pairs = std::views::zip(context.months,context.months | std::views::drop(1));
     for (const auto& [a, b] : month_pairs) {
       ASSERT_LE(a.start_moment_utc8, b.start_moment_utc8);


### PR DESCRIPTION
`Closes #126`

把三条靠注释维护的 margin 论证、和 11 处靠注意力维护的「等编译器」TODO，换成会在该响的时候响的机器闸门。

## 内容

**#126 —— bracket margin 论证做成 directed 闸门**

`sunrise_sunset.hpp` 里三个 bracket 常量各带一句量级论证。golden 测试钉住了结论，没钉住论证：改小一个 bracket、放宽支持区间、或者换个模型，旁边那个数字不会有任何反应。

三条 directed test 扫 402–9050 年，量出每个 bracket 实际要覆盖的偏差，与注释声称的界对齐。每条断两件事，缺一不可：

1. `bracket ≥ bound × 2` —— 纯常量比较。**这半边是收窄 bracket 唯一骗不过的**：把常量改小，Newton 的根会被夹在括号边上，扫出的偏差跟着一起缩，光看「偏差 ≤ 界」会一路绿到底。
2. 扫出的最坏偏差 ≤ 界 —— 这半边管模型换了、支持区间放宽了。

**#131 / #99 —— C++ 特性探针改成编译判定**

此前审计用纯宏扫描判定，把 libc++ 已实现的 `std::ranges::fold_left` 报成不可用（libc++ 实现了它但不定义 `__cpp_lib_ranges_fold`），#131 因此挂上了「等 Apple Clang」——那扇门其实早开了。现在每项特性都用一段真正使用它的程序去编译，三个标准库各跑一遍，基线记在 `EXPECTED`。

闸门有两半：**变化检测**（实测 vs 记录基线）+ **前读检测**（全腿可用 + 无 deferred + 仍有 TODO 站点 → 红）。只有前者的话，一个特性在三腿全可用之后闸门就永远沉默了——而那恰恰是它最该说话的时刻。

## 测试

- 新增 3 条 directed test（201 测试，+3）。合计 1.04 s。
- **检出率验证**（工作树注入 + 快照还原，不碰 git）：四种真实退化 4/4 命中对应闸门——TRANSIT 0.1→0.02、LOWER_CULMINATION 0.1→3e-4、RISE_SET 0.05→0.005、支持区间 9050→12000。收窄类在 0 ms 就响（常量检查排在扫描之前）。
- 闸门三态本地验证：报告态、判定态、前读态（模拟 pairwise 全腿解锁，准确列出 4 个站点）。
- canary 验证：编译器在但环境坏掉时中止并说明，而不是报八项「特性不可用」。

## 验证

**量出来的东西改了两处注释：**

- `TRANSIT_BRACKET` 旁的「|EoT| ≤ 16.5 min — 8.7x margin」是**现代纪元**的值。支持区间内实测 **20.4 min / 7.1x**。bracket 一直够宽，是注释引错了纪元。
- `RISE_SET_BRACKET` 旁的「a few minutes at most」换成实测：|φ| ≤ 65° 内 ≤ 3.5 min。

**探针第一天就还了债**：`std::views::join_with` 三条腿全可用，`delta_t_test_helper.hpp` 那条 TODO 在等一扇不存在的门。已采纳，等价性在 libc++ 与 libstdc++ 上逐字符对拍（空区间/单元素/空分隔符/含空串/transform view）。

**三条 leg 实测矩阵**（不是从 release notes 推的）：

| 特性 | libstdc++ (clang 18.1.3) | libc++ (Apple 21) | MSVC STL (clang 20.1.8) |
|---|---|---|---|
| `ranges::fold_left` | ✅ | ✅ | ✅ |
| `views::enumerate` / `pairwise` / `slide` | ✅ | ❌ | ✅ |
| `std::generator` | ❌ | ❌ | ✅ |
| `views::concat` / `function_ref` | ❌ | ❌ | ❌ |

我先前的占位猜测 24 格里错了 2 格，所以基线是等 CI 实测回来才填的——没有一个提交断言过没量过的东西。

## 审阅

R1 四席三轮（正确性清单家 / 盲审 / 风格设计 / 减法），零 P1，两条 P2 双席以上收敛。R2 双席复验。

这批的主题是「load-bearing 注释必须为真」，而审阅正好在**新闸门自己的注释里**抓到三处假话：

- README §7 说 `join_with` 尚未支持——同一个 PR 已采纳它（三席收敛）
- workflow 说两条 Linux 腿共享 libstdc++ 头文件——用本 PR 自身证伪：`<generator>` 从 libstdc++ 14 才有，而本腿实测 GATED，真共享的话会是 True
- 测试说轨道要素单调漂向远端——实测反驳：|EoT| 在 5000 年下凹，下中天的峰在 600 年附近

减法轮证死一处冗余（`join_with` 探针行采纳后成了纪念碑，回归信号与编译完全重复），并明判 `adoptable`/`deferred`、三条 margin 测试、测试辅助抽象、独立 CI job 都该留。删行之外加了通用的纪念碑检测——**减法轮的结论从此由机器执行**。

## 范围说明

- **#131 本体（11 处 `fold_left` 手写累加）本批不改**：MS STL 的 `fold_left` 从 n≈63 起与手写和差 1–3 ulp，会让 golden 数据按平台分叉。理由逐字记在 `Feature.deferred` 字段里。
- **#99 本体（`std::generator`）本批不改**：三条腿里两条不可用。
- `MIN_BRACKET_MARGIN = 2.0` 是工程垫子不是推导值；`9050` 是仓内软约定不是库契约；`±65°` 是工程切域——三条均经审阅点名、逐条论证后不改，已记账。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
