### PR TITLE
fix(automation): --setup 只装缺的依赖,并把 PEP 668 说清楚

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ export CXX=clang++
 ./project.py --all
 
 # Individual steps
-./project.py --setup      # Install Python deps and verify toolchain
+./project.py --setup      # Install missing Python deps and verify toolchain
 ./project.py --cmake      # Run CMake configuration
 ./project.py --build      # Build shared library and tests
 ./project.py --test       # Run all tests

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The supported year range of lunar conversions depends on the algorithm: 1901–2
 * CMake >=3.22, and make
 * Python 3, mostly for build automation
   * Install dependencies: `python3 -m pip install -r Requirements.txt`
+  * A distro-packaged Python (Debian, Ubuntu, ...) refuses that install under PEP 668. Work in a virtual environment there: `python3 -m venv .venv && .venv/bin/python project.py --all`. `--setup` installs nothing when the dependencies are already present, so an interpreter that already has them is fine as well.
   * `Requirements.txt` covers the build/test automation only. The linters come separately (see §4), and the notebooks and crawlers under `statistics/` need `python3 -m pip install -r Requirements-statistics.txt`
 
 ## 3. How to Build

--- a/automation/env.py
+++ b/automation/env.py
@@ -18,6 +18,7 @@ import tempfile
 
 from pathlib import Path
 from pprint import pformat
+from importlib import metadata
 from dataclasses import dataclass
 
 from operator import not_
@@ -33,15 +34,56 @@ from .utils import (
 
 #region Python Dependencies
 
+def unsatisfied_requirements(req_txt: Path) -> List[str]:
+  """The requirements of `req_txt` that the running interpreter does not already provide.
+
+  Only a bare distribution name gets a verdict here. A line carrying a version specifier, an
+  extra, or a pip flag (`-r other.txt`) is reported as unsatisfied, which leaves pip - not this
+  parser - the authority on what those mean.
+  """
+  unsatisfied = []
+
+  for raw_line in req_txt.read_text().splitlines():
+    line = raw_line.split("#", 1)[0].strip()
+    if not line:
+      continue
+
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", line):
+      unsatisfied.append(line)
+      continue
+
+    try:
+      metadata.version(line)
+    except metadata.PackageNotFoundError:
+      unsatisfied.append(line)
+
+  return unsatisfied
+
+
 def install_dependencies() -> int:
-  """Install the required Python dependencies listed in 'Requirements.txt'."""
+  """Install the Python dependencies listed in 'Requirements.txt' that are missing."""
   req_txt = paths.python_requirements()
   if not req_txt.exists():
     return 0
 
-  yellow_print("# Installing Python dependencies...")
+  # Installing unconditionally would fail on an interpreter that cannot be installed into, even
+  # when it already provides everything - and `--all` stops at the first failing task, so the
+  # build would never start.
+  missing = unsatisfied_requirements(req_txt)
+  if not missing:
+    green_print(f"# Python dependencies already satisfied by {sys.executable}")
+    return 0
+
+  yellow_print(f'# Installing Python dependencies: {", ".join(missing)}')
   this_python = sys.executable
   ret = run_cmd([this_python, "-m", "pip", "install", "-r", str(req_txt)])
+
+  # A distro-packaged interpreter (Debian, Ubuntu, ...) refuses to install into its site-packages.
+  if ret.retcode != 0 and "externally-managed-environment" in ret.stdout + ret.stderr:
+    red_print("# This interpreter is managed by the OS package manager (PEP 668).")
+    yellow_print("# Install into a virtual environment and drive the build from it:")
+    yellow_print(f"#   {this_python} -m venv .venv && .venv/bin/python project.py --all")
+
   return ret.retcode
 
 #endregion

--- a/automation/env.py
+++ b/automation/env.py
@@ -74,7 +74,9 @@ def install_dependencies() -> int:
     green_print(f"# Python dependencies already satisfied by {sys.executable}")
     return 0
 
-  yellow_print(f'# Installing Python dependencies: {", ".join(missing)}')
+  # Named individually, but pip is pointed at the whole file: the lines this probe punts on
+  # (specifiers, extras, `-r other.txt`) still have to go through it.
+  yellow_print(f'# Installing {req_txt.name}, missing: {", ".join(missing)}')
   this_python = sys.executable
   ret = run_cmd([this_python, "-m", "pip", "install", "-r", str(req_txt)])
 


### PR DESCRIPTION
一件事:**别让一次多余的安装废掉整条构建**。

## 问题

`install_dependencies()` 无条件跑 `pip install -r Requirements.txt`。在 distro 打包的解释器上
(Debian / Ubuntu 的 `/usr/bin/python3`,带 `EXTERNALLY-MANAGED` 标记)这条命令必被 PEP 668 拒绝,
而 `run_tasks` 在第一个失败任务处早停 —— `--all` 于是连 cmake 都到不了,`--setup` 单跑也是红的。

被废掉的是整条构建,起因只是一次本来就不必要的安装:`Requirements.txt` 里只有 `requests`,
撞上这条的机器(Ubuntu 25.10 + 系统 Python 3.14)早就装着它。

## 内容

`unsatisfied_requirements()` 逐行读 `Requirements.txt`,只对**裸分发名**用
`importlib.metadata.version` 下判断;带版本约束、extra 或 `-r other.txt` 的行一律算「不满足」,
把这些的解释权留给 pip,不在这里自己实现半个 PEP 508。全部满足就跳过 pip,一个包都不装。

真缺依赖才 pip。若 pip 因 PEP 668 拒绝,补一段可直接粘的 venv 配方 —— pip 自己那段提示要读懂,
人得先知道 externally-managed 说的是解释器而不是包。retcode 照旧透传,该红还是红。

README §2 与 AGENTS.md 的对应一行同步。

## 验证

- `ruff check automation/env.py` 通过。(`ruff format` 不是本仓门禁:全仓 `--check` 都报红,
  存量差异是 license header 的尾随空格。)
- 探测函数:`Requirements.txt` → 空;`Requirements-statistics.txt` → 正确列出未装的包,
  且 `-r` 行保守算缺。
- 强制走 PEP 668 分支(指向一个未安装的包):诊断与 venv 配方照常打印,retcode 仍为 1。
- Ubuntu(系统 Python 3.14)上 `./project.py --all` 端到端通过:setup 0.6s 不装任何东西,
  cmake + build + 209 个测试全过。按 AGENTS.md 的验收口径直接跑 18 个测试二进制得 209,
  与 `grep TEST(` 的宏计数相等。

## 范围说明

只动依赖安装这一步。`setup_environment` 的工具检查与 C++ 支持检查、以及 `--all` 的任务编排,
都不在本 PR 内。
