### PR TITLE
fix(lunar): algo2 声明的年份窗口从此有约束力 (#70 第 3 节)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 * Time scales and time-related quantities: UT1 / UTC / TT with leap seconds and ΔT, Julian Day, sidereal time, obliquity, nutation (时标转换、儒略日、恒星时、黄赤交角、章动)
 * A C ABI shared library (`src/shared_lib/celestial.h`), so the library is consumable from other languages (C 接口动态库)
 
-The supported year range of lunar conversions depends on the algorithm: 1901–2099 for algo1 (Hong Kong Observatory data), 1600–2199 for algo3 (baked table), and 410–5000 for algo2 (computed from VSOP87D / ELP2000-82B — that window is a convention, algo2 itself has no hard limit). In C++ the bounds are the `START_YEAR` / `END_YEAR` constants of each `calendar::lunar::algoN`; the C ABI exports algo1 and algo2, and `get_supported_lunar_year_range` reports their bounds.
+The supported year range of lunar conversions depends on the algorithm: 1901–2099 for algo1 (Hong Kong Observatory data), 1600–2199 for algo3 (baked table), and 410–5000 for algo2 (computed from VSOP87D / ELP2000-82B — that window is a convention rather than a limit of the method, and it is enforced: years outside it are rejected). In C++ the bounds are the `START_YEAR` / `END_YEAR` constants of each `calendar::lunar::algoN`; the C ABI exports algo1 and algo2, and `get_supported_lunar_year_range` reports their bounds.
 
 ## 2. Requirements
 

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -49,9 +49,10 @@ namespace calendar::lunar::algo2 {
 using namespace calendar::jieqi;
 using calendar::lunar::common::LunarYear;
 
-// A convention, not a physical ceiling — the method computes rather than looks up. By year 5000
-// ΔT is off by ~0.36 day, enough to carry a new moon past the UTC+8 midnight that starts a month
-// and reassign a leap month; the decay is smooth, so narrowing needs an error budget (#139).
+// A convention, not a physical ceiling — the method computes rather than looks up. Past ~2100 ΔT
+// is extrapolated with no observational anchor; by year 5000 it reaches ~0.36 day and is uncertain
+// to its own order, enough to move a new moon across the UTC+8 midnight that starts a month.
+// Narrowing the window needs an error budget, not a cliff to cut at (#139).
 
 /** @brief The first supported lunar year. */
 inline constexpr int32_t START_YEAR = 410;

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -32,6 +32,7 @@
 #include <optional>
 #include <iterator>
 #include <algorithm>
+#include <stdexcept>
 #include <functional>
 
 #include "cache.hpp"
@@ -47,6 +48,18 @@ namespace calendar::lunar::algo2 {
 
 using namespace calendar::jieqi;
 using calendar::lunar::common::LunarYear;
+
+// The window below is a convention, not a physical limit — algo2 computes rather than looks up,
+// so it returns something for any year. What decays is ΔT: by year 5000 the extrapolation is off
+// by ~0.36 day, which is enough to carry a new moon across the UTC+8 midnight that starts a month
+// and thus to reassign a leap month. The decay is smooth, so a narrower number needs an error
+// budget rather than a cliff to cut at (#70).
+
+/** @brief The first supported lunar year. */
+inline constexpr int32_t START_YEAR = 410;
+
+/** @brief The last supported lunar year. */
+inline constexpr int32_t END_YEAR = 5000;
 
 
 /**
@@ -386,13 +399,20 @@ inline auto create_lunar_year_context(int32_t year) -> LunarYearContext {
 
 
 /**
- * @brief Calculate the lunar year information for the given year. 
+ * @brief Calculate the lunar year information for the given year.
           计算给定年份的阴历年信息。
+ * @attention The input year should be in the range of [START_YEAR, END_YEAR].
  * @param year The Lunar year. 阴历年份。
  * @return The lunar year information. 阴历年信息。
  * @see https://ytliu0.github.io/ChineseCalendar/rules_simp.html
  */
 inline auto calc_lunar_year(int32_t year) -> LunarYear {
+  if (year < START_YEAR or year > END_YEAR) {
+    throw std::out_of_range {
+      std::format("year {} is out of range [{}, {}]", year, START_YEAR, END_YEAR)
+    };
+  }
+
   const auto context = create_lunar_year_context(year);
 
   // `context` contains raw info. We just need to convert it to `LunarYear`.
@@ -447,12 +467,6 @@ inline auto calc_lunar_year(int32_t year) -> LunarYear {
  */
 const inline auto get_info_for_year = util::cache::cache_func(calc_lunar_year);
 
-
-/** @brief The first supported lunar year. */
-inline constexpr int32_t START_YEAR = 410; // Algo2 actually has no limit on year. Simply use 410 here.
-
-/** @brief The last supported lunar year. */
-inline constexpr int32_t END_YEAR = 5000; // Algo2 actually has no limit on year. Simply use 5000 here.
 
 /**
  * @brief The bounds of the algorithm, i.e. the supported range of lunar and Gregorian dates.

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -49,11 +49,9 @@ namespace calendar::lunar::algo2 {
 using namespace calendar::jieqi;
 using calendar::lunar::common::LunarYear;
 
-// The window below is a convention, not a physical limit — algo2 computes rather than looks up,
-// so it returns something for any year. What decays is ΔT: by year 5000 the extrapolation is off
-// by ~0.36 day, which is enough to carry a new moon across the UTC+8 midnight that starts a month
-// and thus to reassign a leap month. The decay is smooth, so a narrower number needs an error
-// budget rather than a cliff to cut at (#70).
+// A convention, not a physical ceiling — the method computes rather than looks up. By year 5000
+// ΔT is off by ~0.36 day, enough to carry a new moon past the UTC+8 midnight that starts a month
+// and reassign a leap month; the decay is smooth, so narrowing needs an error budget (#139).
 
 /** @brief The first supported lunar year. */
 inline constexpr int32_t START_YEAR = 410;

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -304,7 +304,8 @@ typedef struct LunarYearInfo {
 /**
  * @brief Get the lunar year information for the given year.
  * @param algo The algorithm. Expected to be 1 or 2.
- * @param year The lunar year.
+ * @param year The lunar year. Outside the range `get_supported_lunar_year_range` reports for
+ *             `algo`, the result is `valid = false`.
  * @returns A `LunarYearInfo` struct.
  */
 LunarYearInfo get_lunar_year_info(uint8_t algo, int32_t year);

--- a/src/shared_lib/lib_lunar.cpp
+++ b/src/shared_lib/lib_lunar.cpp
@@ -92,7 +92,7 @@ auto get_lunar_year_info(const uint8_t algo, const int32_t year) -> LunarYearInf
 
   } catch (const std::exception& e) {
     // #67: `e.what()` is a message, not a format string — pass it as an argument.
-    lib::info("Exception raised during execution of get_lunar_year_info_algo1, year = {}", year);
+    lib::info("Exception raised during execution of get_lunar_year_info, algo = {}, year = {}", algo, year);
     lib::info("{}", e.what());
     return {};
   } catch (...) {

--- a/src/test/lunar/algo2_test.cpp
+++ b/src/test/lunar/algo2_test.cpp
@@ -309,6 +309,20 @@ TEST(LunarAlgo2, GetLunarInfo) {
 }
 
 
+TEST(LunarAlgo2, YearOutOfRange) {
+  ASSERT_THROW(calc_lunar_year(START_YEAR - 1), std::out_of_range);
+  ASSERT_THROW(calc_lunar_year(END_YEAR + 1), std::out_of_range);
+
+  // The C ABI reaches algo2 only through the cached wrapper, so the guard has to survive it.
+  ASSERT_THROW(get_info_for_year(START_YEAR - 1), std::out_of_range);
+  ASSERT_THROW(get_info_for_year(END_YEAR + 1), std::out_of_range);
+
+  // Both ends are inclusive — an off-by-one in the guard shows up here and nowhere else.
+  ASSERT_NO_THROW(get_info_for_year(START_YEAR));
+  ASSERT_NO_THROW(get_info_for_year(END_YEAR));
+}
+
+
 TEST(LunarAlgo2, MetadataBoundsAreLazy) {
   // #67: lazy init — reached through a call now.
   ASSERT_EQ(&AlgoMetadata<Algo::ALGO_2>::bounds(), &algo2::bounds());

--- a/src/test/lunar/diff_test.cpp
+++ b/src/test/lunar/diff_test.cpp
@@ -47,7 +47,7 @@ auto pick_random_years() -> std::vector<int32_t> {
        and year != 2057 and year != 2097;
   };
 
-  // Algo2 doesn't really have year limits. So use algo1's.
+  // algo1's window is the narrower of the two, so it bounds the comparison.
   auto years = views::iota(algo1::START_YEAR, algo1::END_YEAR + 1)
              | views::filter(filter_year)
              | to<std::vector>();

--- a/src/test/shared_lib/cabi_smoke_test.cpp
+++ b/src/test/shared_lib/cabi_smoke_test.cpp
@@ -288,6 +288,18 @@ TEST(CAbiSmoke, Lunar) {
 
   EXPECT_TRUE(get_lunar_year_info(2, 2024).valid);
   EXPECT_FALSE(get_lunar_year_info(9, 2024).valid); // unsupported algorithm
+
+  // #70: the advertised window binds. Read the endpoints back from the ABI rather than spelling
+  // them again — the point is that the window reported and the window honoured are one thing.
+  EXPECT_TRUE(get_lunar_year_info(1, range1.start).valid);
+  EXPECT_TRUE(get_lunar_year_info(1, range1.end).valid);
+  EXPECT_FALSE(get_lunar_year_info(1, range1.start - 1).valid);
+  EXPECT_FALSE(get_lunar_year_info(1, range1.end + 1).valid);
+
+  EXPECT_TRUE(get_lunar_year_info(2, range2.start).valid);
+  EXPECT_TRUE(get_lunar_year_info(2, range2.end).valid);
+  EXPECT_FALSE(get_lunar_year_info(2, range2.start - 1).valid);
+  EXPECT_FALSE(get_lunar_year_info(2, range2.end + 1).valid);
 }
 
 


### PR DESCRIPTION
风格架构批 P5a(ε-a1)。一件事:**让 algo2 声明的年份窗口真正有约束力**。

`#70` 第 3 节。**不关 #70** —— 它的第 1、2 节(四年分歧、algo3 baked 段治理)是下一个 PR。

## 问题

`algo2` 把支持范围声明为 `[410, 5000]`,`get_supported_lunar_year_range` 把这两个数经 C ABI
广告出去 —— 然后谁也不执行它。三个阴历算法里 **algo2 是唯一不校验年份的**:algo1
(`algo1.hpp:79-83`)和 algo3(`algo3.hpp:123-127`)越界都 `throw std::out_of_range`,
而 `algo2::calc_lunar_year` 函数体第一行就直接进 `create_lunar_year_context`。

`AGENTS.md` §8 的错误契约点名 #70 是最后一个未闭合项:**公开输入校验必须 throw**
(fail-fast,与构建类型无关);`assert` 只用于内部不变量,绝不作输入闸门。

**洞有多大是量出来的**(HEAD 版 Release dylib,探针见「验证」):

```
get_lunar_year_info(2,   409) -> valid=true         低于声明下界照样成功
get_lunar_year_info(2,  5001) -> valid=true         高于声明上界照样成功
二分实测的事实下界             -> 402                不是声明的 410
get_lunar_year_info(2, 11500) -> valid=false
get_lunar_year_info(2, 12000) -> valid=true         失败非单调
get_lunar_year_info(2, 12500) -> valid=true, leap_month=35
```

最后一行是本轮新发现的,审计没记:结构体文档写明 `1 <= leap_month <= 12`(0 = 无闰月),
而 ABI 报 `valid=true` 把 **35** 交出去。它比已知的 `month_len` uint16 高位截断**更早、
更直接** —— 不用解码位就看得出契约破了。真实边界不是任何声明,是**求根管线碰巧抛不抛**。

## 内容

**c1 `a61c905` · algo2 补输入校验。** `calc_lunar_year` 加边界 `throw std::out_of_range`,
形状逐字抄 `algo1.hpp:79-83`。`START_YEAR`/`END_YEAR` 随之从文件底部上移到 namespace 开头
(与 `algo1.hpp:38-42` 同位置)—— 它们原本声明在**被守卫的函数之后**,不上移引用不到。
补 `<stdexcept>`。

**两条注释删除**:`// Algo2 actually has no limit on year. Simply use 410 here.` ——
enforce 之后它直接是假话。换成的 why 只留一个量级锚点。
**完整退化表不进头文件**,`AGENTS.md` 写的是 "no measurement reports — those live in the
PR/issue",所以它在这里:

| 年 | 2100 | 2200 | 2500 | 3000 | 4000 | 5000 |
|---|---|---|---|---|---|---|
| ΔT | 87 s | 168 s | 1003 s | 4409 s | 14486 s | **31391 s** |
| 折合天 | 0.001 | 0.002 | 0.012 | 0.051 | 0.168 | **0.363** |

> 表里是 **ΔT 的值**,不是误差 —— ΔT = TT − UT1 是一个量,它有多大不影响朔的定位,
> 因为它是被正确减掉的。真正会把朔挪过 UTC+8 午夜的是**外推 ΔT 的不确定度**:2100 之后
> 这条曲线没有观测锚(algo5 用的是 Stephenson–Morrison–Hohenkerk 积分曲线的外推),
> 不确定度与值本身同量级。这一层最初被压进注释时压没了,PR 循环里由 Copilot 抓回(`e27e4b4`)。

**c2 `33d1ebd` · C 层由既有 `try/catch` 自动兑现。** 这里**没有新代码** ——
`get_lunar_year_info` 本来就把异常降级成 `valid=false`,algo1 早就这样工作
(`(1, 1900)`/`(1, 2100)` 实测 `valid=false`)。在 C 层再写一遍范围检查会**给窗口开第二个
出处**,那正是这个 issue 要清的东西。改动是测试与一行日志:

- `cabi_smoke_test.cpp` 四对断言,**端点从 `get_supported_lunar_year_range` 自己读回**,
  不重写 410/5000 —— 钉的是「广告的窗口 = 执行的窗口」这件事本身;硬编码数字会让这条测试
  在窗口哪天真收窄时和被测对象一起改,失去区分力。algo1 侧同样钉上,作回归护栏。
- `lib_lunar.cpp:95` 的日志写死 `get_lunar_year_info_algo1`,而这个函数服务两个 algo
  (后缀是从 `lib_delta_t.cpp` 那些**逐 algo** 函数抄来的)。补校验后 algo2 越界会常走这条路,
  一条指名道姓说错 algo 的日志比没有日志更坏。

## `assert` 为什么不动

`lib_lunar.cpp:78` 的 `assert(days == 29 or days == 30)` 在 Release 是死代码,而 uint16 编码
循环正建立在它之上 —— 看起来像是该换成 throw。**不换**,两个理由:

1. 它是**内部不变量**,不是输入闸门。`AGENTS.md` §8 的契约允许 assert 待在这里,它没被违反。
2. 窗口内 **4591 年逐年扫描实测:最大 13 个月,零违反**(月数 / 月长 / `leap>12` 三项全零)。
   补上输入校验之后,溢出通道由**入口**关闭。再加一道运行期 throw 就是给一个空量加闸门 ——
   上一个 PR 花了一整轮才卸掉同构的东西。

**c3 `21d715d` · 清掉被本 PR 证伪的四处旧陈述**(R1 修复批)· **c4 `e27e4b4` · 窗口注释说
ΔT 的不确定度而非把 ΔT 说成误差**(PR 循环采纳 Copilot)。两条都见「审阅」。

## 测试

`204/204`(净 +1)· 逐头自包含 `31/31` · 特性探针 EXIT 0 · clang-tidy 零 warning。
两个提交各自门禁独立全绿。

> clang-tidy 用 libstdc++-14 拼法跑(CI 是 ubuntu/libstdc++)。本机裸跑钉版 18.1.8 会
> `'algorithm' file not found` 并级联出几十条假告警到 main 既有文件上,那批数字不作数。

## 验证

**C ABI 前后对拍**,同一份只读探针、同一台机器:

| | 改前 | 改后 |
|---|---|---|
| `(2, 409)` / `(2, 5001)` | `valid=true` | **`valid=false`** |
| 二分事实下界 | **402** | **410**(与声明一致) |
| `(2, 6000..12000)` | `valid=true`,~16 ms | `valid=false`,**0 ms** |
| `(2, 12500)` 的 `leap_month=35` | 命中 | 不可达 |

末行那条静默垃圾通道就此关闭。倒数第二行顺带说明:越界现在是立即拒绝,不再跑完整条
VSOP87D + ELP2000 才失败。

**检出率**:把 guard 整段删掉重编,`LunarAlgo2.YearOutOfRange` 当场挂(ctest EXIT 8)。
新测试还钉了两件容易漏的事 —— **经缓存包装 `get_info_for_year` 也抛**(C ABI 只走这条路,
而 `make_cached` 在锁外求值、只在成功时落缓存,异常不会被吞),以及**两端点包含**
(off-by-one 只在这里现形)。

## 审阅

R1 两轮两席(正确性盲审 kimi k3,异族于驾驶者;风格设计 grok),**各自 `P1: 0 · P2: 1 · P3: 1`**。
减法轮按硬触发判据不挂(新增文件 0 / 新增 CI job 0 / 新增公开入口 0)。

**两席 remit 不重叠、互不知情,却撞到同一类缺陷** —— 被本 PR 证伪、却没跟着改的旧陈述。
按收敛分级这是最高置信信号,所以没逐条修,而是**按成因扫全仓**:

| 站点 | 谁报的 | 问题 |
|---|---|---|
| `algo2.hpp` 窗口注释 | 风格席 | **本 PR 自己新写的那句** "so it returns something for any year" —— 现在时的行为陈述,而几十行之下 `calc_lunar_year` 刚加了 throw。**同一个 diff 内自相矛盾** |
| `README.md:15` | 正确性席 | 「algo2 itself has no hard limit」。README 是广告的一部分,而本 PR 的整个论点就是「广告 = 执行」 |
| `diff_test.cpp:50` | 正确性席 | 「Algo2 doesn't really have year limits. So use algo1's.」结论仍对,给的**理由**不再成立 |
| `celestial.h:307` | **两席都没报** | `get_lunar_year_info` 的文档从不说年份契约 —— 而这是 C 消费者唯一会读的那张脸 |

改法:窗口注释按**能力**而非**当前 API 行为**重写(5 行压到 3 行,量级锚与「要误差预算」
两条反脚枪都保住,锚点改指 #139);`celestial.h` 补一句指向 `get_supported_lunar_year_range`,
**不复制数字** —— 与 `cabi_smoke_test` 的端点读回同一个道理:窗口只能有一个出处。

扫法留档:`grep -rniE "no (hard )?limit|doesn'?t really have|any year|not limited"` 覆盖
hpp/cpp/h/md/py/ipynb,五条命中、两条无关,其余即上表前三处。

正确性席的复核不止于读代码:自跑全量门禁与自包含、按配方跑 clang-tidy、
读 `cache.hpp:57-76` 坐实「异常不落缓存」、grep 全仓审计调用方
(`diff_test` 用 algo1 窗口、`algo3_test` 用 algo3 窗口,**都是 [410,5000] 的真子集**
⇒ throw 化无内部回归),并指出行为改变的边界**只**落在改前 `valid=true` 的年份 ——
负年/0 年改前改后都是 `false`,只是失败原因从附带变成确定。

R2 双席 **FIXES VERIFIED**,零新问题。

**PR 循环 bot:2/2 全处置**(`e27e4b4`)。Copilot 的 inline 一条**采纳** —— 它指出注释把
ΔT 本身说成了误差,而 ΔT 是个**量**,有多大不影响朔的定位(它是被正确减掉的);真正会把朔
挪过午夜的是**外推 ΔT 的不确定度**。这条**本地两席都没抓到**:风格席记「R1 未对其量级提出
异议」,正确性席记「旧注释论据的保留改写,本轮复核无新反证」—— 两席都把这个量级当成继承
下来、已被审过的前提,而它其实是 R1 修复批里新写的。claude[bot] 报 **No bugs found**,
附一条 sanity note(是否还有别的语言绑定或生成文档重复旧说法),已**验证闭合**:
全树 grep 不限文件类型,零残留;全仓只有一个 `.h`(即 `celestial.h`),无其它绑定或文档管线。

## 范围说明

- **#70 不关。** 只吃第 3 节,且是它的**后半句**。
- **验收标准第 3 条的前半句「收敛到真实可支撑的窗口」不做**,已拆成 #139。
  理由:ΔT 退化平滑无悬崖(见上表),任何单一数字都是约定;要拍一个**有依据**的数,
  得先回答「允许多大概率的日界翻转」——那是产品判断,不是代码判断。
  收窄的追改成本也一并记在 #139 里(`converter_test.cpp` 约 12 处端点断言 + 三个采样锚)。
- **本 PR 故意改变了 C ABI 的可观测行为**:`[410, 5000]` 之外的年份从 `valid=true`
  变 `valid=false`。这是把广告和实现对齐,方向是收紧;窗口之内一个值都没动。
