### PR TITLE
fix(toolbox): normalize_deg/rad 的半开区间承诺从此成立 (#88)

### DIFF
--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -40,8 +40,8 @@ namespace astro::toolbox {
 
 /**
  * @brief Normalize degree to [0, 360).
- * @throw std::invalid_argument If `deg` is not finite. A non-finite angle has no normal form,
- *        and returning it would let one bad value reach every consumer downstream unremarked (#88).
+ * @throw std::invalid_argument If `deg` is not finite — a non-finite angle has no normal form,
+ *        and returning one would pass it off as already normalized (#88).
  */
 constexpr auto normalize_deg(const double deg) -> double {
   if (not std::isfinite(deg)) [[unlikely]] {

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <cmath>
+#include <format>
 #include <limits>
 #include <cstddef>
 #include <numbers>
@@ -37,19 +38,50 @@ namespace astro::toolbox {
 
 #pragma region Angle Stuff
 
-/** @brief Normalize degree to [0, 360). */
+/**
+ * @brief Normalize degree to [0, 360).
+ * @throw std::invalid_argument If `deg` is not finite. A non-finite angle has no normal form,
+ *        and returning it would let one bad value reach every consumer downstream unremarked (#88).
+ */
 constexpr auto normalize_deg(const double deg) -> double {
-  const double _deg = std::remainder(deg, 360.0);
-  return _deg < 0.0 ? _deg + 360.0 : _deg; 
+  if (not std::isfinite(deg)) [[unlikely]] {
+    throw std::invalid_argument {
+      std::format("Argument `deg` is not finite, whose value is {}", deg)
+    };
+  }
+
+  const double rem     = std::remainder(deg, 360.0);
+  const double wrapped = rem < 0.0 ? rem + 360.0 : rem;
+
+  // Two values escape [0, 360) without this line: `rem + 360.0` rounds up to exactly 360.0 once
+  // `rem` is within ulp(360)/2 of zero, and -0.0 skips the wrap altogether (`-0.0 < 0.0` is false).
+  return (wrapped >= 360.0 or wrapped == 0.0) ? 0.0 : wrapped;
 }
 
-/** @brief Normalize radian to [0, 2π). */
+/**
+ * @brief Normalize radian to [0, 2π).
+ * @throw std::invalid_argument If `rad` is not finite.
+ * @note Twin of `normalize_deg` — same three edges, same order; the reasoning is written out there.
+ */
 constexpr auto normalize_rad(const double rad) -> double {
-  const double _rad = std::remainder(rad, 2.0 * std::numbers::pi);
-  return _rad < 0.0 ? _rad + 2.0 * std::numbers::pi : _rad;
+  if (not std::isfinite(rad)) [[unlikely]] {
+    throw std::invalid_argument {
+      std::format("Argument `rad` is not finite, whose value is {}", rad)
+    };
+  }
+
+  constexpr double two_pi = 2.0 * std::numbers::pi;
+
+  const double rem     = std::remainder(rad, two_pi);
+  const double wrapped = rem < 0.0 ? rem + two_pi : rem;
+
+  return (wrapped >= two_pi or wrapped == 0.0) ? 0.0 : wrapped;
 }
 
-/** @brief Normalize degree to [-180, 180). Useful for hour angles, where sign carries meaning. */
+/**
+ * @brief Normalize degree to [-180, 180). Useful for hour angles, where sign carries meaning.
+ * @throw std::invalid_argument If `deg` is not finite — inherited from `normalize_deg`.
+ */
 constexpr auto normalize_pm180(const double deg) -> double {
   const double _deg = normalize_deg(deg);
   return _deg >= 180.0 ? _deg - 360.0 : _deg;
@@ -188,6 +220,7 @@ struct Angle {
   /**
    * @brief Normalize the angle to [0, 360) / [0, 2π), depending on the angle's unit.
    * @return The normalized angle. The returned angle is of the same unit as the original angle.
+   * @throw std::invalid_argument If the angle is not finite — inherited from `normalize_deg` / `normalize_rad`.
    */
   [[nodiscard]] constexpr auto normalize() const -> Angle<Unit> {
     if constexpr (Unit == AngleUnit::DEG) {

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -313,6 +313,57 @@ TEST(AstroMath, AngleDivisionByZeroThrows) {
 }
 
 
+TEST(AstroMath, Distance) {
+  using DistanceUnit::AU;
+  using DistanceUnit::KM;
+
+  static_assert(std::is_same_v<DistanceAu, Distance<AU>>);
+  static_assert(std::is_same_v<DistanceKm, Distance<KM>>);
+  // A bare double must not become a distance, and AU must not quietly become KM — the same rule
+  // `Angle` follows (#48), asserted here because `Distance` had no test of its own at all.
+  static_assert(not std::is_convertible_v<double, DistanceAu>);
+  static_assert(not std::is_convertible_v<DistanceAu, DistanceKm>);
+
+  // Pinned against the constant rather than against 149597870.691: #86 moves this to the IAU 2012
+  // value and renames it, and a test holding the literal would have to be re-derived, not repointed.
+  ASSERT_EQ(au_to_km(1.0), au_km_scale);
+  ASSERT_EQ(km_to_au(au_km_scale), 1.0);
+  ASSERT_EQ(au_to_km(0.0), 0.0);
+  ASSERT_EQ(km_to_au(0.0), 0.0);
+
+  for (auto i = 0; i < 1000; ++i) {
+    const double au = util::random(-50.0, 50.0);
+
+    const DistanceAu distance { au };
+
+    ASSERT_FLOAT_EQ(distance.as<AU>(), au);
+    ASSERT_FLOAT_EQ(distance.as<KM>(), au_to_km(au));
+    ASSERT_FLOAT_EQ(distance.au(), au);
+    ASSERT_FLOAT_EQ(distance.km(), au_to_km(au));
+
+    const DistanceKm in_km { distance };
+
+    ASSERT_FLOAT_EQ(in_km.km(), au_to_km(au));
+    ASSERT_FLOAT_EQ(in_km.au(), au);
+  }
+
+  for (auto i = 0; i < 1000; ++i) {
+    const double km = util::random(-1e9, 1e9);
+
+    const DistanceKm distance { km };
+
+    ASSERT_FLOAT_EQ(distance.as<KM>(), km);
+    ASSERT_FLOAT_EQ(distance.as<AU>(), km_to_au(km));
+    ASSERT_FLOAT_EQ(distance.km(), km);
+    ASSERT_FLOAT_EQ(distance.au(), km_to_au(km));
+
+    const DistanceAu in_au { distance };
+
+    ASSERT_FLOAT_EQ(in_au.km(), km);
+    ASSERT_FLOAT_EQ(in_au.au(), km_to_au(km));
+  }
+}
+
 TEST(AstroMath, Ulp) {
   // A double carries 52 fraction bits, so the ulp is 2^(exponent-52) and doubles with the exponent.
   // Hex float literals rather than `std::pow`: exact by construction, so `ASSERT_EQ` does not rest

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -24,6 +24,7 @@
 #include <gtest/gtest.h>
 #include <cmath>
 #include <limits>
+#include <numbers>
 #include <stdexcept>
 #include <type_traits>
 #include "toolbox.hpp"
@@ -99,6 +100,83 @@ TEST(AstroMath, NormalizedPm180) {
     ASSERT_LT(x, 180.0);
     // Result is congruent to the input modulo 360.
     ASSERT_FLOAT_EQ(normalize_deg(x), normalize_deg(random_deg));
+  }
+}
+
+TEST(AstroMath, NormalizedDegHalfOpenNearZero) {
+  // The wrap `rem + 360.0` rounds up to exactly 360.0 for any `rem` within ulp(360)/2 = 2^-45 of
+  // zero, so the whole of [-2^-45, 0) used to leave the range the doc promises is open (#88).
+  // The last two inputs sit past that threshold and normalize the ordinary way — they are here so
+  // that an over-correction pushing them out of range fails too.
+  for (const double deg : { -1e-16, -1e-15, -1e-14, -2.0e-14, -2.8e-14, -2.9e-14, -1e-13 }) {
+    const double x = normalize_deg(deg);
+    ASSERT_GE(x, 0.0) << "deg = " << deg;
+    ASSERT_LT(x, 360.0) << "deg = " << deg;
+  }
+}
+
+TEST(AstroMath, NormalizedRad) {
+  constexpr double TWO_PI = 2.0 * std::numbers::pi;
+
+  {
+    const auto x = normalize_rad(0.0);
+    ASSERT_EQ(x, 0.0);
+  }
+  {
+    const auto x = normalize_rad(std::numbers::pi);
+    ASSERT_FLOAT_EQ(x, std::numbers::pi);
+  }
+  {
+    const auto x = normalize_rad(TWO_PI + 1.0);
+    ASSERT_FLOAT_EQ(x, 1.0);
+  }
+  {
+    const auto x = normalize_rad(-1.0);
+    ASSERT_FLOAT_EQ(x, TWO_PI - 1.0);
+  }
+
+  // Same edge as `NormalizedDegHalfOpenNearZero`, one unit down: ulp(2π)/2 = 2^-51.
+  for (const double rad : { -1e-18, -1e-17, -1e-16, -4.0e-16, -5.0e-16, -1e-15 }) {
+    const double x = normalize_rad(rad);
+    ASSERT_GE(x, 0.0) << "rad = " << rad;
+    ASSERT_LT(x, TWO_PI) << "rad = " << rad;
+  }
+
+  for (auto i = 0; i < 1000; ++i) {
+    const double x = normalize_rad(util::random(-2.0 * TWO_PI, 2.0 * TWO_PI));
+    ASSERT_GE(x, 0.0);
+    ASSERT_LT(x, TWO_PI);
+  }
+}
+
+TEST(AstroMath, NormalizedWholeTurnsGivePositiveZero) {
+  // `rem < 0.0` is false for -0.0, so whole turns used to skip the wrap and keep their sign bit.
+  // `ASSERT_EQ(x, 0.0)` alone cannot see this — -0.0 compares equal to 0.0 (#88).
+  for (const double deg : { -0.0, -360.0, -720.0, -1080.0 }) {
+    const double x = normalize_deg(deg);
+    ASSERT_EQ(x, 0.0) << "deg = " << deg;
+    ASSERT_FALSE(std::signbit(x)) << "deg = " << deg;
+  }
+
+  constexpr double TWO_PI = 2.0 * std::numbers::pi;
+
+  for (const double rad : { -0.0, -TWO_PI, -2.0 * TWO_PI }) {
+    const double x = normalize_rad(rad);
+    ASSERT_EQ(x, 0.0) << "rad = " << rad;
+    ASSERT_FALSE(std::signbit(x)) << "rad = " << rad;
+  }
+}
+
+TEST(AstroMath, NormalizeRejectsNonFinite) {
+  constexpr double INF_D = std::numeric_limits<double>::infinity();
+  constexpr double NAN_D = std::numeric_limits<double>::quiet_NaN();
+
+  for (const double bad : { INF_D, -INF_D, NAN_D }) {
+    ASSERT_THROW((void) normalize_deg(bad), std::invalid_argument);
+    ASSERT_THROW((void) normalize_rad(bad), std::invalid_argument);
+    ASSERT_THROW((void) normalize_pm180(bad), std::invalid_argument);
+    ASSERT_THROW((void) Angle<AngleUnit::DEG> { bad }.normalize(), std::invalid_argument);
+    ASSERT_THROW((void) Angle<AngleUnit::RAD> { bad }.normalize(), std::invalid_argument);
   }
 }
 

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -105,9 +105,9 @@ TEST(AstroMath, NormalizedPm180) {
 
 TEST(AstroMath, NormalizedDegHalfOpenNearZero) {
   // The wrap `rem + 360.0` rounds up to exactly 360.0 for any `rem` within ulp(360)/2 = 2^-45 of
-  // zero, so the whole of [-2^-45, 0) used to leave the range the doc promises is open (#88).
-  // The last two inputs sit past that threshold and normalize the ordinary way — they are here so
-  // that an over-correction pushing them out of range fails too.
+  // zero, so all of [-2^-45, 0) used to land on the end the range excludes (#88). The last two
+  // inputs sit past that threshold and normalize the ordinary way — they are here so that an
+  // over-correction pushing them out of range fails too.
   for (const double deg : { -1e-16, -1e-15, -1e-14, -2.0e-14, -2.8e-14, -2.9e-14, -1e-13 }) {
     const double x = normalize_deg(deg);
     ASSERT_GE(x, 0.0) << "deg = " << deg;
@@ -320,12 +320,12 @@ TEST(AstroMath, Distance) {
   static_assert(std::is_same_v<DistanceAu, Distance<AU>>);
   static_assert(std::is_same_v<DistanceKm, Distance<KM>>);
   // A bare double must not become a distance, and AU must not quietly become KM — the same rule
-  // `Angle` follows (#48), asserted here because `Distance` had no test of its own at all.
+  // `Angle` follows (#48).
   static_assert(not std::is_convertible_v<double, DistanceAu>);
   static_assert(not std::is_convertible_v<DistanceAu, DistanceKm>);
 
-  // Pinned against the constant rather than against 149597870.691: #86 moves this to the IAU 2012
-  // value and renames it, and a test holding the literal would have to be re-derived, not repointed.
+  // Pinned against the constant, not the literal 149597870.691: a re-value or rename (#86) then
+  // repoints this test instead of forcing its expected values to be re-derived.
   ASSERT_EQ(au_to_km(1.0), au_km_scale);
   ASSERT_EQ(km_to_au(au_km_scale), 1.0);
   ASSERT_EQ(au_to_km(0.0), 0.0);

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -118,21 +118,26 @@ TEST(AstroMath, NormalizedDegHalfOpenNearZero) {
 TEST(AstroMath, NormalizedRad) {
   constexpr double TWO_PI = 2.0 * std::numbers::pi;
 
+  // `ASSERT_DOUBLE_EQ` here and in `Distance`, where the older tests in this file use
+  // `ASSERT_FLOAT_EQ`: these results land within ~1 ulp of double, and a float-scale tolerance
+  // would wave through an error nine orders of magnitude larger. The neighbours keep the looser
+  // one for a reason — the deg↔rad round trips they assert drift past 4 ulp and fail under this.
+
   {
     const auto x = normalize_rad(0.0);
     ASSERT_EQ(x, 0.0);
   }
   {
     const auto x = normalize_rad(std::numbers::pi);
-    ASSERT_FLOAT_EQ(x, std::numbers::pi);
+    ASSERT_DOUBLE_EQ(x, std::numbers::pi);
   }
   {
     const auto x = normalize_rad(TWO_PI + 1.0);
-    ASSERT_FLOAT_EQ(x, 1.0);
+    ASSERT_DOUBLE_EQ(x, 1.0);
   }
   {
     const auto x = normalize_rad(-1.0);
-    ASSERT_FLOAT_EQ(x, TWO_PI - 1.0);
+    ASSERT_DOUBLE_EQ(x, TWO_PI - 1.0);
   }
 
   // Same edge as `NormalizedDegHalfOpenNearZero`, one unit down: ulp(2π)/2 = 2^-51.
@@ -336,15 +341,15 @@ TEST(AstroMath, Distance) {
 
     const DistanceAu distance { au };
 
-    ASSERT_FLOAT_EQ(distance.as<AU>(), au);
-    ASSERT_FLOAT_EQ(distance.as<KM>(), au_to_km(au));
-    ASSERT_FLOAT_EQ(distance.au(), au);
-    ASSERT_FLOAT_EQ(distance.km(), au_to_km(au));
+    ASSERT_DOUBLE_EQ(distance.as<AU>(), au);
+    ASSERT_DOUBLE_EQ(distance.as<KM>(), au_to_km(au));
+    ASSERT_DOUBLE_EQ(distance.au(), au);
+    ASSERT_DOUBLE_EQ(distance.km(), au_to_km(au));
 
     const DistanceKm in_km { distance };
 
-    ASSERT_FLOAT_EQ(in_km.km(), au_to_km(au));
-    ASSERT_FLOAT_EQ(in_km.au(), au);
+    ASSERT_DOUBLE_EQ(in_km.km(), au_to_km(au));
+    ASSERT_DOUBLE_EQ(in_km.au(), au);
   }
 
   for (auto i = 0; i < 1000; ++i) {
@@ -352,15 +357,15 @@ TEST(AstroMath, Distance) {
 
     const DistanceKm distance { km };
 
-    ASSERT_FLOAT_EQ(distance.as<KM>(), km);
-    ASSERT_FLOAT_EQ(distance.as<AU>(), km_to_au(km));
-    ASSERT_FLOAT_EQ(distance.km(), km);
-    ASSERT_FLOAT_EQ(distance.au(), km_to_au(km));
+    ASSERT_DOUBLE_EQ(distance.as<KM>(), km);
+    ASSERT_DOUBLE_EQ(distance.as<AU>(), km_to_au(km));
+    ASSERT_DOUBLE_EQ(distance.km(), km);
+    ASSERT_DOUBLE_EQ(distance.au(), km_to_au(km));
 
     const DistanceAu in_au { distance };
 
-    ASSERT_FLOAT_EQ(in_au.km(), km);
-    ASSERT_FLOAT_EQ(in_au.au(), km_to_au(km));
+    ASSERT_DOUBLE_EQ(in_au.km(), km);
+    ASSERT_DOUBLE_EQ(in_au.au(), km_to_au(km));
   }
 }
 


### PR DESCRIPTION
风格架构批 P9。一件事:**让 `normalize_deg` / `normalize_rad` 的 doc 承诺重新成立**。

`Closes #88`。**#87 不关** —— 本 PR 只吃它 7 条缺口里的 1 条(toolbox),余 6 条见「范围说明」。

## 问题

两个函数的 doc 写着返回值落在 `[0°, 360°)` / `[0, 2π)`,实际有三处破损。三处**同源** ——
`_deg < 0.0` 这一个比较被要求同时管住三件事,一件也没管住:

| 破损 | 机制 |
|---|---|
| 极小负输入返回**恰好 360.0** | `rem + 360.0` 在 `rem` 落入 `ulp(360)/2 = 2⁻⁴⁵` 内时进位到 360.0,加完不复查 |
| 整周期负输入返回 **-0.0** | `-0.0 < 0.0` 为 false,跳过回绕,符号位原样带出 |
| **inf / NaN 静默穿透** | 同一个比较对 NaN 也是 false,非有限值走「已在范围内」分支原样返回 |

第三条是 throw 的理由。同文件 `Angle::operator/` 早就对除零抛异常,`sunrise_sunset` 对每个
入参角度都校验 —— 一个把 NaN 当成合法归一化角交还的入口是这里的异类。

**这三条在 `b18c5fe` 上逐条复验仍然成立**(P3 重写过 `toolbox.hpp` 但没顺手修掉任何一条),
所以范围没有缩。

## 内容 —— 三个提交

**c1 `dd5fadc` · 契约与三处修复。** 进门 `throw std::invalid_argument`(对齐
`sunrise_sunset.hpp` 的写法,不对齐 `datetime.hpp` 的 `runtime_error` —— 后者是 #86 第 1 项
在追的历史不一致),出门一个双条件同时收掉进位与 -0.0。`normalize_pm180` 与 `Angle::normalize()`
**不动**,委托关系自动继承,doc 各补一行 `@throw`。

`constexpr` **保留**:C++ 允许 constexpr 函数体内有 throw,常量求值时不走到那条分支就照常算。
将来 C++26 让 `std::remainder` constexpr 之后,`normalize_deg(370.0)` 照样能编译期算,
只有 `normalize_deg(NaN)` 编译不过 —— 那是白捡的编译期检查。今天更是零损失:
探针实证它现在**根本无法常量求值**。

测试侧:`normalize_deg` 原有六例全是精确值断言、负侧只探到 -1;`normalize_rad` **一个测试都没有**
—— 这正是 #88 第 4 节说的「测试从没探过那一侧」。补三处破损各自的定向断言 + 两个函数的
区间断言 + `signbit` 断言 + 五个入口 × 三个非有限值的 `EXPECT_THROW`。

**c2 `4097d8a` · `Distance` / `au_to_km` / `km_to_au` 的首批测试(#87 的 toolbox 一条)。**
测试**钉往返恒等与常量本身,不钉字面值 149597870.691** —— #86 要把它改成 IAU 2012 的值并改名,
钉字面值会让那个 PR 回来重算期望值。同 P5a「端点从 ABI 自己读回」的形状。

**c3 `5a59b6a` · R1 风格轮的修复批(comment-only)。** 四条措辞,分别是:说错了后果的
`@throw`、一个花园小径句、一句来历叙事(该住 commit)、一句会腐烂的计划信息(#86 落地当天就成假话)。

## 测试

209/209(main 204,净 +5)· 自包含 **31/31** · 特性探针 EXIT 0 · clang-tidy 与 main 差集里
本 PR 自己的代码**零新增诊断**(只有 gtest 宏展开随 `ASSERT_THROW` 数量线性上升,类别与 main 相同)。

## 验证

**检出率 —— 逐条验,不合并验。** 三个变异头文件,每个只 revert 一条边:

| 变异 | 挂掉的测试 |
|---|---|
| 去掉 `isfinite` guard | `NormalizeRejectsNonFinite` |
| 去掉「加后复查 360 / 2π」 | `NormalizedDegHalfOpenNearZero` + `NormalizedRad` |
| 去掉「-0.0 消符号位」 | `NormalizedWholeTurnsGivePositiveZero` |

一一对应、零交叉 ⇒ 「一处修法覆盖三条」成立,且三条各有独立守卫。#87 侧两个变异
(`au_to_km` 乘改除、`Distance::as` 跳过转换)均被 `AstroMath.Distance` 抓住。

**零行为改变(库自身路径)。** 434,017 次检查覆盖 402–9050 年:VSOP87D、两个章动模型、
黄赤交角、光行差、日月视位置、恒星时三层、均时差、两个坐标变换,外加五个地点
(含极昼极夜与逼近极点的退化分母)的日出日落、以及范围外病态 jde —— **零非有限值,
guard 一次都没触发**。探针过突变检出:注入 NaN 会传到它检查的每个出口。

**逐比特。** 同一扫描的 2472 行 hexfloat 输出前后**零差异**;该探针同样过突变检出 ——
把一个章动系数末位改 1e-6,2472 行全变。

## 审阅

R1 双轮零重叠 + R2 双席,全部 kimi k3(**阵容有降级,如实记录**:风格席原定 grok,
因本机 grok CLI 未开 always-approve 而三次空跑,按免请示条款换 kimi 第二实例;
两席同族,异族约 40% 的互补率不可外推,本轮覆盖面实际打了折)。

- **R1 正确性盲审:NO FINDINGS**(P1=0 P2=0 P3=0)。该席**不信声明,独立重做**:自造 5 个
  mutant + 自写探针复刻断言谓词、自取基线树做 10105 行 hexfloat 对拍 + 敏感性验证
  (扰动章动系数 → 8954/10105 行变化),并补探了本 PR 测试未覆盖的边界(阈值本身、
  `-denorm_min`、±1e16、`normalize_pm180` 的 -0.0 继承、同余性)。
- **R1 风格/设计:P1=0 P2=0 P3=4**,全采,落成 c3。
- **R2 双席:FIXES VERIFIED**,新增 0。R2 特别核了「修复批新说出口的话」——
  c3 新写的三条机制断言由探针回放旧代码逐条证真(含 `-2⁻⁴⁵` tie 点在 round-half-even
  下确实落 360.0,故注释里 `[-2⁻⁴⁵, 0)` 的闭端写法精确)。

## 范围说明

- **`#88` 可关**:三处破损全修 + 区间/边界断言补齐,其验收标准全覆盖。
- **`#87` 不关**。本 PR 只做 toolbox 一条。余 6 条 —— `aberration::compute` 直接 golden、
  `true_obliquity`、`jde_to_ut1`/`ut1_to_jde`、jieqi 越界 + `JieqiGenerator` 排他边界、
  `vsop87d::evaluate` 模板封装、`moon_phase` 三条 `invalid_argument` —— **批后处理**,
  已在 issue 留范围注记。
- **不越权**:`[[nodiscard]]` 补齐、`std::midpoint`、`au_km_scale` 改名改值、
  `#pragma once` 换 include guard 分属 #81 / #86 / #73,本 PR 一律不动。
- 一条实测更正:#87 称 `Distance` 「完全无测试」只对**直接**测试成立 —— 把 `au_to_km` 改成
  除法全量跑,`Moon.CoordAndPpi` 与三条 `MoonHorizonsGolden` 本来就抓得住。c2 真正新增的是
  **类型层契约**(golden 数据看不见 `not is_convertible_v<double, DistanceAu>`)与**定位**
  (错误不再表现为三层之外的月球视差失配)。
