### PR TITLE
refactor(toolbox): Angle/Distance API 收口与全库角度拼写统一 (#48, #53, #51 astro 侧)

### DIFF
--- a/src/astro/coord_transform.hpp
+++ b/src/astro/coord_transform.hpp
@@ -36,8 +36,8 @@ namespace astro::coords {
  * @note α is the right ascension, normalized to [0°, 360°). δ is the declination, in [-90°, 90°].
  */
 struct EquatorialCoord {
-  astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> α; // Right ascension
-  astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> δ; // Declination
+  astro::toolbox::AngleDeg α; // Right ascension
+  astro::toolbox::AngleDeg δ; // Declination
 };
 
 /**
@@ -46,8 +46,8 @@ struct EquatorialCoord {
  *       normalized to [0°, 360°). h is the altitude, in [-90°, 90°].
  */
 struct HorizontalCoord {
-  astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> A; // Azimuth, from the south, positive westward
-  astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> h; // Altitude
+  astro::toolbox::AngleDeg A; // Azimuth, from the south, positive westward
+  astro::toolbox::AngleDeg h; // Altitude
 };
 
 
@@ -64,12 +64,11 @@ struct HorizontalCoord {
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 13, Formulas (13.3) and (13.4).
  */
 inline auto ecliptic_to_equatorial(
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& λ,
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& β,
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& ε
+  const astro::toolbox::AngleDeg& λ,
+  const astro::toolbox::AngleDeg& β,
+  const astro::toolbox::AngleDeg& ε
 ) -> EquatorialCoord {
-  using astro::toolbox::Angle;
-  using astro::toolbox::AngleUnit::DEG;
+  using astro::toolbox::AngleDeg;
   using astro::toolbox::rad_to_deg;
 
   const double λ_rad = λ.rad();
@@ -95,8 +94,8 @@ inline auto ecliptic_to_equatorial(
   const double δ_rad = std::asin(std::clamp(sin_β * cos_ε + cos_β * sin_ε * sin_λ, -1.0, 1.0));
 
   return {
-    .α = Angle<DEG> { rad_to_deg(α_rad) }.normalize(),
-    .δ = Angle<DEG> { rad_to_deg(δ_rad) },
+    .α = AngleDeg { rad_to_deg(α_rad) }.normalize(),
+    .δ = AngleDeg { rad_to_deg(δ_rad) },
   };
 }
 
@@ -116,12 +115,11 @@ inline auto ecliptic_to_equatorial(
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 13, Formulas (13.5) and (13.6).
  */
 inline auto equatorial_to_horizontal(
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& H,
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& δ,
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& φ
+  const astro::toolbox::AngleDeg& H,
+  const astro::toolbox::AngleDeg& δ,
+  const astro::toolbox::AngleDeg& φ
 ) -> HorizontalCoord {
-  using astro::toolbox::Angle;
-  using astro::toolbox::AngleUnit::DEG;
+  using astro::toolbox::AngleDeg;
   using astro::toolbox::rad_to_deg;
 
   const double H_rad = H.rad();
@@ -147,8 +145,8 @@ inline auto equatorial_to_horizontal(
   const double h_rad = std::asin(std::clamp(sin_φ * sin_δ + cos_φ * cos_δ * cos_H, -1.0, 1.0));
 
   return {
-    .A = Angle<DEG> { rad_to_deg(A_rad) }.normalize(),
-    .h = Angle<DEG> { rad_to_deg(h_rad) },
+    .A = AngleDeg { rad_to_deg(A_rad) }.normalize(),
+    .h = AngleDeg { rad_to_deg(h_rad) },
   };
 }
 

--- a/src/astro/earth.hpp
+++ b/src/astro/earth.hpp
@@ -37,13 +37,6 @@
 #include "vsop87d/defines.hpp"
 
 
-namespace astro::earth {
-
-
-
-} // namespace astro::earth
-
-
 namespace astro::earth::heliocentric_coord {
 
 /**

--- a/src/astro/earth.hpp
+++ b/src/astro/earth.hpp
@@ -331,6 +331,9 @@ inline auto gen_eval_θ(const double jc) -> std::function<Angle<DEG>(θCoeffs)> 
  * @param model The model to use when calculating the nutation. Defaults to `Model::IAU_1980`.
  * @return The nutation in longitude (Δψ) in degrees.
  * @note By default, the IAU 1980 model is used, since it is more accurate.
+ * @note Twin of `nutation::obliquity`, which sums the same table and differs in exactly two
+ *       places: it reads `coeffs.Δε` and it takes the cosine. The duplication is deliberate —
+ *       each body mirrors its own Meeus summation — so fix both or neither (#49).
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 22.
  */
 inline auto longitude(const double jde, const Model model = Model::IAU_1980) -> Angle<DEG> {
@@ -366,6 +369,9 @@ inline auto longitude(const double jde, const Model model = Model::IAU_1980) -> 
  * @param model The model to use when calculating the nutation. Defaults to `Model::IAU_1980`.
  * @return The nutation in obliquity (Δε) in degrees.
  * @note By default, the IAU 1980 model is used, since it is more accurate.
+ * @note Twin of `nutation::longitude`, which sums the same table and differs in exactly two
+ *       places: it reads `coeffs.Δψ` and it takes the sine. The duplication is deliberate —
+ *       each body mirrors its own Meeus summation — so fix both or neither (#49).
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 22.
  */
 inline auto obliquity(const double jde, const Model model = Model::IAU_1980) -> Angle<DEG> {

--- a/src/astro/earth.hpp
+++ b/src/astro/earth.hpp
@@ -39,14 +39,7 @@
 
 namespace astro::earth {
 
-using astro::toolbox::Angle;
-using astro::toolbox::AngleUnit::DEG;
-using astro::toolbox::AngleUnit::RAD;
-using astro::toolbox::DistanceUnit::AU;
-using astro::toolbox::Distance;
-using astro::toolbox::SphericalCoordinate;
 
-using astro::vsop87d::Planet;
 
 } // namespace astro::earth
 
@@ -58,15 +51,15 @@ namespace astro::earth::heliocentric_coord {
  * @param jde The julian ephemeris day number, which is based on TT.
  * @return The heliocentric ecliptic position of the Earth, calculated using VSOP87D.
  */
-inline auto vsop87d(const double jde) -> SphericalCoordinate {
+inline auto vsop87d(const double jde) -> toolbox::SphericalCoordinate {
   const double jm = astro::julian_day::jde_to_jm(jde);
-  const auto evaluated = astro::vsop87d::evaluate<Planet::EAR>(jm);
+  const auto evaluated = astro::vsop87d::evaluate<vsop87d::Planet::EAR>(jm);
 
   return {
     // As per the algorithm, the longitude is normalized to [0, 2π).
-    .λ = Angle<DEG> { Angle<RAD> { evaluated.λ }.normalize() },
-    .β = Angle<DEG> { Angle<RAD> { evaluated.β } },
-    .r = Distance<AU> { evaluated.r }
+    .λ = toolbox::AngleDeg { toolbox::AngleRad { evaluated.λ }.normalize() },
+    .β = toolbox::AngleDeg { toolbox::AngleRad { evaluated.β } },
+    .r = toolbox::DistanceAu { evaluated.r }
   };
 }
 
@@ -303,7 +296,7 @@ inline auto find_model(const Model model) -> std::span<const NutationCoeffs> {
  * @return The function to calculate the θ values, which takes `θParams` as input and returns the θ value in degrees.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 22.
  */
-inline auto gen_eval_θ(const double jc) -> std::function<Angle<DEG>(θCoeffs)> {
+inline auto gen_eval_θ(const double jc) -> std::function<toolbox::AngleDeg(θCoeffs)> {
   const double jc2 = jc * jc;
   const double jc3 = jc * jc2;
 
@@ -318,9 +311,9 @@ inline auto gen_eval_θ(const double jc) -> std::function<Angle<DEG>(θCoeffs)> 
   // Ω is the longitude of the ascending node of the Moon's mean orbit on the ecliptic in degrees.
   const double Ω  = 125.04452 - 1934.136261   * jc + 0.0020708 * jc2 + jc3 / 450000.0;
 
-  return [=](const θCoeffs& coeffs) -> Angle<DEG> {
+  return [=](const θCoeffs& coeffs) -> toolbox::AngleDeg {
     const double degrees = D * coeffs.D + M * coeffs.M + Mp * coeffs.Mp + F * coeffs.F + Ω * coeffs.Ω;
-    return Angle<DEG> { degrees };
+    return toolbox::AngleDeg { degrees };
   };
 };
 
@@ -336,7 +329,7 @@ inline auto gen_eval_θ(const double jc) -> std::function<Angle<DEG>(θCoeffs)> 
  *       each body mirrors its own Meeus summation — so fix both or neither (#49).
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 22.
  */
-inline auto longitude(const double jde, const Model model = Model::IAU_1980) -> Angle<DEG> {
+inline auto longitude(const double jde, const Model model = Model::IAU_1980) -> toolbox::AngleDeg {
   // Get the Julian century since J2000.
   const double jc = astro::julian_day::jde_to_jc(jde);
 
@@ -348,7 +341,7 @@ inline auto longitude(const double jde, const Model model = Model::IAU_1980) -> 
 
   // Evaluate each term.
   const auto results = coeff_terms | std::views::transform([&](const NutationCoeffs& coeffs) {
-    const Angle<DEG> θ = eval_θ(coeffs.θ);
+    const toolbox::AngleDeg θ = eval_θ(coeffs.θ);
     const auto& [a, b] = coeffs.Δψ;
     return (a + b * jc) * std::sin(θ.rad());
   });
@@ -359,7 +352,7 @@ inline auto longitude(const double jde, const Model model = Model::IAU_1980) -> 
   const auto Δψ_arcsec = sum_results * 0.0001;
 
   // Convert the result to degrees.
-  return Angle<DEG>::from_arcsec(Δψ_arcsec);
+  return toolbox::AngleDeg::from_arcsec(Δψ_arcsec);
 }
 
 
@@ -374,7 +367,7 @@ inline auto longitude(const double jde, const Model model = Model::IAU_1980) -> 
  *       each body mirrors its own Meeus summation — so fix both or neither (#49).
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 22.
  */
-inline auto obliquity(const double jde, const Model model = Model::IAU_1980) -> Angle<DEG> {
+inline auto obliquity(const double jde, const Model model = Model::IAU_1980) -> toolbox::AngleDeg {
   // Get the Julian century since J2000.
   const double jc = astro::julian_day::jde_to_jc(jde);
 
@@ -386,7 +379,7 @@ inline auto obliquity(const double jde, const Model model = Model::IAU_1980) -> 
 
   // Evaluate each term.
   const auto results = coeff_terms | std::views::transform([&](const NutationCoeffs& coeffs) {
-    const Angle<DEG> θ = eval_θ(coeffs.θ);
+    const toolbox::AngleDeg θ = eval_θ(coeffs.θ);
     const auto& [a, b] = coeffs.Δε;
     return (a + b * jc) * std::cos(θ.rad());
   });
@@ -397,7 +390,7 @@ inline auto obliquity(const double jde, const Model model = Model::IAU_1980) -> 
   const auto Δε_arcsec = sum_results * 0.0001;
 
   // Convert the result to degrees.
-  return Angle<DEG>::from_arcsec(Δε_arcsec);
+  return toolbox::AngleDeg::from_arcsec(Δε_arcsec);
 }
 
 } // namespace astro::earth::nutation
@@ -415,7 +408,7 @@ namespace astro::earth::obliquity {
  * @details Accuracy ~1" over ±2000 years from J2000; the polynomial degrades farther out.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 22, Formula (22.2).
  */
-inline auto mean(const double jde) -> Angle<DEG> {
+inline auto mean(const double jde) -> toolbox::AngleDeg {
   // Get the Julian century since J2000.
   const double jc = astro::julian_day::jde_to_jc(jde);
 
@@ -423,7 +416,7 @@ inline auto mean(const double jde) -> Angle<DEG> {
   // The polynomial is evaluated in arcseconds.
   const double ε0_arcsec = 84381.448 + jc * (-46.8150 + jc * (-0.00059 + jc * 0.001813));
 
-  return Angle<DEG>::from_arcsec(ε0_arcsec);
+  return toolbox::AngleDeg::from_arcsec(ε0_arcsec);
 }
 
 /**
@@ -436,7 +429,7 @@ inline auto mean(const double jde) -> Angle<DEG> {
 inline auto true_obliquity(
   const double jde,
   const nutation::Model model = nutation::Model::IAU_1980
-) -> Angle<DEG> {
+) -> toolbox::AngleDeg {
   return mean(jde) + nutation::obliquity(jde, model);
 }
 
@@ -498,7 +491,7 @@ inline auto daily_λ_variation(const double jde) -> double {
   using namespace std::ranges;
   const double τ = astro::julian_day::jde_to_jm(jde);
   const auto terms = MEEUS_DAILY_VARIATION_TERMS | views::transform([τ](const DailyVariationTerm& t) {
-    const Angle<DEG> θ { t.phase + t.rate * τ };
+    const toolbox::AngleDeg θ { t.phase + t.rate * τ };
     return t.amplitude * std::pow(τ, t.tau_power) * std::sin(θ.rad());
   });
   return 3548.330 + std::reduce(cbegin(terms), cend(terms));
@@ -521,9 +514,9 @@ inline constexpr double LIGHT_TIME_DAYS_PER_AU = 0.0057755183;
  *       κ(1−e²), not the bare aberration constant κ = 20.49552″ (#66).
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, (25.10)-(25.11), p. 167-168.
  */
-inline auto compute(const double jde, const Distance<AU> r) -> Angle<DEG> {
+inline auto compute(const double jde, const toolbox::DistanceAu r) -> toolbox::AngleDeg {
   const double aberration_arcsec = LIGHT_TIME_DAYS_PER_AU * r.au() * daily_λ_variation(jde);
-  return Angle<DEG>::from_arcsec(aberration_arcsec);
+  return toolbox::AngleDeg::from_arcsec(aberration_arcsec);
 }
 
 } // namespace astro::earth::aberration

--- a/src/astro/earth.hpp
+++ b/src/astro/earth.hpp
@@ -64,9 +64,9 @@ inline auto vsop87d(const double jde) -> SphericalCoordinate {
 
   return {
     // As per the algorithm, the longitude is normalized to [0, 2π).
-    .λ = Angle<RAD>(evaluated.λ).normalize(),
-    .β = Angle<RAD>(evaluated.β),
-    .r = Distance<AU>(evaluated.r)
+    .λ = Angle<DEG> { Angle<RAD> { evaluated.λ }.normalize() },
+    .β = Angle<DEG> { Angle<RAD> { evaluated.β } },
+    .r = Distance<AU> { evaluated.r }
   };
 }
 

--- a/src/astro/elp2000_82b.hpp
+++ b/src/astro/elp2000_82b.hpp
@@ -192,12 +192,7 @@ inline constexpr std::array<BCoefficients, 60> B {{
 
 namespace astro::elp2000_82b {
 
-using coeff::LR;
-using coeff::B;
 
-using toolbox::Angle;
-using toolbox::AngleUnit::DEG;
-using toolbox::AngleUnit::RAD;
 
 
 /**
@@ -219,14 +214,14 @@ inline constexpr double RADIUS_SCALING_FACTOR = 1e3;
 struct Context {
   double     jc; // The julian century
 
-  Angle<DEG> Lp; // The argument for the mean longitude of the Moon from the Sun
-  Angle<DEG> D;  // The argument for the mean elongation of the Moon from the Sun
-  Angle<DEG> M;  // The argument for the mean anomaly of the Sun
-  Angle<DEG> Mp; // The argument for the mean anomaly of the Moon
-  Angle<DEG> F;  // The argument for the distance of the Moon from its Ascending Node
-  Angle<DEG> A1; // Further argument 1, as indicated in Astronomical Algorithms, Jean Meeus, 1998, Chapter 47
-  Angle<DEG> A2; // Further argument 2, as indicated in Astronomical Algorithms, Jean Meeus, 1998, Chapter 47
-  Angle<DEG> A3; // Further argument 3, as indicated in Astronomical Algorithms, Jean Meeus, 1998, Chapter 47
+  toolbox::AngleDeg Lp; // The argument for the mean longitude of the Moon from the Sun
+  toolbox::AngleDeg D;  // The argument for the mean elongation of the Moon from the Sun
+  toolbox::AngleDeg M;  // The argument for the mean anomaly of the Sun
+  toolbox::AngleDeg Mp; // The argument for the mean anomaly of the Moon
+  toolbox::AngleDeg F;  // The argument for the distance of the Moon from its Ascending Node
+  toolbox::AngleDeg A1; // Further argument 1, as indicated in Astronomical Algorithms, Jean Meeus, 1998, Chapter 47
+  toolbox::AngleDeg A2; // Further argument 2, as indicated in Astronomical Algorithms, Jean Meeus, 1998, Chapter 47
+  toolbox::AngleDeg A3; // Further argument 3, as indicated in Astronomical Algorithms, Jean Meeus, 1998, Chapter 47
   double E;      // The argument for the eccentricity of the Earth's orbit around the Sun
 };
 
@@ -242,15 +237,15 @@ inline auto create_context(const double jc) -> Context {
   const double jc3 = jc2 * jc;
   const double jc4 = jc3 * jc;
 
-  const Angle<DEG> Lp { 218.3164477 + 481267.88123421 * jc - 0.0015786 * jc2 + jc3 / 538841 - jc4 / 65194000 };
-  const Angle<DEG> D  { 297.8501921 + 445267.1114034 * jc - 0.0018819 * jc2 + jc3 / 545868 - jc4 / 113065000 };
-  const Angle<DEG> M  { 357.5291092 + 35999.0502909 * jc - 0.0001536 * jc2 + jc3 / 24490000 };
-  const Angle<DEG> Mp { 134.9633964 + 477198.8675055 * jc + 0.0087414 * jc2 + jc3 / 69699 - jc4 / 14712000 };
-  const Angle<DEG> F  { 93.2720950 + 483202.0175233 * jc - 0.0036539 * jc2 - jc3 / 3526000 + jc4 / 863310000 };
+  const toolbox::AngleDeg Lp { 218.3164477 + 481267.88123421 * jc - 0.0015786 * jc2 + jc3 / 538841 - jc4 / 65194000 };
+  const toolbox::AngleDeg D  { 297.8501921 + 445267.1114034 * jc - 0.0018819 * jc2 + jc3 / 545868 - jc4 / 113065000 };
+  const toolbox::AngleDeg M  { 357.5291092 + 35999.0502909 * jc - 0.0001536 * jc2 + jc3 / 24490000 };
+  const toolbox::AngleDeg Mp { 134.9633964 + 477198.8675055 * jc + 0.0087414 * jc2 + jc3 / 69699 - jc4 / 14712000 };
+  const toolbox::AngleDeg F  { 93.2720950 + 483202.0175233 * jc - 0.0036539 * jc2 - jc3 / 3526000 + jc4 / 863310000 };
 
-  const Angle<DEG> A1 { 119.75 + 131.849 * jc };
-  const Angle<DEG> A2 { 53.09 + 479264.290 * jc };
-  const Angle<DEG> A3 { 313.45 + 481266.484 * jc };
+  const toolbox::AngleDeg A1 { 119.75 + 131.849 * jc };
+  const toolbox::AngleDeg A2 { 53.09 + 479264.290 * jc };
+  const toolbox::AngleDeg A3 { 313.45 + 481266.484 * jc };
 
   const double E = 1 - 0.002516 * jc - 0.0000074 * jc2;
 
@@ -293,8 +288,8 @@ inline auto evaluate(const double jc) -> Evaluation {
   const auto ctx = create_context(jc);
 
   // Calculate the longitude periodic terms.
-  const auto lon_terms = LR | views::transform([&](const coeff::LRCoefficients& coeff) {
-    const Angle<DEG> θ {
+  const auto lon_terms = coeff::LR | views::transform([&](const coeff::LRCoefficients& coeff) {
+    const toolbox::AngleDeg θ {
       coeff.D  * ctx.D.deg()  +
       coeff.M  * ctx.M.deg()  +
       coeff.Mp * ctx.Mp.deg() +
@@ -306,8 +301,8 @@ inline auto evaluate(const double jc) -> Evaluation {
   });
 
   // Calculate the distance/radius periodic terms.
-  const auto rad_terms = LR | views::transform([&](const coeff::LRCoefficients& coeff) {
-    const Angle<DEG> θ {
+  const auto rad_terms = coeff::LR | views::transform([&](const coeff::LRCoefficients& coeff) {
+    const toolbox::AngleDeg θ {
       coeff.D  * ctx.D.deg()  +
       coeff.M  * ctx.M.deg()  +
       coeff.Mp * ctx.Mp.deg() +
@@ -319,8 +314,8 @@ inline auto evaluate(const double jc) -> Evaluation {
   });
 
   // Calculate the latitude periodic terms.
-  const auto lat_terms = B | views::transform([&](const coeff::BCoefficients& coeff) {
-    const Angle<DEG> θ {
+  const auto lat_terms = coeff::B | views::transform([&](const coeff::BCoefficients& coeff) {
+    const toolbox::AngleDeg θ {
       coeff.D  * ctx.D.deg()  +
       coeff.M  * ctx.M.deg()  +
       coeff.Mp * ctx.Mp.deg() +

--- a/src/astro/elp2000_82b.hpp
+++ b/src/astro/elp2000_82b.hpp
@@ -192,9 +192,6 @@ inline constexpr std::array<BCoefficients, 60> B {{
 
 namespace astro::elp2000_82b {
 
-
-
-
 /**
  * @brief The scaling factor used in the Jean Meeus's Astronomical Algorithms, for the longitude and latitude.
  *        The unit of the raw evaluation result of longitude and latitude is 0.000001 degree.

--- a/src/astro/moon.hpp
+++ b/src/astro/moon.hpp
@@ -97,7 +97,7 @@ inline auto apparent(const double jde) -> SphericalCoordinate {
   // Longitude, considering the perturbation and nutation.
   const auto Σl = evaluated.Σl + perturbation::longitude(evaluated.ctx);
   const auto lon_nutation = astro::earth::nutation::longitude(jde);
-  const Angle<DEG> lon = evaluated.ctx.Lp + (Σl / LON_LAT_SCALING_FACTOR) + lon_nutation; 
+  const Angle<DEG> lon = evaluated.ctx.Lp + Angle<DEG> { Σl / LON_LAT_SCALING_FACTOR } + lon_nutation;
 
   // Latitude, considering the perturbation.
   const auto Σb = evaluated.Σb + perturbation::latitude(evaluated.ctx);
@@ -109,7 +109,7 @@ inline auto apparent(const double jde) -> SphericalCoordinate {
   return {
     .λ = lon.normalize(),
     .β = lat,
-    .r = r
+    .r = Distance<astro::toolbox::DistanceUnit::AU> { r }
   };
 }
 
@@ -121,7 +121,7 @@ inline auto apparent(const double jde) -> SphericalCoordinate {
  */
 inline auto equatorial_horizontal_parallax(const Distance<KM>& distance) -> Angle<RAD> {
   const auto ppi_rad = std::asin(6378.14 / distance.km());
-  return { ppi_rad };
+  return Angle<RAD> { ppi_rad };
 }
 
 } // namespace astro::moon::geocentric_coord

--- a/src/astro/moon.hpp
+++ b/src/astro/moon.hpp
@@ -33,7 +33,6 @@
 
 namespace astro::moon::perturbation {
 
-using astro::elp2000_82b::Context;
 
 /**
  * @brief Calculate perturbation of the Moon's geocentric longitude.
@@ -43,7 +42,7 @@ using astro::elp2000_82b::Context;
  * @return The perturbation of the Moon's geocentric longitude. Unit is 0.000001 degrees.
  * @see Astronomical Algorithms, Jean Meeus, 1998, Chapter 47.
  */
-inline auto longitude(const Context& ctx) -> double {
+inline auto longitude(const elp2000_82b::Context& ctx) -> double {
   return 3958.0 * std::sin(ctx.A1.rad()) 
        + 1962.0 * std::sin(ctx.Lp.rad() - ctx.F.rad()) 
        + 318.0 * std::sin(ctx.A2.rad());
@@ -58,7 +57,7 @@ inline auto longitude(const Context& ctx) -> double {
  * @return The perturbation of the Moon's geocentric latitude. Unit is 0.000001 degrees.
  * @see Astronomical Algorithms, Jean Meeus, 1998, Chapter 47.
  */
-inline auto latitude(const Context& ctx) -> double {
+inline auto latitude(const elp2000_82b::Context& ctx) -> double {
   return -2235.0 * std::sin(ctx.Lp.rad())
        + 382.0 * std::sin(ctx.A3.rad())
        + 175.0 * std::sin(ctx.A1.rad() - ctx.F.rad())
@@ -72,16 +71,7 @@ inline auto latitude(const Context& ctx) -> double {
 
 namespace astro::moon::geocentric_coord {
 
-using astro::toolbox::Angle;
-using astro::toolbox::AngleUnit::DEG;
-using astro::toolbox::AngleUnit::RAD;
-using astro::toolbox::DistanceUnit::KM;
-using astro::toolbox::Distance;
-using astro::toolbox::SphericalCoordinate;
 
-using astro::elp2000_82b::evaluate;
-using astro::elp2000_82b::LON_LAT_SCALING_FACTOR;
-using astro::elp2000_82b::RADIUS_SCALING_FACTOR;
 
 
 /**
@@ -89,27 +79,27 @@ using astro::elp2000_82b::RADIUS_SCALING_FACTOR;
  * @param jde The julian ephemeris day number, which is based on TT.
  * @return The geocentric ecliptic position of the Moon, calculated using truncated ELP2000-82B.
  */
-inline auto apparent(const double jde) -> SphericalCoordinate {
+inline auto apparent(const double jde) -> toolbox::SphericalCoordinate {
   const double jc = astro::julian_day::jde_to_jc(jde);
 
-  const auto evaluated = evaluate(jc);
+  const auto evaluated = elp2000_82b::evaluate(jc);
 
   // Longitude, considering the perturbation and nutation.
   const auto Σl = evaluated.Σl + perturbation::longitude(evaluated.ctx);
   const auto lon_nutation = astro::earth::nutation::longitude(jde);
-  const Angle<DEG> lon = evaluated.ctx.Lp + Angle<DEG> { Σl / LON_LAT_SCALING_FACTOR } + lon_nutation;
+  const toolbox::AngleDeg lon = evaluated.ctx.Lp + toolbox::AngleDeg { Σl / elp2000_82b::LON_LAT_SCALING_FACTOR } + lon_nutation;
 
   // Latitude, considering the perturbation.
   const auto Σb = evaluated.Σb + perturbation::latitude(evaluated.ctx);
-  const Angle<DEG> lat { Σb / LON_LAT_SCALING_FACTOR };
+  const toolbox::AngleDeg lat { Σb / elp2000_82b::LON_LAT_SCALING_FACTOR };
 
   // Distance, in KM.
-  const Distance<KM> r { 385000.56 + evaluated.Σr / RADIUS_SCALING_FACTOR };
+  const toolbox::DistanceKm r { 385000.56 + evaluated.Σr / elp2000_82b::RADIUS_SCALING_FACTOR };
 
   return {
     .λ = lon.normalize(),
     .β = lat,
-    .r = Distance<astro::toolbox::DistanceUnit::AU> { r }
+    .r = astro::toolbox::DistanceAu { r }
   };
 }
 
@@ -119,9 +109,9 @@ inline auto apparent(const double jde) -> SphericalCoordinate {
  * @param distance The geocentric distance of the Moon.
  * @return The equatorial horizontal parallax of the Moon.
  */
-inline auto equatorial_horizontal_parallax(const Distance<KM>& distance) -> Angle<RAD> {
+inline auto equatorial_horizontal_parallax(const toolbox::DistanceKm& distance) -> toolbox::AngleRad {
   const auto ppi_rad = std::asin(6378.14 / distance.km());
-  return Angle<RAD> { ppi_rad };
+  return toolbox::AngleRad { ppi_rad };
 }
 
 } // namespace astro::moon::geocentric_coord

--- a/src/astro/moon.hpp
+++ b/src/astro/moon.hpp
@@ -33,7 +33,6 @@
 
 namespace astro::moon::perturbation {
 
-
 /**
  * @brief Calculate perturbation of the Moon's geocentric longitude.
  * @details As per Astronomical Algorithms, Jean Meeus, 1998, Chapter 47, 
@@ -70,9 +69,6 @@ inline auto latitude(const elp2000_82b::Context& ctx) -> double {
 
 
 namespace astro::moon::geocentric_coord {
-
-
-
 
 /**
  * @brief Calculate the apparent geocentric position of the Moon, using truncated ELP2000-82B.

--- a/src/astro/moon.hpp
+++ b/src/astro/moon.hpp
@@ -99,7 +99,7 @@ inline auto apparent(const double jde) -> toolbox::SphericalCoordinate {
   return {
     .λ = lon.normalize(),
     .β = lat,
-    .r = astro::toolbox::DistanceAu { r }
+    .r = toolbox::DistanceAu { r }
   };
 }
 

--- a/src/astro/sidereal_time.hpp
+++ b/src/astro/sidereal_time.hpp
@@ -48,9 +48,8 @@ namespace astro::sidereal {
  *       is TT-based.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 12, Formulas (12.2)-(12.4).
  */
-inline auto greenwich_mean(const double jd_ut1) -> astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> {
-  using astro::toolbox::Angle;
-  using astro::toolbox::AngleUnit::DEG;
+inline auto greenwich_mean(const double jd_ut1) -> astro::toolbox::AngleDeg {
+  using astro::toolbox::AngleDeg;
 
   // Days and julian centuries of *universal* time since J2000.0 UT.
   const double d_ut1 = jd_ut1 - astro::julian_day::J2000;
@@ -61,7 +60,7 @@ inline auto greenwich_mean(const double jd_ut1) -> astro::toolbox::Angle<astro::
                   + 0.000387933 * t_ut1 * t_ut1
                   - (t_ut1 * t_ut1 * t_ut1) / 38710000.0;
 
-  return Angle<DEG> { θ0 }.normalize();
+  return AngleDeg { θ0 }.normalize();
 }
 
 /**
@@ -82,14 +81,13 @@ inline auto greenwich_apparent(
   const double jd_ut1,
   const double jde_tt,
   const astro::earth::nutation::Model model = astro::earth::nutation::Model::IAU_1980
-) -> astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> {
-  using astro::toolbox::Angle;
-  using astro::toolbox::AngleUnit::DEG;
+) -> astro::toolbox::AngleDeg {
+  using astro::toolbox::AngleDeg;
 
   // The nutation correction in right ascension: Δψ·cos ε. Nutation is computed on the TT scale.
   const auto Δψ = astro::earth::nutation::longitude(jde_tt, model);
   const auto ε  = astro::earth::obliquity::true_obliquity(jde_tt, model);
-  const Angle<DEG> correction = Δψ * std::cos(ε.rad());
+  const AngleDeg correction = Δψ * std::cos(ε.rad());
 
   return (greenwich_mean(jd_ut1) + correction).normalize();
 }
@@ -110,9 +108,9 @@ inline auto greenwich_apparent(
 inline auto local_apparent(
   const double jd_ut1,
   const double jde_tt,
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& longitude_west,
+  const astro::toolbox::AngleDeg& longitude_west,
   const astro::earth::nutation::Model model = astro::earth::nutation::Model::IAU_1980
-) -> astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> {
+) -> astro::toolbox::AngleDeg {
   return (greenwich_apparent(jd_ut1, jde_tt, model) - longitude_west).normalize();
 }
 

--- a/src/astro/sidereal_time.hpp
+++ b/src/astro/sidereal_time.hpp
@@ -98,22 +98,22 @@ inline auto greenwich_apparent(
  * @brief Compute the Local Apparent Sidereal Time (LAST) for an observer.
  * @param jd_ut1 The julian day number, on the **UT1** scale (see `greenwich_mean`'s warning).
  * @param jde_tt The julian ephemeris day, on the **TT** scale, of the same instant (nutation).
- * @param longitude The observer's geographic longitude, measured **positive west** from Greenwich
- *        (Meeus's convention; e.g. Washington USNO ≈ +77°.0656). East-positive longitudes must
- *        be negated before calling.
+ * @param longitude_west The observer's geographic longitude, measured **positive west** from
+ *        Greenwich (Meeus's convention; e.g. Washington USNO ≈ +77°.0656). East-positive
+ *        longitudes must be negated before calling — the `_west` suffix is the guard (#127/D2).
  * @param model The nutation model to use. Defaults to `earth::nutation::Model::IAU_1980`.
  * @return The LAST, normalized to [0°, 360°).
- * @note With the west-positive convention the relation reads θ = θ₀(GAST) − longitude, consistent
- *       with Meeus's hour-angle formula H = θ₀ − L − α used from Chapter 13 onward.
+ * @note With the west-positive convention the relation reads θ = θ₀(GAST) − longitude_west,
+ *       consistent with Meeus's hour-angle formula H = θ₀ − L − α used from Chapter 13 onward.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 12.
  */
 inline auto local_apparent(
   const double jd_ut1,
   const double jde_tt,
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& longitude,
+  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& longitude_west,
   const astro::earth::nutation::Model model = astro::earth::nutation::Model::IAU_1980
 ) -> astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> {
-  return (greenwich_apparent(jd_ut1, jde_tt, model) - longitude).normalize();
+  return (greenwich_apparent(jd_ut1, jde_tt, model) - longitude_west).normalize();
 }
 
 } // namespace astro::sidereal

--- a/src/astro/solar_time.hpp
+++ b/src/astro/solar_time.hpp
@@ -52,9 +52,8 @@ namespace detail {
  * @return L0, unnormalized.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Formula (28.2).
  */
-constexpr auto sun_mean_longitude(const double jde_tt) -> astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> {
-  using astro::toolbox::Angle;
-  using astro::toolbox::AngleUnit::DEG;
+constexpr auto sun_mean_longitude(const double jde_tt) -> astro::toolbox::AngleDeg {
+  using astro::toolbox::AngleDeg;
 
   const double τ = astro::julian_day::jde_to_jm(jde_tt);
   const double L0 = 280.4664567
@@ -63,7 +62,7 @@ constexpr auto sun_mean_longitude(const double jde_tt) -> astro::toolbox::Angle<
                   + τ * (1.0 / 49931.0
                   + τ * (-1.0 / 15300.0
                   + τ * (-1.0 / 2000000.0)))));
-  return Angle<DEG> { L0 };
+  return AngleDeg { L0 };
 }
 
 } // namespace detail
@@ -79,9 +78,8 @@ constexpr auto sun_mean_longitude(const double jde_tt) -> astro::toolbox::Angle<
  *          the mean longitude L0 can sit on opposite sides of the 0°/360° seam.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Formula (28.1).
  */
-inline auto equation_of_time(const double jde_tt) -> astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> {
-  using astro::toolbox::Angle;
-  using astro::toolbox::AngleUnit::DEG;
+inline auto equation_of_time(const double jde_tt) -> astro::toolbox::AngleDeg {
+  using astro::toolbox::AngleDeg;
   using astro::toolbox::normalize_pm180;
 
   const auto L0 = detail::sun_mean_longitude(jde_tt);
@@ -91,7 +89,7 @@ inline auto equation_of_time(const double jde_tt) -> astro::toolbox::Angle<astro
 
   // (28.1); the constant 0°.0057183 folds aberration and the FK5 correction into L0.
   const double e = L0.deg() - 0.0057183 - α.deg() + Δψ.deg() * std::cos(ε.rad());
-  return Angle<DEG> { normalize_pm180(e) };
+  return AngleDeg { normalize_pm180(e) };
 }
 
 
@@ -112,7 +110,7 @@ inline auto equation_of_time(const double jde_tt) -> astro::toolbox::Angle<astro
  */
 inline auto apparent(
   const calendar::Datetime& utc_dt,
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& longitude
+  const astro::toolbox::AngleDeg& longitude
 ) -> calendar::Datetime {
   const double lon = longitude.deg();
   if (not std::isfinite(lon) or lon < -180.0 or lon > 180.0) {

--- a/src/astro/sun.hpp
+++ b/src/astro/sun.hpp
@@ -37,8 +37,6 @@
 
 namespace astro::sun::geocentric_coord {
 
-
-
 /**
  * @brief Calculate the geocentric position of the Sun, using VSOP87D.
  * @param jde The Julian Ephemeris Day.

--- a/src/astro/sun.hpp
+++ b/src/astro/sun.hpp
@@ -73,8 +73,8 @@ inline auto vsop87d(const double jde) -> SphericalCoordinate {
 
 /** @brief The FK5 correction for the coordinate calculated using VSOP87D. */
 struct Fk5Correction {
-  const Angle<DEG> Δλ;
-  const Angle<DEG> Δβ;
+  Angle<DEG> Δλ;
+  Angle<DEG> Δβ;
 };
 
 

--- a/src/astro/sun.hpp
+++ b/src/astro/sun.hpp
@@ -37,10 +37,6 @@
 
 namespace astro::sun::geocentric_coord {
 
-using astro::toolbox::Angle;
-using astro::toolbox::AngleUnit::DEG;
-using astro::toolbox::AngleUnit::RAD;
-using astro::toolbox::SphericalCoordinate;
 
 
 /**
@@ -50,7 +46,7 @@ using astro::toolbox::SphericalCoordinate;
  * @details The function invokes `astro::earth::heliocentric_coord::vsop87d`, and
  *          transforms the heliocentric coordinates to geocentric coordinates.
  */
-inline auto vsop87d(const double jde) -> SphericalCoordinate {
+inline auto vsop87d(const double jde) -> toolbox::SphericalCoordinate {
   const auto& [λ_helio, β_helio, r_helio] = astro::earth::heliocentric_coord::vsop87d(jde);
   return {
     // Convert the heliocentric ecliptic longitude of Earth to geocentric ecliptic longitude of Sun.
@@ -73,8 +69,8 @@ inline auto vsop87d(const double jde) -> SphericalCoordinate {
 
 /** @brief The FK5 correction for the coordinate calculated using VSOP87D. */
 struct Fk5Correction {
-  Angle<DEG> Δλ;
-  Angle<DEG> Δβ;
+  toolbox::AngleDeg Δλ;
+  toolbox::AngleDeg Δβ;
 };
 
 
@@ -84,20 +80,20 @@ struct Fk5Correction {
  * @return The correction (i.e. Δlongitude and Δlatitude).
  * @details As per Jean Meeus's Astronomical Algorithms, this correction is applied for accuracy.
  */
-inline auto fk5_correction(const double jde, const SphericalCoordinate& vsop87d_coord) -> Fk5Correction {
+inline auto fk5_correction(const double jde, const toolbox::SphericalCoordinate& vsop87d_coord) -> Fk5Correction {
   const double jc = astro::julian_day::jde_to_jc(jde);
   const auto& [vsop_λ, vsop_β, vsop_r] = vsop87d_coord;
 
   // Calculate the deltas for longitude and latitude, in arcsec.
-  const Angle λ_dash = vsop_λ - Angle<DEG> { (1.397 + 0.00031 * jc) * jc };
+  const toolbox::AngleDeg λ_dash = vsop_λ - toolbox::AngleDeg { (1.397 + 0.00031 * jc) * jc };
   const double λ_dash_rad = λ_dash.rad();
 
   const double delta_λ_arcsec = -0.09033 + 0.03916 * (std::cos(λ_dash_rad) + std::sin(λ_dash_rad)) * std::tan(vsop_β.rad());
   const double delta_β_arcsec = 0.03916 * (std::cos(λ_dash_rad) - std::sin(λ_dash_rad));
 
   return {
-    .Δλ = Angle<DEG>::from_arcsec(delta_λ_arcsec),
-    .Δβ = Angle<DEG>::from_arcsec(delta_β_arcsec),
+    .Δλ = toolbox::AngleDeg::from_arcsec(delta_λ_arcsec),
+    .Δβ = toolbox::AngleDeg::from_arcsec(delta_β_arcsec),
   };
 }
 
@@ -108,7 +104,7 @@ inline auto fk5_correction(const double jde, const SphericalCoordinate& vsop87d_
  * @param jde The julian ephemeris day number, which is based on TT.
  * @return The geocentric ecliptic position of the Sun, after correction.
  */
-inline auto apparent(const double jde) -> SphericalCoordinate {
+inline auto apparent(const double jde) -> toolbox::SphericalCoordinate {
   // Use VSOP87D to calculate the geocentric ecliptic position of the Sun.
   const auto vsop_coord = vsop87d(jde);
 

--- a/src/astro/sunrise_sunset.hpp
+++ b/src/astro/sunrise_sunset.hpp
@@ -48,16 +48,16 @@ namespace astro::sunrise_sunset {
  * @note Meeus Chapter 15: -34' of standard atmospheric refraction at the horizon,
  *       plus -16' so that the event refers to the Sun's upper limb, not its center.
  */
-inline constexpr auto STANDARD_ALTITUDE = astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>::from_arcmin(-50.0);
+inline constexpr auto STANDARD_ALTITUDE = astro::toolbox::AngleDeg::from_arcmin(-50.0);
 
 /** @brief The Sun's altitude at civil twilight: -6°. */
-inline constexpr astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> CIVIL_TWILIGHT { -6.0 };
+inline constexpr astro::toolbox::AngleDeg CIVIL_TWILIGHT { -6.0 };
 
 /** @brief The Sun's altitude at nautical twilight: -12°. */
-inline constexpr astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> NAUTICAL_TWILIGHT { -12.0 };
+inline constexpr astro::toolbox::AngleDeg NAUTICAL_TWILIGHT { -12.0 };
 
 /** @brief The Sun's altitude at astronomical twilight: -18°. */
-inline constexpr astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> ASTRONOMICAL_TWILIGHT { -18.0 };
+inline constexpr astro::toolbox::AngleDeg ASTRONOMICAL_TWILIGHT { -18.0 };
 
 /**
  * @brief How far past ±1 cos(H₀) may land and still count as a grazing event rather than
@@ -141,8 +141,8 @@ inline constexpr double RISE_SET_RESIDUAL_GUARD_DEG = 1e-3;
  *       matching the intended UT window — deliberate, same behavior as other UT-date APIs.
  */
 struct GeoLocation {
-  astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> latitude;  // North-positive, [-90°, 90°].
-  astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> longitude; // East-positive, [-180°, 180°].
+  astro::toolbox::AngleDeg latitude;  // North-positive, [-90°, 90°].
+  astro::toolbox::AngleDeg longitude; // East-positive, [-180°, 180°].
 };
 
 /**
@@ -235,13 +235,12 @@ struct SunLocal {
 [[nodiscard]] inline auto sun_altitude(
   const double jde_tt,
   const GeoLocation& location
-) -> astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> {
-  using astro::toolbox::Angle;
-  using astro::toolbox::AngleUnit::DEG;
+) -> astro::toolbox::AngleDeg {
+  using astro::toolbox::AngleDeg;
 
   const auto local = sun_local(jde_tt, location);
   const auto horizontal = astro::coords::equatorial_to_horizontal(
-    Angle<DEG> { local.hour_angle_deg }, local.eq.δ, location.latitude
+    AngleDeg { local.hour_angle_deg }, local.eq.δ, location.latitude
   );
   return horizontal.h;
 }
@@ -282,7 +281,7 @@ struct SunLocal {
 inline void validate_rise_set_inputs(
   const double transit,
   const GeoLocation& location,
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& h0
+  const astro::toolbox::AngleDeg& h0
 ) {
   validate(location);
 
@@ -359,12 +358,11 @@ requires std::invocable<Func, double>
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 15, Formula (15.1).
  */
 [[nodiscard]] inline auto hour_angle_at_altitude(
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& δ,
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& φ,
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& h0
-) -> std::optional<astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>> {
-  using astro::toolbox::Angle;
-  using astro::toolbox::AngleUnit::DEG;
+  const astro::toolbox::AngleDeg& δ,
+  const astro::toolbox::AngleDeg& φ,
+  const astro::toolbox::AngleDeg& h0
+) -> std::optional<astro::toolbox::AngleDeg> {
+  using astro::toolbox::AngleDeg;
   using astro::toolbox::rad_to_deg;
 
   const auto reject_outside_pm90 = [](const char* name, const double deg) {
@@ -401,7 +399,7 @@ requires std::invocable<Func, double>
     cos_H0 = 1.0;
   }
 
-  return Angle<DEG> { rad_to_deg(std::acos(cos_H0)) };
+  return AngleDeg { rad_to_deg(std::acos(cos_H0)) };
 }
 
 
@@ -467,7 +465,7 @@ requires std::invocable<Func, double>
   const double transit,
   const bool is_sunrise,
   const GeoLocation& location,
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& h0 = STANDARD_ALTITUDE
+  const astro::toolbox::AngleDeg& h0 = STANDARD_ALTITUDE
 ) -> std::optional<double> {
   detail::validate_rise_set_inputs(transit, location, h0);
 
@@ -541,7 +539,7 @@ requires std::invocable<Func, double>
 [[nodiscard]] inline auto calculate(
   const std::chrono::year_month_day& ymd,
   const GeoLocation& location,
-  const astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG>& h0 = STANDARD_ALTITUDE
+  const astro::toolbox::AngleDeg& h0 = STANDARD_ALTITUDE
 ) -> Result {
   const double transit = transit_jde(ymd, location);
 

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -134,10 +134,7 @@ struct Angle {
     return Angle<Unit> { Angle<AngleUnit::DEG> { arcsec_to_deg(value) } };
   }
 
-  /**
-   * @brief Convert to the other unit. Explicit: a unit change is a step the reader should see,
-   *        and the round trip through radians is not bit-exact.
-   */
+  /** @brief Convert to the other unit — explicit, so a unit change never happens silently. */
   template <AngleUnit As>
   constexpr explicit operator Angle<As>() const {
     return Angle<As> { as<As>() };
@@ -160,7 +157,7 @@ struct Angle {
   }
 
   /**
-   * @brief Scale the angle down by a bare factor.
+   * @brief Divide the angle by a bare (dimensionless) factor.
    * @throws std::runtime_error if the divisor is zero — an infinite angle is never the intent (#48).
    */
   constexpr auto operator/(const double other) const -> Angle<Unit> {
@@ -279,7 +276,7 @@ template <DistanceUnit Unit>
 struct Distance {
   constexpr explicit Distance(const double value) : _value { value } {}
 
-  /** @brief Convert to the other unit. Explicit for the same reason as `Angle`'s — see there. */
+  /** @brief Convert to the other unit. */
   template <DistanceUnit As>
   constexpr explicit operator Distance<As>() const {
     return Distance<As> { as<As>() };
@@ -307,7 +304,7 @@ struct Distance {
   }
 
  private:
-  double _value; // Private for the same reason as `Angle::_value` — see the note there.
+  double _value;
 };
 
 /** @brief The spelling used outside this header, for the same reason as `AngleDeg` (#53). */
@@ -319,8 +316,8 @@ using DistanceKm = Distance<DistanceUnit::KM>;
  * @brief Represents a position in a spherical coordinate system.
  */
 struct SphericalCoordinate {
-  AngleDeg      λ; // Longitude
-  AngleDeg      β; // Latitude
+  AngleDeg   λ; // Longitude
+  AngleDeg   β; // Latitude
   DistanceAu r; // Radius/Distance
 };
 

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -119,51 +119,50 @@ enum class AngleUnit : uint8_t { RAD, DEG };
  */
 template <AngleUnit Unit>
 struct Angle {
-  constexpr Angle(const double value) : _value { value } {} // NOLINT(google-explicit-constructor)
+  constexpr explicit Angle(const double value) : _value { value } {}
 
   constexpr static auto from_arcmin(const double value) -> Angle<AngleUnit::DEG> {
-    return { arcmin_to_deg(value) };
+    return Angle<AngleUnit::DEG> { arcmin_to_deg(value) };
   }
 
   constexpr static auto from_arcsec(const double value) -> Angle<AngleUnit::DEG> {
-    return { arcsec_to_deg(value) };
+    return Angle<AngleUnit::DEG> { arcsec_to_deg(value) };
   }
 
-  /** @brief Allow implicit conversion to the other unit. */
+  /**
+   * @brief Convert to the other unit. Explicit: a unit change is a step the reader should see,
+   *        and the round trip through radians is not bit-exact.
+   */
   template <AngleUnit As>
-  constexpr operator Angle<As>() const { // NOLINT(google-explicit-constructor)
-    return { as<As>() };
+  constexpr explicit operator Angle<As>() const {
+    return Angle<As> { as<As>() };
   }
 
   constexpr auto operator+(const Angle<Unit>& other) const -> Angle<Unit> {
-    return { _value + other._value };
-  }
-
-  constexpr auto operator+(const double other) const -> Angle<Unit> {
-    return { _value + other };
+    return Angle<Unit> { _value + other._value };
   }
 
   constexpr auto operator-(const Angle<Unit>& other) const -> Angle<Unit> {
-    return { _value - other._value };
-  }
-
-  constexpr auto operator-(const double other) const -> Angle<Unit> {
-    return { _value - other };
+    return Angle<Unit> { _value - other._value };
   }
 
   constexpr auto operator-() const -> Angle<Unit> {
-    return { -_value };
+    return Angle<Unit> { -_value };
   }
 
   constexpr auto operator*(const double other) const -> Angle<Unit> {
-    return { _value * other };
+    return Angle<Unit> { _value * other };
   }
 
+  /**
+   * @brief Scale the angle down by a bare factor.
+   * @throws std::runtime_error if the divisor is zero — an infinite angle is never the intent (#48).
+   */
   constexpr auto operator/(const double other) const -> Angle<Unit> {
     if (other == 0.0) {
       throw std::runtime_error { "Division by zero." };
     }
-    return { _value / other };
+    return Angle<Unit> { _value / other };
   }
 
   /**
@@ -190,9 +189,9 @@ struct Angle {
    */
   [[nodiscard]] constexpr auto normalize() const -> Angle<Unit> {
     if constexpr (Unit == AngleUnit::DEG) {
-      return { normalize_deg(_value) };
+      return Angle<Unit> { normalize_deg(_value) };
     } else {
-      return { normalize_rad(_value) };
+      return Angle<Unit> { normalize_rad(_value) };
     }
   }
 
@@ -221,7 +220,7 @@ struct Angle {
 namespace literals {
 
 inline auto operator""_deg(const long double value) -> Angle<AngleUnit::DEG> {
-  return { static_cast<double>(value) };
+  return Angle<AngleUnit::DEG> { static_cast<double>(value) };
 }
 
 inline auto operator""_arcmin(const long double value) -> Angle<AngleUnit::DEG> {
@@ -233,7 +232,7 @@ inline auto operator""_arcsec(const long double value) -> Angle<AngleUnit::DEG> 
 }
 
 inline auto operator""_rad(const long double value) -> Angle<AngleUnit::RAD> {
-  return { static_cast<double>(value) };
+  return Angle<AngleUnit::RAD> { static_cast<double>(value) };
 }
 
 }  // namespace literals
@@ -263,12 +262,12 @@ constexpr auto km_to_au(const double km) -> double {
 /** @brief Represents a distance. */
 template <DistanceUnit Unit>
 struct Distance {
-  constexpr Distance(const double value) : _value { value } {} // NOLINT(google-explicit-constructor)
+  constexpr explicit Distance(const double value) : _value { value } {}
 
-  /** @brief Allow implicit conversion to the other unit. */
+  /** @brief Convert to the other unit. Explicit for the same reason as `Angle`'s — see there. */
   template <DistanceUnit As>
-  constexpr operator Distance<As>() const { // NOLINT(google-explicit-constructor)
-    return { as<As>() };
+  constexpr explicit operator Distance<As>() const {
+    return Distance<As> { as<As>() };
   }
 
   template <DistanceUnit As>

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -217,6 +217,16 @@ struct Angle {
   double _value;
 };
 
+/**
+ * @brief The spelling used everywhere outside this header (#53).
+ * @note `Angle<DEG>` needs both names in scope, which outside `astro::toolbox` only a
+ *       namespace-scope `using` can arrange — and headers may not have one (#51). These
+ *       aliases keep the unit in the type name without asking the reader's namespace for
+ *       anything: `toolbox::AngleDeg`.
+ */
+using AngleDeg = Angle<AngleUnit::DEG>;
+using AngleRad = Angle<AngleUnit::RAD>;
+
 #pragma endregion
 
 
@@ -224,20 +234,20 @@ struct Angle {
 
 namespace literals {
 
-constexpr auto operator""_deg(const long double value) -> Angle<AngleUnit::DEG> {
-  return Angle<AngleUnit::DEG> { static_cast<double>(value) };
+constexpr auto operator""_deg(const long double value) -> AngleDeg {
+  return AngleDeg { static_cast<double>(value) };
 }
 
-constexpr auto operator""_arcmin(const long double value) -> Angle<AngleUnit::DEG> {
-  return Angle<AngleUnit::DEG>::from_arcmin(static_cast<double>(value));
+constexpr auto operator""_arcmin(const long double value) -> AngleDeg {
+  return AngleDeg::from_arcmin(static_cast<double>(value));
 }
 
-constexpr auto operator""_arcsec(const long double value) -> Angle<AngleUnit::DEG> {
-  return Angle<AngleUnit::DEG>::from_arcsec(static_cast<double>(value));
+constexpr auto operator""_arcsec(const long double value) -> AngleDeg {
+  return AngleDeg::from_arcsec(static_cast<double>(value));
 }
 
-constexpr auto operator""_rad(const long double value) -> Angle<AngleUnit::RAD> {
-  return Angle<AngleUnit::RAD> { static_cast<double>(value) };
+constexpr auto operator""_rad(const long double value) -> AngleRad {
+  return AngleRad { static_cast<double>(value) };
 }
 
 }  // namespace literals
@@ -300,14 +310,18 @@ struct Distance {
   double _value; // Private for the same reason as `Angle::_value` — see the note there.
 };
 
+/** @brief The spelling used outside this header, for the same reason as `AngleDeg` (#53). */
+using DistanceAu = Distance<DistanceUnit::AU>;
+using DistanceKm = Distance<DistanceUnit::KM>;
+
 
 /**
  * @brief Represents a position in a spherical coordinate system.
  */
 struct SphericalCoordinate {
-  Angle<AngleUnit::DEG>      λ; // Longitude
-  Angle<AngleUnit::DEG>      β; // Latitude
-  Distance<DistanceUnit::AU> r; // Radius/Distance
+  AngleDeg      λ; // Longitude
+  AngleDeg      β; // Latitude
+  DistanceAu r; // Radius/Distance
 };
 
 #pragma endregion

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -121,12 +121,17 @@ template <AngleUnit Unit>
 struct Angle {
   constexpr explicit Angle(const double value) : _value { value } {}
 
-  constexpr static auto from_arcmin(const double value) -> Angle<AngleUnit::DEG> {
-    return Angle<AngleUnit::DEG> { arcmin_to_deg(value) };
+  /**
+   * @brief Build an angle from a count of arcminutes, carried in this angle's own unit.
+   * @note Arcminutes subdivide the degree, so the count lands in DEG and converts from there.
+   */
+  constexpr static auto from_arcmin(const double value) -> Angle<Unit> {
+    return Angle<Unit> { Angle<AngleUnit::DEG> { arcmin_to_deg(value) } };
   }
 
-  constexpr static auto from_arcsec(const double value) -> Angle<AngleUnit::DEG> {
-    return Angle<AngleUnit::DEG> { arcsec_to_deg(value) };
+  /** @brief Build an angle from a count of arcseconds, carried in this angle's own unit. */
+  constexpr static auto from_arcsec(const double value) -> Angle<Unit> {
+    return Angle<Unit> { Angle<AngleUnit::DEG> { arcsec_to_deg(value) } };
   }
 
   /**
@@ -219,19 +224,19 @@ struct Angle {
 
 namespace literals {
 
-inline auto operator""_deg(const long double value) -> Angle<AngleUnit::DEG> {
+constexpr auto operator""_deg(const long double value) -> Angle<AngleUnit::DEG> {
   return Angle<AngleUnit::DEG> { static_cast<double>(value) };
 }
 
-inline auto operator""_arcmin(const long double value) -> Angle<AngleUnit::DEG> {
+constexpr auto operator""_arcmin(const long double value) -> Angle<AngleUnit::DEG> {
   return Angle<AngleUnit::DEG>::from_arcmin(static_cast<double>(value));
 }
 
-inline auto operator""_arcsec(const long double value) -> Angle<AngleUnit::DEG> {
+constexpr auto operator""_arcsec(const long double value) -> Angle<AngleUnit::DEG> {
   return Angle<AngleUnit::DEG>::from_arcsec(static_cast<double>(value));
 }
 
-inline auto operator""_rad(const long double value) -> Angle<AngleUnit::RAD> {
+constexpr auto operator""_rad(const long double value) -> Angle<AngleUnit::RAD> {
   return Angle<AngleUnit::RAD> { static_cast<double>(value) };
 }
 

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -119,8 +119,6 @@ enum class AngleUnit : uint8_t { RAD, DEG };
  */
 template <AngleUnit Unit>
 struct Angle {
-  const double _value;
-
   constexpr Angle(const double value) : _value { value } {} // NOLINT(google-explicit-constructor)
 
   constexpr static auto from_arcmin(const double value) -> Angle<AngleUnit::DEG> {
@@ -207,6 +205,12 @@ struct Angle {
   [[nodiscard]] constexpr auto rad() const -> double {
     return as<AngleUnit::RAD>();
   }
+
+ private:
+  // Private, not const: `const` would also make the type unassignable, which breaks
+  // `std::optional<Angle>` and every sort/erase over aggregates holding one.
+  // Immutability is carried by the interface instead — every operator returns a new value.
+  double _value;
 };
 
 #pragma endregion
@@ -259,8 +263,6 @@ constexpr auto km_to_au(const double km) -> double {
 /** @brief Represents a distance. */
 template <DistanceUnit Unit>
 struct Distance {
-  const double _value;
-
   constexpr Distance(const double value) : _value { value } {} // NOLINT(google-explicit-constructor)
 
   /** @brief Allow implicit conversion to the other unit. */
@@ -289,6 +291,9 @@ struct Distance {
   [[nodiscard]] constexpr auto km() const -> double {
     return as<DistanceUnit::KM>();
   }
+
+ private:
+  double _value; // Private for the same reason as `Angle::_value` — see the note there.
 };
 
 

--- a/src/shared_lib/lib_astro.cpp
+++ b/src/shared_lib/lib_astro.cpp
@@ -363,7 +363,7 @@ auto apparent_solar_time(
   try {
     const auto ymd = util::to_ymd(y, m, d);
     const auto utc_dt = calendar::Datetime(ymd, fraction);
-    const auto lon = astro::toolbox::Angle<astro::toolbox::AngleUnit::DEG> { longitude };
+    const auto lon = astro::toolbox::AngleDeg { longitude };
     const auto apparent_dt = astro::solar_time::apparent(utc_dt, lon);
 
     const auto [ay, am, ad] = util::from_ymd(apparent_dt.ymd);

--- a/src/test/astro/coord_transform_test.cpp
+++ b/src/test/astro/coord_transform_test.cpp
@@ -53,13 +53,13 @@ TEST(CoordTransform, EclipticToEquatorialPoles) {
   // The ecliptic north pole maps to δ = 90° − ε, α = 270°; the south pole to δ = −(90° − ε), α = 90°.
   const double ε = 23.4392911;
 
-  const auto north = ecliptic_to_equatorial(0.0_deg, 90.0_deg, Angle<DEG> { ε });
+  const auto north = ecliptic_to_equatorial(0.0_deg, 90.0_deg, AngleDeg { ε });
   ASSERT_TRUE(std::isfinite(north.α.deg()));
   ASSERT_TRUE(std::isfinite(north.δ.deg()));
   ASSERT_NEAR(north.δ.deg(), 90.0 - ε, 1e-9);
   ASSERT_NEAR(north.α.deg(), 270.0, 1e-9);
 
-  const auto south = ecliptic_to_equatorial(0.0_deg, -90.0_deg, Angle<DEG> { ε });
+  const auto south = ecliptic_to_equatorial(0.0_deg, -90.0_deg, AngleDeg { ε });
   ASSERT_TRUE(std::isfinite(south.α.deg()));
   ASSERT_TRUE(std::isfinite(south.δ.deg()));
   ASSERT_NEAR(south.δ.deg(), -(90.0 - ε), 1e-9);
@@ -75,13 +75,13 @@ TEST(CoordTransform, EclipticToEquatorialAsinDomain) {
   for (auto i = 0; i < 10000; ++i) {
     const double ε = 22.0 + 3.0 * i / 9999.0;
 
-    const auto north = ecliptic_to_equatorial(90.0_deg, Angle<DEG> { 90.0 - ε }, Angle<DEG> { ε });
+    const auto north = ecliptic_to_equatorial(90.0_deg, AngleDeg { 90.0 - ε }, AngleDeg { ε });
     ASSERT_TRUE(std::isfinite(north.α.deg()));
     ASSERT_TRUE(std::isfinite(north.δ.deg()));
     ASSERT_NEAR(north.δ.deg(), 90.0, 1e-5);
     ASSERT_LE(north.δ.deg(), 90.0);
 
-    const auto south = ecliptic_to_equatorial(270.0_deg, Angle<DEG> { ε - 90.0 }, Angle<DEG> { ε });
+    const auto south = ecliptic_to_equatorial(270.0_deg, AngleDeg { ε - 90.0 }, AngleDeg { ε });
     ASSERT_TRUE(std::isfinite(south.α.deg()));
     ASSERT_TRUE(std::isfinite(south.δ.deg()));
     ASSERT_NEAR(south.δ.deg(), -90.0, 1e-5);
@@ -95,12 +95,12 @@ TEST(CoordTransform, EclipticEquatorialRoundTrip) {
     const double β = util::random(-89.0, 89.0);
     const double ε = util::random(22.0, 25.0);
 
-    const auto [α, δ] = ecliptic_to_equatorial(Angle<DEG> { λ }, Angle<DEG> { β }, Angle<DEG> { ε });
+    const auto [α, δ] = ecliptic_to_equatorial(AngleDeg { λ }, AngleDeg { β }, AngleDeg { ε });
 
     // Invert with Meeus (13.1)-(13.2), multiplied through by cos δ so nothing diverges at the poles.
     const double α_rad = α.rad();
     const double δ_rad = δ.rad();
-    const double ε_rad = Angle<DEG> { ε }.rad();
+    const double ε_rad = AngleDeg { ε }.rad();
 
     const double sin_α = std::sin(α_rad);
     const double cos_α = std::cos(α_rad);
@@ -148,11 +148,11 @@ TEST(CoordTransform, EquatorialToHorizontalHorizon) {
   const double H0 = rad_to_deg(std::acos(-std::tan(deg_to_rad(φ)) * std::tan(deg_to_rad(δ))));
 
   // Rising: H = −H0 in the morning; setting: H = +H0 in the evening. Both must yield h ≈ 0.
-  const auto rise = equatorial_to_horizontal(Angle<DEG> { -H0 }, Angle<DEG> { δ }, Angle<DEG> { φ });
+  const auto rise = equatorial_to_horizontal(AngleDeg { -H0 }, AngleDeg { δ }, AngleDeg { φ });
   ASSERT_NEAR(rise.h.deg(), 0.0, 1e-9);
   ASSERT_TRUE(std::isfinite(rise.A.deg()));
 
-  const auto set = equatorial_to_horizontal(Angle<DEG> { H0 }, Angle<DEG> { δ }, Angle<DEG> { φ });
+  const auto set = equatorial_to_horizontal(AngleDeg { H0 }, AngleDeg { δ }, AngleDeg { φ });
   ASSERT_NEAR(set.h.deg(), 0.0, 1e-9);
   ASSERT_TRUE(std::isfinite(set.A.deg()));
 }
@@ -167,13 +167,13 @@ TEST(CoordTransform, EquatorialToHorizontalAsinDomain) {
   for (auto i = 0; i < 10000; ++i) {
     const double φ = -90.0 + 180.0 * i / 9999.0;
 
-    const auto zenith = equatorial_to_horizontal(0.0_deg, Angle<DEG> { φ }, Angle<DEG> { φ });
+    const auto zenith = equatorial_to_horizontal(0.0_deg, AngleDeg { φ }, AngleDeg { φ });
     ASSERT_TRUE(std::isfinite(zenith.A.deg()));
     ASSERT_TRUE(std::isfinite(zenith.h.deg()));
     ASSERT_NEAR(zenith.h.deg(), 90.0, 1e-5);
     ASSERT_LE(zenith.h.deg(), 90.0);
 
-    const auto nadir = equatorial_to_horizontal(180.0_deg, Angle<DEG> { -φ }, Angle<DEG> { φ });
+    const auto nadir = equatorial_to_horizontal(180.0_deg, AngleDeg { -φ }, AngleDeg { φ });
     ASSERT_TRUE(std::isfinite(nadir.A.deg()));
     ASSERT_TRUE(std::isfinite(nadir.h.deg()));
     ASSERT_NEAR(nadir.h.deg(), -90.0, 1e-5);
@@ -187,13 +187,13 @@ TEST(CoordTransform, HorizontalRoundTrip) {
     const double δ = util::random(-80.0, 80.0);
     const double φ = util::random(-80.0, 80.0);
 
-    const auto [A, h] = equatorial_to_horizontal(Angle<DEG> { H }, Angle<DEG> { δ }, Angle<DEG> { φ });
+    const auto [A, h] = equatorial_to_horizontal(AngleDeg { H }, AngleDeg { δ }, AngleDeg { φ });
 
     // Invert (azimuth from the south): sin δ = sin φ sin h − cos φ cos h cos A;
     // then recover H from its sine and cosine, dropping the common positive factor cos δ in atan2.
     const double A_rad = A.rad();
     const double h_rad = h.rad();
-    const double φ_rad = Angle<DEG> { φ }.rad();
+    const double φ_rad = AngleDeg { φ }.rad();
 
     const double sin_A = std::sin(A_rad);
     const double cos_A = std::cos(A_rad);
@@ -224,7 +224,7 @@ TEST(CoordTransform, EquatorialToHorizontalMeeus13b) {
   const double δ = -(6.0 + 43.0 / 60.0 + 11.61 / 3600.0);
   const double φ = 38.0 + 55.0 / 60.0 + 17.0 / 3600.0;
 
-  const auto [A, h] = equatorial_to_horizontal(Angle<DEG> { H }, Angle<DEG> { δ }, Angle<DEG> { φ });
+  const auto [A, h] = equatorial_to_horizontal(AngleDeg { H }, AngleDeg { δ }, AngleDeg { φ });
 
   // Meeus prints A = +68°.0337, h = +15°.1249; his intermediate values are rounded, hence the looser tolerance.
   ASSERT_NEAR(A.deg(), 68.0337, 1e-4);
@@ -299,7 +299,7 @@ TEST(CoordTransform, EclipticToEquatorialPymeeus) {
   };
 
   for (const auto& [λ, β, ε, expected_α, expected_δ] : dataset) {
-    const auto [α, δ] = ecliptic_to_equatorial(Angle<DEG> { λ }, Angle<DEG> { β }, Angle<DEG> { ε });
+    const auto [α, δ] = ecliptic_to_equatorial(AngleDeg { λ }, AngleDeg { β }, AngleDeg { ε });
     ASSERT_NEAR(α.deg(), expected_α, 1e-9);
     ASSERT_NEAR(δ.deg(), expected_δ, 1e-9);
   }
@@ -373,7 +373,7 @@ TEST(CoordTransform, EquatorialToHorizontalPymeeus) {
   };
 
   for (const auto& [H, δ, φ, expected_A, expected_h] : dataset) {
-    const auto [A, h] = equatorial_to_horizontal(Angle<DEG> { H }, Angle<DEG> { δ }, Angle<DEG> { φ });
+    const auto [A, h] = equatorial_to_horizontal(AngleDeg { H }, AngleDeg { δ }, AngleDeg { φ });
     ASSERT_NEAR(A.deg(), expected_A, 1e-9);
     ASSERT_NEAR(h.deg(), expected_h, 1e-9);
   }

--- a/src/test/astro/earth_test.cpp
+++ b/src/test/astro/earth_test.cpp
@@ -32,6 +32,11 @@
 namespace astro::earth::test {
 
 using namespace astro::earth;
+using astro::toolbox::AngleDeg;
+using astro::toolbox::AngleRad;
+using astro::toolbox::DistanceAu;
+using astro::toolbox::AngleUnit::DEG;
+using astro::toolbox::AngleUnit::RAD;
 
 TEST(Earth, Vsop87dEvaluate) {
   using namespace heliocentric_coord;
@@ -584,7 +589,7 @@ TEST(Earth, AberrationGolden) {
   };
 
   for (const auto& [jde, r, aberration] : dataset) {
-    const auto ab = aberration::compute(jde, Distance<AU> { r });
+    const auto ab = aberration::compute(jde, DistanceAu { r });
     ASSERT_NEAR(ab.as<DEG>(), aberration / 3600.0, 1e-6 / 3600.0);
   }
 }
@@ -593,7 +598,7 @@ TEST(Earth, AberrationMeeus25b) {
   // Meeus Example 25.b (p. 169): JDE 2448908.5, R = 0.99760775, aberration correction -20.539"
   // by (25.10) — signed; compute returns the magnitude to subtract. Our (25.11) differs from
   // (25.10) by up to 0.01" per Meeus; the measured gap here is 0.008".
-  const auto ab = aberration::compute(2448908.5, Distance<AU> { 0.99760775 });
+  const auto ab = aberration::compute(2448908.5, DistanceAu { 0.99760775 });
   ASSERT_NEAR(ab.as<DEG>(), 20.539 / 3600.0, 0.01 / 3600.0);
 }
 

--- a/src/test/astro/earth_test.cpp
+++ b/src/test/astro/earth_test.cpp
@@ -32,8 +32,6 @@
 namespace astro::earth::test {
 
 using namespace astro::earth;
-using astro::toolbox::AngleDeg;
-using astro::toolbox::AngleRad;
 using astro::toolbox::DistanceAu;
 using astro::toolbox::AngleUnit::DEG;
 using astro::toolbox::AngleUnit::RAD;

--- a/src/test/astro/elp2000_82b_test.cpp
+++ b/src/test/astro/elp2000_82b_test.cpp
@@ -32,7 +32,6 @@ namespace astro::elp2000_82b::test {
 
 using namespace astro::elp2000_82b::coeff;
 using namespace astro::elp2000_82b;
-using astro::toolbox::AngleDeg;
 using astro::toolbox::AngleUnit::DEG;
 
 TEST(Elp2000, Evaluate) {

--- a/src/test/astro/elp2000_82b_test.cpp
+++ b/src/test/astro/elp2000_82b_test.cpp
@@ -32,6 +32,8 @@ namespace astro::elp2000_82b::test {
 
 using namespace astro::elp2000_82b::coeff;
 using namespace astro::elp2000_82b;
+using astro::toolbox::AngleDeg;
+using astro::toolbox::AngleUnit::DEG;
 
 TEST(Elp2000, Evaluate) {
   // Characterization data self-generated from this code (determinism check only, see #65's root-cause

--- a/src/test/astro/moon_test.cpp
+++ b/src/test/astro/moon_test.cpp
@@ -98,7 +98,7 @@ TEST(Moon, CoordAndPpi) {
     ASSERT_NEAR(β.deg(),    std::get<1>(expected), 1e-11);
     ASSERT_NEAR(r.km(),     std::get<2>(expected), 1e-7);
 
-    const auto ppi = equatorial_horizontal_parallax(r);
+    const auto ppi = equatorial_horizontal_parallax(Distance<KM> { r });
     ASSERT_NEAR(ppi.rad(),  std::get<3>(expected), 1e-14);
   }
 }

--- a/src/test/astro/moon_test.cpp
+++ b/src/test/astro/moon_test.cpp
@@ -32,6 +32,8 @@
 namespace astro::moon::test {
 
 using namespace astro::moon::geocentric_coord;
+using astro::elp2000_82b::evaluate;
+using astro::toolbox::DistanceKm;
 
 
 TEST(Moon, CoordAndPpi) {
@@ -98,7 +100,7 @@ TEST(Moon, CoordAndPpi) {
     ASSERT_NEAR(β.deg(),    std::get<1>(expected), 1e-11);
     ASSERT_NEAR(r.km(),     std::get<2>(expected), 1e-7);
 
-    const auto ppi = equatorial_horizontal_parallax(Distance<KM> { r });
+    const auto ppi = equatorial_horizontal_parallax(DistanceKm { r });
     ASSERT_NEAR(ppi.rad(),  std::get<3>(expected), 1e-14);
   }
 }

--- a/src/test/astro/sidereal_time_test.cpp
+++ b/src/test/astro/sidereal_time_test.cpp
@@ -121,7 +121,7 @@ TEST(SiderealTime, LocalApparentMeeus13b) {
   constexpr double α_hours = 23.0 + 9.0 / 60.0 + 16.641 / 3600.0;
   const double expected = normalize_deg(64.352133 + α_hours * 15.0); // std::remainder is not constexpr until C++26.
 
-  ASSERT_NEAR(local_apparent(jd_ut1, jde_tt, Angle<DEG> { lon }).deg(), expected, 2e-4);
+  ASSERT_NEAR(local_apparent(jd_ut1, jde_tt, AngleDeg { lon }).deg(), expected, 2e-4);
 }
 
 TEST(SiderealTime, LocalApparentLongitude) {
@@ -132,7 +132,7 @@ TEST(SiderealTime, LocalApparentLongitude) {
     const double lon = util::random(-180.0, 180.0); // east-positive sites are negative here
 
     const double gast = greenwich_apparent(jd_ut1, jde_tt).deg();
-    const double last = local_apparent(jd_ut1, jde_tt, Angle<DEG> { lon }).deg();
+    const double last = local_apparent(jd_ut1, jde_tt, AngleDeg { lon }).deg();
 
     ASSERT_NEAR(ang_diff(last, gast - lon), 0.0, 1e-12);
   }
@@ -378,7 +378,7 @@ TEST(SiderealTime, LocalApparentUsno) {
   };
 
   for (const auto& [jd_ut1, jde_tt, lon_west, expected_last] : dataset) {
-    ASSERT_NEAR(ang_diff(local_apparent(jd_ut1, jde_tt, Angle<DEG> { lon_west }).deg(), expected_last), 0.0, TOL_LAST);
+    ASSERT_NEAR(ang_diff(local_apparent(jd_ut1, jde_tt, AngleDeg { lon_west }).deg(), expected_last), 0.0, TOL_LAST);
   }
 }
 

--- a/src/test/astro/solar_time_test.cpp
+++ b/src/test/astro/solar_time_test.cpp
@@ -39,7 +39,7 @@
 
 namespace astro::solar_time::test {
 
-using astro::toolbox::Angle;
+using astro::toolbox::AngleDeg;
 using astro::toolbox::AngleUnit::DEG;
 
 namespace {
@@ -246,10 +246,10 @@ struct TransitCase {
 };
 
 const std::array<TransitCase, 4> TRANSIT_CASES {{
-  { 2024,  2, 11, { .latitude = Angle<DEG> { 39.9042 }, .longitude = Angle<DEG> { 116.4074 } } },
-  { 2024, 11,  3, { .latitude = Angle<DEG> { 40.7128 }, .longitude = Angle<DEG> { -74.0060 } } },
-  { 1992, 10, 13, { .latitude = Angle<DEG> { 51.4769 }, .longitude = Angle<DEG> {   0.0    } } },
-  { 2024,  6, 21, { .latitude = Angle<DEG> { 69.65   }, .longitude = Angle<DEG> {  18.96   } } },
+  { 2024,  2, 11, { .latitude = AngleDeg { 39.9042 }, .longitude = AngleDeg { 116.4074 } } },
+  { 2024, 11,  3, { .latitude = AngleDeg { 40.7128 }, .longitude = AngleDeg { -74.0060 } } },
+  { 1992, 10, 13, { .latitude = AngleDeg { 51.4769 }, .longitude = AngleDeg {   0.0    } } },
+  { 2024,  6, 21, { .latitude = AngleDeg { 69.65   }, .longitude = AngleDeg {  18.96   } } },
 }};
 
 } // namespace
@@ -336,7 +336,7 @@ TEST(SolarTime, ApparentSolarTimeGolden) {
     const auto ymd = util::to_ymd(row.year, row.month, row.day);
     const auto apparent_dt = apparent(
       calendar::Datetime { ymd, row.utc_frac },
-      Angle<DEG> { row.lon_deg }
+      AngleDeg { row.lon_deg }
     );
 
     const auto day_diff = (std::chrono::sys_days { apparent_dt.ymd } - std::chrono::sys_days { ymd }).count();
@@ -347,11 +347,11 @@ TEST(SolarTime, ApparentSolarTimeGolden) {
 
 TEST(SolarTime, ApparentRejectsBadLongitude) {
   const auto utc = calendar::Datetime { util::to_ymd(2024, 6, 1), 0.5 };
-  ASSERT_THROW({ apparent(utc, Angle<DEG> { 180.5 }); },  std::invalid_argument);
-  ASSERT_THROW({ apparent(utc, Angle<DEG> { -181.0 }); }, std::invalid_argument);
-  ASSERT_THROW({ apparent(utc, Angle<DEG> { std::numeric_limits<double>::quiet_NaN() }); }, std::invalid_argument);
-  ASSERT_NO_THROW({ apparent(utc, Angle<DEG> { 180.0 }); });
-  ASSERT_NO_THROW({ apparent(utc, Angle<DEG> { -180.0 }); });
+  ASSERT_THROW({ apparent(utc, AngleDeg { 180.5 }); },  std::invalid_argument);
+  ASSERT_THROW({ apparent(utc, AngleDeg { -181.0 }); }, std::invalid_argument);
+  ASSERT_THROW({ apparent(utc, AngleDeg { std::numeric_limits<double>::quiet_NaN() }); }, std::invalid_argument);
+  ASSERT_NO_THROW({ apparent(utc, AngleDeg { 180.0 }); });
+  ASSERT_NO_THROW({ apparent(utc, AngleDeg { -180.0 }); });
 }
 
 } // namespace astro::solar_time::test

--- a/src/test/astro/solar_time_test.cpp
+++ b/src/test/astro/solar_time_test.cpp
@@ -40,7 +40,6 @@
 namespace astro::solar_time::test {
 
 using astro::toolbox::AngleDeg;
-using astro::toolbox::AngleUnit::DEG;
 
 namespace {
 

--- a/src/test/astro/sun_test.cpp
+++ b/src/test/astro/sun_test.cpp
@@ -33,7 +33,6 @@ using namespace std::literals;
 
 using namespace astro::sun::geocentric_coord;
 using namespace astro::sun::geocentric_coord::math;
-using astro::toolbox::AngleDeg;
 using astro::toolbox::AngleUnit::DEG;
 
 TEST(Sun, GeocentricPosition) {

--- a/src/test/astro/sun_test.cpp
+++ b/src/test/astro/sun_test.cpp
@@ -33,6 +33,8 @@ using namespace std::literals;
 
 using namespace astro::sun::geocentric_coord;
 using namespace astro::sun::geocentric_coord::math;
+using astro::toolbox::AngleDeg;
+using astro::toolbox::AngleUnit::DEG;
 
 TEST(Sun, GeocentricPosition) {
   // Provenance (#68): self-generated characterization data, introduced 2024-07 ("Enhanced

--- a/src/test/astro/sunrise_sunset_golden_test.cpp
+++ b/src/test/astro/sunrise_sunset_golden_test.cpp
@@ -55,7 +55,7 @@
 namespace astro::sunrise_sunset::test {
 
 using namespace astro::sunrise_sunset;
-using astro::toolbox::Angle;
+using astro::toolbox::AngleDeg;
 using astro::toolbox::AngleUnit::DEG;
 
 namespace {
@@ -63,7 +63,7 @@ namespace {
 constexpr double TOL_MIN = 2.0;
 
 constexpr auto loc(const double lat_deg, const double lon_deg) -> GeoLocation {
-  return { .latitude = Angle<DEG> { lat_deg }, .longitude = Angle<DEG> { lon_deg } };
+  return { .latitude = AngleDeg { lat_deg }, .longitude = AngleDeg { lon_deg } };
 }
 
 /** @brief Parse "HH:MM" / "HH:MM:SS" into minutes-of-day; blank cell → `nullopt`. */

--- a/src/test/astro/sunrise_sunset_golden_test.cpp
+++ b/src/test/astro/sunrise_sunset_golden_test.cpp
@@ -56,7 +56,6 @@ namespace astro::sunrise_sunset::test {
 
 using namespace astro::sunrise_sunset;
 using astro::toolbox::AngleDeg;
-using astro::toolbox::AngleUnit::DEG;
 
 namespace {
 

--- a/src/test/astro/sunrise_sunset_test.cpp
+++ b/src/test/astro/sunrise_sunset_test.cpp
@@ -44,7 +44,6 @@ namespace astro::sunrise_sunset::test {
 
 using namespace astro::sunrise_sunset;
 using astro::toolbox::AngleDeg;
-using astro::toolbox::AngleUnit::DEG;
 
 namespace {
 

--- a/src/test/astro/sunrise_sunset_test.cpp
+++ b/src/test/astro/sunrise_sunset_test.cpp
@@ -43,13 +43,13 @@
 namespace astro::sunrise_sunset::test {
 
 using namespace astro::sunrise_sunset;
-using astro::toolbox::Angle;
+using astro::toolbox::AngleDeg;
 using astro::toolbox::AngleUnit::DEG;
 
 namespace {
 
 constexpr auto loc(const double lat_deg, const double lon_deg) -> GeoLocation {
-  return { .latitude = Angle<DEG> { lat_deg }, .longitude = Angle<DEG> { lon_deg } };
+  return { .latitude = AngleDeg { lat_deg }, .longitude = AngleDeg { lon_deg } };
 }
 
 // East-positive longitudes, per `GeoLocation`'s convention.
@@ -93,14 +93,14 @@ TEST(SunriseSunset, HourAngleAtAltitudeMatchesHorizontalAltitude) {
   for (const double δ : declinations) {
     for (const double φ : latitudes) {
       for (const double h0 : altitudes) {
-        const auto H0 = hour_angle_at_altitude(Angle<DEG> { δ }, Angle<DEG> { φ }, Angle<DEG> { h0 });
+        const auto H0 = hour_angle_at_altitude(AngleDeg { δ }, AngleDeg { φ }, AngleDeg { h0 });
         if (not H0.has_value()) {
           continue; // Polar cases are covered by their own test.
         }
 
         for (const double sign : { 1.0, -1.0 }) {
           const auto horizontal = astro::coords::equatorial_to_horizontal(
-            req(H0) * sign, Angle<DEG> { δ }, Angle<DEG> { φ }
+            req(H0) * sign, AngleDeg { δ }, AngleDeg { φ }
           );
           ASSERT_NEAR(horizontal.h.deg(), h0, 1e-9)
             << "δ=" << δ << " φ=" << φ << " h0=" << h0 << " sign=" << sign;
@@ -111,19 +111,19 @@ TEST(SunriseSunset, HourAngleAtAltitudeMatchesHorizontalAltitude) {
 }
 
 TEST(SunriseSunset, HourAngleAtAltitudePolarAndDegenerateCases) {
-  const Angle<DEG> h0_standard { -0.8333 };
+  const AngleDeg h0_standard { -0.8333 };
 
   // Midnight sun at 80°N in northern summer: the Sun's minimum altitude is ~+13.4°, far above h₀.
-  ASSERT_FALSE(hour_angle_at_altitude(Angle<DEG> { 23.44 }, Angle<DEG> { 80.0 }, h0_standard).has_value());
+  ASSERT_FALSE(hour_angle_at_altitude(AngleDeg { 23.44 }, AngleDeg { 80.0 }, h0_standard).has_value());
 
   // Polar night at 80°N in northern winter: the maximum altitude is ~-13.4°, below h₀.
-  ASSERT_FALSE(hour_angle_at_altitude(Angle<DEG> { -23.44 }, Angle<DEG> { 80.0 }, h0_standard).has_value());
+  ASSERT_FALSE(hour_angle_at_altitude(AngleDeg { -23.44 }, AngleDeg { 80.0 }, h0_standard).has_value());
 
   // The equation degenerates at the geographic pole (cos φ = 0).
-  ASSERT_FALSE(hour_angle_at_altitude(Angle<DEG> { 10.0 }, Angle<DEG> { 90.0 }, h0_standard).has_value());
+  ASSERT_FALSE(hour_angle_at_altitude(AngleDeg { 10.0 }, AngleDeg { 90.0 }, h0_standard).has_value());
 
   // Equator, equinoctial Sun, geometric horizon: the diurnal arc is exactly a half turn.
-  const auto H0 = hour_angle_at_altitude(Angle<DEG> { 0.0 }, Angle<DEG> { 0.0 }, Angle<DEG> { 0.0 });
+  const auto H0 = hour_angle_at_altitude(AngleDeg { 0.0 }, AngleDeg { 0.0 }, AngleDeg { 0.0 });
   ASSERT_TRUE(H0.has_value());
   ASSERT_NEAR(req(H0).deg(), 90.0, 1e-9);
 }
@@ -204,7 +204,7 @@ TEST(SunriseSunset, TransitIsUpperCulmination) {
 }
 
 TEST(SunriseSunset, RiseSetAltitudeIsH0) {
-  const std::vector<std::tuple<std::chrono::year_month_day, GeoLocation, Angle<DEG>>> cases {
+  const std::vector<std::tuple<std::chrono::year_month_day, GeoLocation, AngleDeg>> cases {
     { util::to_ymd(2024, 3, 20), LONDON,  STANDARD_ALTITUDE },
     { util::to_ymd(2024, 6, 21), BEIJING, STANDARD_ALTITUDE },
     { util::to_ymd(2024, 12, 21), SYDNEY, STANDARD_ALTITUDE },
@@ -390,17 +390,17 @@ TEST(SunriseSunset, InvalidInputsThrow) {
 
   const double transit = transit_jde(ymd, EQUATOR);
   ASSERT_THROW((void) rise_set_jde(NAN_D, true, EQUATOR), std::invalid_argument);
-  ASSERT_THROW((void) rise_set_jde(transit, true, EQUATOR, Angle<DEG> { NAN_D }), std::invalid_argument);
-  ASSERT_THROW((void) rise_set_jde(transit, true, EQUATOR, Angle<DEG> { 100.0 }), std::invalid_argument);
+  ASSERT_THROW((void) rise_set_jde(transit, true, EQUATOR, AngleDeg { NAN_D }), std::invalid_argument);
+  ASSERT_THROW((void) rise_set_jde(transit, true, EQUATOR, AngleDeg { 100.0 }), std::invalid_argument);
   ASSERT_THROW((void) rise_set_jde(transit, true, loc(-91.0, 0.0)), std::invalid_argument);
 
   // hour_angle_at_altitude is public API too: out-of-domain angles alias through sin/cos into
   // physically meaningless H₀ values, so they are rejected rather than returned (per review).
-  ASSERT_THROW((void) hour_angle_at_altitude(Angle<DEG> { NAN_D }, Angle<DEG> { 0.0 }, Angle<DEG> { 0.0 }),
+  ASSERT_THROW((void) hour_angle_at_altitude(AngleDeg { NAN_D }, AngleDeg { 0.0 }, AngleDeg { 0.0 }),
                std::invalid_argument);
-  ASSERT_THROW((void) hour_angle_at_altitude(Angle<DEG> { 0.0 }, Angle<DEG> { 95.0 }, Angle<DEG> { 0.0 }),
+  ASSERT_THROW((void) hour_angle_at_altitude(AngleDeg { 0.0 }, AngleDeg { 95.0 }, AngleDeg { 0.0 }),
                std::invalid_argument);
-  ASSERT_THROW((void) hour_angle_at_altitude(Angle<DEG> { 0.0 }, Angle<DEG> { 0.0 }, Angle<DEG> { 100.0 }),
+  ASSERT_THROW((void) hour_angle_at_altitude(AngleDeg { 0.0 }, AngleDeg { 0.0 }, AngleDeg { 100.0 }),
                std::invalid_argument);
 }
 

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -122,7 +122,7 @@ TEST(AstroMath, Angle) {
   for (auto i = 0; i < 1000; ++i) {
     const double deg = util::random(-720.0, 720.0);
 
-    const Angle<DEG> angle { deg };
+    const AngleDeg angle { deg };
 
     ASSERT_FLOAT_EQ(angle.as<DEG>(), deg);
     ASSERT_FLOAT_EQ(angle.as<RAD>(), deg_to_rad(deg));
@@ -130,7 +130,7 @@ TEST(AstroMath, Angle) {
     ASSERT_FLOAT_EQ(angle.normalize().as<DEG>(), normalize_deg(deg));
     ASSERT_FLOAT_EQ(angle.normalize().as<RAD>(), normalize_rad(deg_to_rad(deg)));
 
-    const Angle<RAD> angle_rad { angle }; // Unit conversion — explicit since #48, direct-init spells it.
+    const AngleRad angle_rad { angle }; // Unit conversion — explicit since #48, direct-init spells it.
 
     ASSERT_FLOAT_EQ(angle_rad.as<DEG>(), deg);
     ASSERT_FLOAT_EQ(angle_rad.as<RAD>(), deg_to_rad(deg));
@@ -139,7 +139,7 @@ TEST(AstroMath, Angle) {
   for (auto i = 0; i < 1000; ++i) {
     const double rad = util::random(-2 * std::numbers::pi, 2 * std::numbers::pi);
 
-    const Angle<RAD> angle { rad };
+    const AngleRad angle { rad };
 
     ASSERT_FLOAT_EQ(angle.as<DEG>(), rad_to_deg(rad));
     ASSERT_FLOAT_EQ(angle.as<RAD>(), rad);
@@ -147,7 +147,7 @@ TEST(AstroMath, Angle) {
     ASSERT_FLOAT_EQ(angle.normalize().as<DEG>(), normalize_deg(rad_to_deg(rad)));
     ASSERT_FLOAT_EQ(angle.normalize().as<RAD>(), normalize_rad(rad));
 
-    const Angle<DEG> angle_deg { angle }; // Unit conversion — explicit since #48, direct-init spells it.
+    const AngleDeg angle_deg { angle }; // Unit conversion — explicit since #48, direct-init spells it.
 
     ASSERT_FLOAT_EQ(angle_deg.as<DEG>(), rad_to_deg(rad));
     ASSERT_FLOAT_EQ(angle_deg.as<RAD>(), rad);
@@ -160,19 +160,19 @@ TEST(AstroMath, AngleFromArcSubdivisions) {
 
   // Arcminutes and arcseconds subdivide the degree, but the angle they name is carried in
   // whichever unit it is asked of. The factory used to hand back DEG regardless of `Unit`,
-  // which no call site noticed because all nine of them asked a `Angle<DEG>` (#48).
-  static_assert(std::is_same_v<decltype(Angle<DEG>::from_arcmin(1.0)), Angle<DEG>>);
-  static_assert(std::is_same_v<decltype(Angle<RAD>::from_arcmin(1.0)), Angle<RAD>>);
-  static_assert(std::is_same_v<decltype(Angle<DEG>::from_arcsec(1.0)), Angle<DEG>>);
-  static_assert(std::is_same_v<decltype(Angle<RAD>::from_arcsec(1.0)), Angle<RAD>>);
+  // which no call site noticed because all nine of them asked an `AngleDeg` (#48).
+  static_assert(std::is_same_v<decltype(AngleDeg::from_arcmin(1.0)), AngleDeg>);
+  static_assert(std::is_same_v<decltype(AngleRad::from_arcmin(1.0)), AngleRad>);
+  static_assert(std::is_same_v<decltype(AngleDeg::from_arcsec(1.0)), AngleDeg>);
+  static_assert(std::is_same_v<decltype(AngleRad::from_arcsec(1.0)), AngleRad>);
 
-  ASSERT_DOUBLE_EQ(Angle<DEG>::from_arcmin(60.0).deg(), 1.0);
-  ASSERT_DOUBLE_EQ(Angle<RAD>::from_arcmin(60.0).deg(), 1.0);
-  ASSERT_DOUBLE_EQ(Angle<RAD>::from_arcmin(60.0).rad(), deg_to_rad(1.0));
+  ASSERT_DOUBLE_EQ(AngleDeg::from_arcmin(60.0).deg(), 1.0);
+  ASSERT_DOUBLE_EQ(AngleRad::from_arcmin(60.0).deg(), 1.0);
+  ASSERT_DOUBLE_EQ(AngleRad::from_arcmin(60.0).rad(), deg_to_rad(1.0));
 
-  ASSERT_DOUBLE_EQ(Angle<DEG>::from_arcsec(3600.0).deg(), 1.0);
-  ASSERT_DOUBLE_EQ(Angle<RAD>::from_arcsec(3600.0).deg(), 1.0);
-  ASSERT_DOUBLE_EQ(Angle<RAD>::from_arcsec(3600.0).rad(), deg_to_rad(1.0));
+  ASSERT_DOUBLE_EQ(AngleDeg::from_arcsec(3600.0).deg(), 1.0);
+  ASSERT_DOUBLE_EQ(AngleRad::from_arcsec(3600.0).deg(), 1.0);
+  ASSERT_DOUBLE_EQ(AngleRad::from_arcsec(3600.0).rad(), deg_to_rad(1.0));
 }
 
 TEST(AstroMath, literals) {

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -23,6 +23,9 @@
 
 #include <gtest/gtest.h>
 #include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
 #include "toolbox.hpp"
 #include "util.hpp"
 
@@ -151,6 +154,27 @@ TEST(AstroMath, Angle) {
   }
 }
 
+TEST(AstroMath, AngleFromArcSubdivisions) {
+  using AngleUnit::DEG;
+  using AngleUnit::RAD;
+
+  // Arcminutes and arcseconds subdivide the degree, but the angle they name is carried in
+  // whichever unit it is asked of. The factory used to hand back DEG regardless of `Unit`,
+  // which no call site noticed because all nine of them asked a `Angle<DEG>` (#48).
+  static_assert(std::is_same_v<decltype(Angle<DEG>::from_arcmin(1.0)), Angle<DEG>>);
+  static_assert(std::is_same_v<decltype(Angle<RAD>::from_arcmin(1.0)), Angle<RAD>>);
+  static_assert(std::is_same_v<decltype(Angle<DEG>::from_arcsec(1.0)), Angle<DEG>>);
+  static_assert(std::is_same_v<decltype(Angle<RAD>::from_arcsec(1.0)), Angle<RAD>>);
+
+  ASSERT_DOUBLE_EQ(Angle<DEG>::from_arcmin(60.0).deg(), 1.0);
+  ASSERT_DOUBLE_EQ(Angle<RAD>::from_arcmin(60.0).deg(), 1.0);
+  ASSERT_DOUBLE_EQ(Angle<RAD>::from_arcmin(60.0).rad(), deg_to_rad(1.0));
+
+  ASSERT_DOUBLE_EQ(Angle<DEG>::from_arcsec(3600.0).deg(), 1.0);
+  ASSERT_DOUBLE_EQ(Angle<RAD>::from_arcsec(3600.0).deg(), 1.0);
+  ASSERT_DOUBLE_EQ(Angle<RAD>::from_arcsec(3600.0).rad(), deg_to_rad(1.0));
+}
+
 TEST(AstroMath, literals) {
   using namespace literals;
   using AngleUnit::DEG;
@@ -200,6 +224,19 @@ TEST(AstroMath, AngleOperators) {
     ASSERT_EQ(angle.as<RAD>() * 2.0, (angle * 2.0).as<RAD>());
     ASSERT_EQ(angle.as<RAD>() / 2.0, (angle / 2.0).as<RAD>());
   }
+}
+
+TEST(AstroMath, AngleDivisionByZeroThrows) {
+  using namespace literals;
+
+  // The error contract of #48: a zero divisor is a caller mistake, not a state to hand on as ±inf.
+  // The branch had no coverage at all until now, so nothing held the contract in place.
+  const auto angle = 30.0_deg;
+  ASSERT_THROW((void) (angle / 0.0), std::runtime_error);
+  ASSERT_THROW((void) (angle / -0.0), std::runtime_error); // IEEE says -0.0 == 0.0; so does the guard.
+
+  // The guard tests for zero, not for smallness — a denormal divisor still divides.
+  ASSERT_NO_THROW((void) (angle / std::numeric_limits<double>::denorm_min()));
 }
 
 

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -127,7 +127,7 @@ TEST(AstroMath, Angle) {
     ASSERT_FLOAT_EQ(angle.normalize().as<DEG>(), normalize_deg(deg));
     ASSERT_FLOAT_EQ(angle.normalize().as<RAD>(), normalize_rad(deg_to_rad(deg)));
 
-    const Angle<RAD> angle_rad { angle }; // Test implicit conversion.
+    const Angle<RAD> angle_rad { angle }; // Unit conversion — explicit since #48, direct-init spells it.
 
     ASSERT_FLOAT_EQ(angle_rad.as<DEG>(), deg);
     ASSERT_FLOAT_EQ(angle_rad.as<RAD>(), deg_to_rad(deg));
@@ -144,7 +144,7 @@ TEST(AstroMath, Angle) {
     ASSERT_FLOAT_EQ(angle.normalize().as<DEG>(), normalize_deg(rad_to_deg(rad)));
     ASSERT_FLOAT_EQ(angle.normalize().as<RAD>(), normalize_rad(rad));
 
-    const Angle<DEG> angle_deg { angle }; // Test implicit conversion.
+    const Angle<DEG> angle_deg { angle }; // Unit conversion — explicit since #48, direct-init spells it.
 
     ASSERT_FLOAT_EQ(angle_deg.as<DEG>(), rad_to_deg(rad));
     ASSERT_FLOAT_EQ(angle_deg.as<RAD>(), rad);
@@ -186,8 +186,6 @@ TEST(AstroMath, AngleOperators) {
   {
     const auto angle = 360.0_deg;
 
-    ASSERT_EQ(angle.as<DEG>(), (angle + 0.0).as<DEG>());
-    ASSERT_EQ(angle.as<DEG>(), (angle - 0.0).as<DEG>());
     ASSERT_EQ(angle.as<DEG>(), (angle + 0.0_deg).as<DEG>());
     ASSERT_EQ(angle.as<DEG>(), (angle - 0.0_deg).as<DEG>());
     ASSERT_EQ(angle.as<DEG>() * 2.0, (angle * 2.0).as<DEG>());
@@ -197,8 +195,6 @@ TEST(AstroMath, AngleOperators) {
   {
     const auto angle = 1.0_rad;
 
-    ASSERT_EQ(angle.as<RAD>(), (angle + 0.0).as<RAD>());
-    ASSERT_EQ(angle.as<RAD>(), (angle - 0.0).as<RAD>());
     ASSERT_EQ(angle.as<RAD>(), (angle + 0.0_rad).as<RAD>());
     ASSERT_EQ(angle.as<RAD>(), (angle - 0.0_rad).as<RAD>());
     ASSERT_EQ(angle.as<RAD>() * 2.0, (angle * 2.0).as<RAD>());

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -130,7 +130,7 @@ TEST(AstroMath, Angle) {
     ASSERT_FLOAT_EQ(angle.normalize().as<DEG>(), normalize_deg(deg));
     ASSERT_FLOAT_EQ(angle.normalize().as<RAD>(), normalize_rad(deg_to_rad(deg)));
 
-    const AngleRad angle_rad { angle }; // Unit conversion — explicit since #48, direct-init spells it.
+    const AngleRad angle_rad { angle };
 
     ASSERT_FLOAT_EQ(angle_rad.as<DEG>(), deg);
     ASSERT_FLOAT_EQ(angle_rad.as<RAD>(), deg_to_rad(deg));
@@ -147,7 +147,7 @@ TEST(AstroMath, Angle) {
     ASSERT_FLOAT_EQ(angle.normalize().as<DEG>(), normalize_deg(rad_to_deg(rad)));
     ASSERT_FLOAT_EQ(angle.normalize().as<RAD>(), normalize_rad(rad));
 
-    const AngleDeg angle_deg { angle }; // Unit conversion — explicit since #48, direct-init spells it.
+    const AngleDeg angle_deg { angle };
 
     ASSERT_FLOAT_EQ(angle_deg.as<DEG>(), rad_to_deg(rad));
     ASSERT_FLOAT_EQ(angle_deg.as<RAD>(), rad);
@@ -155,12 +155,8 @@ TEST(AstroMath, Angle) {
 }
 
 TEST(AstroMath, AngleFromArcSubdivisions) {
-  using AngleUnit::DEG;
-  using AngleUnit::RAD;
-
   // Arcminutes and arcseconds subdivide the degree, but the angle they name is carried in
-  // whichever unit it is asked of. The factory used to hand back DEG regardless of `Unit`,
-  // which no call site noticed because all nine of them asked an `AngleDeg` (#48).
+  // whichever unit it is asked of.
   static_assert(std::is_same_v<decltype(AngleDeg::from_arcmin(1.0)), AngleDeg>);
   static_assert(std::is_same_v<decltype(AngleRad::from_arcmin(1.0)), AngleRad>);
   static_assert(std::is_same_v<decltype(AngleDeg::from_arcsec(1.0)), AngleDeg>);
@@ -229,8 +225,7 @@ TEST(AstroMath, AngleOperators) {
 TEST(AstroMath, AngleDivisionByZeroThrows) {
   using namespace literals;
 
-  // The error contract of #48: a zero divisor is a caller mistake, not a state to hand on as ±inf.
-  // The branch had no coverage at all until now, so nothing held the contract in place.
+  // The contract (#48): a zero divisor is a caller mistake, not a state to hand on as ±inf.
   const auto angle = 30.0_deg;
   ASSERT_THROW((void) (angle / 0.0), std::runtime_error);
   ASSERT_THROW((void) (angle / -0.0), std::runtime_error); // IEEE says -0.0 == 0.0; so does the guard.


### PR DESCRIPTION
Closes #48
Closes #53

风格架构批 P3。改的是全库消费的核心值类型 `Angle<Unit>` / `Distance<Unit>` 的构造与转换语义,外加一次全库角度拼写统一。三条设计裁决(D-A/D-B/D-C)由作者 2026-08-02 拍板后开工。

## 内容

**#48 三条腿全清。**

1. **表示层**(`3c6ee8a`)—— `const double _value` 表达的不是不可变性,而是不可赋值性。不可变性本来就由接口承载(运算符全 const 且返回新值,没有 setter);`const` 成员额外做掉的是 regularity:`Angle`、`EquatorialCoord`、`GeoLocation`、`Context` 实测均不可拷贝赋值,而 `std::optional<AngleDeg>` 已在 `sunrise_sunset.hpp` 实例化,今天不炸只因为消费点从没写过一行赋值。成员没跟着转 public —— 公开且可变的数据成员就是一个没起名字的 setter。`_value` 外部访问实测 0 处。
2. **隐式转换收口**(`1f1f67a`)—— 构造与单位转换算子都加 `explicit`,并删掉 `Angle::operator±(const double)`(构造还隐式时它们是纯冗余,构造 explicit 之后就是裸 double 的后门;缩放的 `operator*` / `operator/` 保留,乘一个无量纲因子有量纲意义,加一个无量纲数没有)。
3. **错误契约**(`64a68a6`)—— `operator/` 的除零 throw 分支此前**零覆盖**,补测试钉住:`0.0` 抛、`-0.0` 抛(IEEE 下 `-0.0 == 0.0`,守卫也是)、denormal 不抛(守卫查的是零,不是小)。契约本身不动:宪章写明 public 输入校验一律 throw,`std::expected` 方向归 #97。

顺带修掉两件:`from_arcmin` / `from_arcsec` 的返回类型硬写 `Angle<AngleUnit::DEG>` 而不跟随 `Unit`(`AngleRad::from_arcsec(3600)` 拿到的是 `AngleDeg{1.0}`);四个字面量运算符补 `constexpr`(`Angle` 从构造到运算符全程 constexpr,只有自家 UDL 不是)。

**#53 一个名字**(`ff7b251`)。改前三种写法并存 —— 全限定 32 处、中间态 11 处、短拼 139 处,正是 issue 自己警告的 half-migrated。现在只有 `toolbox::AngleDeg` / `AngleRad` / `DistanceAu` / `DistanceKm`,别名立在类型自己家,与 `toolbox::SphericalCoordinate` 一个写法。`coord_transform.hpp` 的字段声明从 53 字符降到 17。

**#51 astro 侧清空**(同一提交)。earth / sun / moon / elp2000_82b 四个头的 26 条 namespace-scope using 全删。这两件必须同批:短拼 `Angle<DEG>` 的合法性来源正是这些 using —— 它要 `Angle` 和 `DEG` 同时在作用域,而消费者都在兄弟命名空间,卡住的又恰恰是**声明位置**(`Context` 的 8 个成员、`Fk5Correction`、一堆函数签名),那里在函数体外,函数体内 using 够不着。**保短拼与删 #51 只能二选一。**

**另外两件**(`45ca910`):#49 关闭时裁定「保留孪生重复、改用互指注释,搭最近一个路过 `earth.hpp` 的 PR」—— 这就是那个 PR;差异实测是**两处**不是 issue 正文说的三处(`coeffs.Δψ` vs `coeffs.Δε`、`sin` vs `cos`)。D2 经度改名按 names-as-contracts 裁决落地,西正侧带 `_west` 后缀。

## 测试

`203/203`(+2:`AngleFromArcSubdivisions`、`AngleDivisionByZeroThrows`)· 逐头自包含 `31/31` · 特性探针 EXIT 0 · 零 warning。每个提交独立跑过门禁。

**检出率**:`from_arcsec` 那条缺陷,新测试打在未修的代码上挂 **2/2** —— 挂的正是两条 `is_same_v<..., AngleRad>` 类型断言,三条值断言**一条都没挂**(旧代码返回 `AngleDeg{1.0}`,`.deg()` 照样是 1.0)。这条缺陷只有类型断言有区分力。除零测试的对照组(摘掉守卫)两个除数都不抛,`ASSERT_THROW` 会当场红。

## 验证

**零回归是执行式证明的,不是推理出来的。** 审阅盲审席用 `git archive 511a636 src` 解出基线头文件单独编一份,与工作树版本跑同一份探针,hexfloat 输出逐比特 `diff`:

> **356/356 行逐比特一致**,覆盖 sun apparent + fk5_correction、moon apparent + 视差、nutation longitude/obliquity(双模型)、obliquity mean/true、aberration、GMST/GAST/LAST、equation_of_time、坐标双向变换、solar_time::apparent、sunrise_sunset(5 地点含 ±89° 极昼极夜 × 4 种 h₀)、jieqi 24 气 × 3 年完整 Newton 求根管线。

外加 9 条**负向护栏**(必须编译失败的片段全部按预期失败):`AngleDeg a = 1.0`、`AngleRad r = a`、`angle + 1.0`、`a._value`、`double d = a`、常量求值中的 `/ 0.0` 等。

**165 处机械拼写替换单位零翻转**,两种独立方法同一答案:驾驶者做归一化记号对拍,清单席做 difflib 分块 + 单位 token multiset 对拍。

## 范围说明

- **#51 只做了 astro 侧,不关单。** 剩余 13 条在 `calendar/` 与 `util/`,实测摘掉其中五条 `using namespace` 会连带 **931 个待限定站点**(`datetime.hpp` 的 `using namespace std::chrono;` 一条占 754,其测试再加 100)。与角度拼写完全正交,落点 `calendar/lunar/*` 又是 #70 的施工面,已在 #51 留测量评论并排到 #70 之后。
- **#127 不关**:D2 改名已落地,但设计台账本体归 P8。
- **#49 已是 CLOSED**,本 PR 只是补上它当初裁定、一直没落地的互指注释。
- UDL 加 `constexpr` **不能兑现**审计说的那笔「代价」:`sunrise_sunset.hpp` 四个常量要用 UDL 得在头文件命名空间作用域写 using-directive,正是 #51 禁的。constexpr 解锁的只有函数体内。
- `_arcmin` / `_arcsec` 两个 UDL 零生产消费者(唯一引用是它们自己的测试块),减法轮建议删 —— **挂 backlog**:删公开 API 超出本批范围,且这对 UDL 非本 PR 引入。

## 审阅

R1 三轮四席:正确性清单席(grok)**NO FINDINGS** · 正确性盲审席(kimi,异族于驾驶者)**NO FINDINGS** · 风格设计席(grok)P2×4 P3×5 · 减法席(kimi)P2×1 P3×4。**零 P1。**

三条双席收敛(注释里的人口普查数字、逐字重复的毕业时间戳、同函数内限定不匀),两条单席独有且都是本 PR 自己制造的债:删完 using 留下的**空命名空间壳**,以及拼写替换后**九条从未被引用的 using**(unused using 不产生任何编译诊断,所以 203/203 绿不能作为它们活着的证据)。修复批 `96b06af` 全部处置,R2 双席 **FIXES VERIFIED**(第二 remit「扫修复 diff 本身」确认没有删过头、没有新问题)。

两条驳回也走完闭环、交回原发现家明示接受:风格轮「`from_arcsec` 应补对称 `@note`」标 `REJECTED-ACCEPTED`,并**撤回了它 R1 的一条判断** —— 它原把 `Distance` 侧两条「same reason as `Angle`'s」放进保留反例,R2 自纠为「尺子用错了:孪生互指的适用前提是*刻意分歧*(如 `#49` 的 fix both or neither),而 `Angle`/`Distance` 是收敛孪生,互指只剩导航成本」。减法轮「删 UDL」的 backlog 挂起也标 `REJECTED-ACCEPTED`。
