### PR TITLE
refactor: #81 现代 C++ 小件收尾(Pδ)

### DIFF
--- a/automation/feature_probe.py
+++ b/automation/feature_probe.py
@@ -165,8 +165,14 @@ FEATURES: Final[List[Feature]] = [
 #   libstdc++  clang 18.1.3 + ubuntu-24.04's default libstdc++ (GCC 13)
 #   libc++     Apple clang 21.0.0 + its bundled libc++
 #   msvc-stl   clang 20.1.8 + the MSVC STL on the runner image
+# `std::tuple_like` (#81): measured False on libstdc++ (clang 21.1.8 and g++ 15.2, both -std=c++23
+# and -std=c++26 -- libstdc++ 15 has only the internal `__glibcxx_want_tuple_like` machinery).
+# The libc++ and msvc-stl entries are the author's expectation, not a measurement: neither
+# toolchain is reachable from the machine this was written on. CI is the authority -- if a leg
+# disagrees, this table is what is wrong, and the mismatch message says so.
 EXPECTED: Final[Dict[str, Dict[str, bool]]] = {
   "libstdc++": {
+    "std::tuple_like": False,
     "std::generator": False,
     "std::ranges::fold_left": True,
     "std::views::enumerate": True,
@@ -176,6 +182,7 @@ EXPECTED: Final[Dict[str, Dict[str, bool]]] = {
     "std::function_ref": False,
   },
   "libc++": {
+    "std::tuple_like": False,
     "std::generator": False,
     "std::ranges::fold_left": True,
     "std::views::enumerate": False,
@@ -185,6 +192,7 @@ EXPECTED: Final[Dict[str, Dict[str, bool]]] = {
     "std::function_ref": False,
   },
   "msvc-stl": {
+    "std::tuple_like": False,
     "std::generator": True,
     "std::ranges::fold_left": True,
     "std::views::enumerate": True,

--- a/automation/feature_probe.py
+++ b/automation/feature_probe.py
@@ -165,11 +165,8 @@ FEATURES: Final[List[Feature]] = [
 #   libstdc++  clang 18.1.3 + ubuntu-24.04's default libstdc++ (GCC 13)
 #   libc++     Apple clang 21.0.0 + its bundled libc++
 #   msvc-stl   clang 20.1.8 + the MSVC STL on the runner image
-# `std::tuple_like` (#81): measured False on libstdc++ (clang 21.1.8 and g++ 15.2, both -std=c++23
-# and -std=c++26 -- libstdc++ 15 has only the internal `__glibcxx_want_tuple_like` machinery).
-# The libc++ and msvc-stl entries are the author's expectation, not a measurement: neither
-# toolchain is reachable from the machine this was written on. CI is the authority -- if a leg
-# disagrees, this table is what is wrong, and the mismatch message says so.
+# `std::tuple_like` (#81): False on all three legs. libstdc++ exposes only the internal
+# `__glibcxx_want_tuple_like` machinery, with nothing under `std::`.
 EXPECTED: Final[Dict[str, Dict[str, bool]]] = {
   "libstdc++": {
     "std::tuple_like": False,

--- a/automation/feature_probe.py
+++ b/automation/feature_probe.py
@@ -42,6 +42,20 @@ class Feature:
 # as "blocked on Apple Clang" when it was not.
 FEATURES: Final[List[Feature]] = [
   Feature(
+    name="std::tuple_like",
+    token="tuple_like",
+    issue="#81",
+    program="""
+      #include <tuple>
+      #include <utility>
+      template <std::tuple_like T> struct Probe {};
+      auto main() -> int {
+        Probe<std::pair<int, int>> probe;
+        (void) probe;
+      }
+    """,
+  ),
+  Feature(
     name="std::generator",
     token="generator",
     issue="#99",

--- a/src/astro/coord_transform.hpp
+++ b/src/astro/coord_transform.hpp
@@ -63,7 +63,7 @@ struct HorizontalCoord {
  *       and the cos β-multiplied form silently shifts α by 180°.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 13, Formulas (13.3) and (13.4).
  */
-inline auto ecliptic_to_equatorial(
+[[nodiscard]] inline auto ecliptic_to_equatorial(
   const astro::toolbox::AngleDeg& λ,
   const astro::toolbox::AngleDeg& β,
   const astro::toolbox::AngleDeg& ε
@@ -114,7 +114,7 @@ inline auto ecliptic_to_equatorial(
  *       is taken into account (for refraction see Meeus Chapter 16; for parallax, Chapter 40).
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 13, Formulas (13.5) and (13.6).
  */
-inline auto equatorial_to_horizontal(
+[[nodiscard]] inline auto equatorial_to_horizontal(
   const astro::toolbox::AngleDeg& H,
   const astro::toolbox::AngleDeg& δ,
   const astro::toolbox::AngleDeg& φ

--- a/src/astro/delta_t.hpp
+++ b/src/astro/delta_t.hpp
@@ -130,7 +130,7 @@ find_coefficients(const int32_t year) -> std::optional<
  * @note The original algorithm takes integers as input. But I am using doubles here,
  *       with the hope of getting more accurate results.
  */
-constexpr auto compute(const double year) -> double {
+[[nodiscard]] constexpr auto compute(const double year) -> double {
   if (year < -4000) {
     throw std::out_of_range {
       std::vformat("Year {} is not supported by algorithm 1.", std::make_format_args(year))
@@ -191,7 +191,7 @@ namespace algo2 {
  * 
  * @ref https://eclipse.gsfc.nasa.gov/SEcat5/deltatpoly.html
  */
-constexpr auto compute(const double year) noexcept -> double {
+[[nodiscard]] constexpr auto compute(const double year) noexcept -> double {
   if (year < -500) {
     const double u = (year - 1820) / 100.0;
     return -20.0 + 32.0 * std::pow(u, 2);
@@ -303,7 +303,7 @@ namespace algo3 {
  * 
  * @ref https://eclipsewise.com/help/deltatpoly2014.html
  */
-constexpr auto compute(const double year) -> double {
+[[nodiscard]] constexpr auto compute(const double year) -> double {
   if (year >= 3000) {
     throw std::out_of_range {
       std::vformat("Year {} is not supported by algorithm 3.", std::make_format_args(year))
@@ -360,7 +360,7 @@ namespace algo4 {
  * @note For 2005.0 <= year < 2024.0, poly model trained on Bulletin A data is used.
  * @note For 2024.0 <= year < 2035.0, poly model trained on USNO ΔT predictions (deltat.preds) is used.
  */
-constexpr auto compute(const double year) -> double {
+[[nodiscard]] constexpr auto compute(const double year) -> double {
   if (year >= 2035) {
     throw std::out_of_range {
       std::format("The year {} is out of range for algorithm 4.", year)
@@ -422,7 +422,7 @@ inline constexpr double LAST_OBSERVATION_YEAR = 2026.4135844748857;
  * @note There is no upper bound: beyond the last observation, the anchored integrated-lod
  *       curve extrapolates smoothly for all future years.
  */
-constexpr auto compute(const double year) noexcept -> double {
+[[nodiscard]] constexpr auto compute(const double year) noexcept -> double {
   if (year < 2005) {
     return algo2::compute(year);
   }
@@ -458,7 +458,7 @@ constexpr auto compute(const double year) noexcept -> double {
  * @example `compute(1984.0)` returns the delta T for the first moment of year 1984.
  * @example `compute(2015.5)` returns the delta T for the middle moment of year 2015 (roughly June 30/July 1).
  */
-constexpr auto compute(const double year) noexcept -> double {
+[[nodiscard]] constexpr auto compute(const double year) noexcept -> double {
   return algo5::compute(year);
 }
 
@@ -471,7 +471,7 @@ constexpr auto compute(const double year) noexcept -> double {
  * @note Some caller are passing `calendar::Datetime` in UT1, and some are passing `calendar::Datetime` in TT.
  *       Considering the longness of a year, the difference between `UT1` and `TT` is ignored.
  */
-constexpr auto compute(const calendar::Datetime& ut1_dt) -> double {
+[[nodiscard]] constexpr auto compute(const calendar::Datetime& ut1_dt) -> double {
   using namespace std::chrono;
   using namespace util::ymd_operator;
 
@@ -498,7 +498,7 @@ constexpr auto compute(const calendar::Datetime& ut1_dt) -> double {
  * @param ut1_dt The datetime in UT1.
  * @return The datetime in TT.
  */
-constexpr auto ut1_to_tt(const calendar::Datetime& ut1_dt) -> calendar::Datetime {
+[[nodiscard]] constexpr auto ut1_to_tt(const calendar::Datetime& ut1_dt) -> calendar::Datetime {
   // As per the formula, TT = UT1 + ΔT.
   return calendar::add_seconds(ut1_dt, compute(ut1_dt));
 }
@@ -509,7 +509,7 @@ constexpr auto ut1_to_tt(const calendar::Datetime& ut1_dt) -> calendar::Datetime
  * @param tt_dt The datetime in TT.
  * @return The datetime in UT1.
  */
-constexpr auto tt_to_ut1(const calendar::Datetime& tt_dt) -> calendar::Datetime {
+[[nodiscard]] constexpr auto tt_to_ut1(const calendar::Datetime& tt_dt) -> calendar::Datetime {
   // As per the formula, UT1 = TT - ΔT.
   return calendar::add_seconds(tt_dt, -compute(tt_dt));
 }

--- a/src/astro/earth.hpp
+++ b/src/astro/earth.hpp
@@ -43,7 +43,7 @@ namespace astro::earth::heliocentric_coord {
  * @param jde The julian ephemeris day number, which is based on TT.
  * @return The heliocentric ecliptic position of the Earth, calculated using VSOP87D.
  */
-inline auto vsop87d(const double jde) -> toolbox::SphericalCoordinate {
+[[nodiscard]] inline auto vsop87d(const double jde) -> toolbox::SphericalCoordinate {
   const double jm = astro::julian_day::jde_to_jm(jde);
   const auto evaluated = astro::vsop87d::evaluate<vsop87d::Planet::EAR>(jm);
 
@@ -273,7 +273,7 @@ inline constexpr std::array<NutationCoeffs, 106> IAU1980_NUTATION_COEFFS {{
 enum class Model : uint8_t { MEEUS, IAU_1980 };
 
 /** @brief Find the nutation coefficients for the given model. */
-inline auto find_model(const Model model) -> std::span<const NutationCoeffs> {
+[[nodiscard]] inline auto find_model(const Model model) -> std::span<const NutationCoeffs> {
   switch (model) {
     case Model::MEEUS:    return { MEEUS_NUTATION_COEFFS };
     case Model::IAU_1980: return { IAU1980_NUTATION_COEFFS };
@@ -291,7 +291,7 @@ inline auto find_model(const Model model) -> std::span<const NutationCoeffs> {
  *       of every nutation evaluation (#98).
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 22.
  */
-inline auto gen_eval_θ(const double jc) {
+[[nodiscard]] inline auto gen_eval_θ(const double jc) {
   const double jc2 = jc * jc;
   const double jc3 = jc * jc2;
 
@@ -324,7 +324,7 @@ inline auto gen_eval_θ(const double jc) {
  *       each body mirrors its own Meeus summation — so fix both or neither (#49).
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 22.
  */
-inline auto longitude(const double jde, const Model model = Model::IAU_1980) -> toolbox::AngleDeg {
+[[nodiscard]] inline auto longitude(const double jde, const Model model = Model::IAU_1980) -> toolbox::AngleDeg {
   // Get the Julian century since J2000.
   const double jc = astro::julian_day::jde_to_jc(jde);
 
@@ -362,7 +362,7 @@ inline auto longitude(const double jde, const Model model = Model::IAU_1980) -> 
  *       each body mirrors its own Meeus summation — so fix both or neither (#49).
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 22.
  */
-inline auto obliquity(const double jde, const Model model = Model::IAU_1980) -> toolbox::AngleDeg {
+[[nodiscard]] inline auto obliquity(const double jde, const Model model = Model::IAU_1980) -> toolbox::AngleDeg {
   // Get the Julian century since J2000.
   const double jc = astro::julian_day::jde_to_jc(jde);
 
@@ -403,7 +403,7 @@ namespace astro::earth::obliquity {
  * @details Accuracy ~1" over ±2000 years from J2000; the polynomial degrades farther out.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 22, Formula (22.2).
  */
-inline auto mean(const double jde) -> toolbox::AngleDeg {
+[[nodiscard]] inline auto mean(const double jde) -> toolbox::AngleDeg {
   // Get the Julian century since J2000.
   const double jc = astro::julian_day::jde_to_jc(jde);
 
@@ -421,7 +421,7 @@ inline auto mean(const double jde) -> toolbox::AngleDeg {
  * @return The true obliquity (ε = ε₀ + Δε) in degrees.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 22.
  */
-inline auto true_obliquity(
+[[nodiscard]] inline auto true_obliquity(
   const double jde,
   const nutation::Model model = nutation::Model::IAU_1980
 ) -> toolbox::AngleDeg {
@@ -482,7 +482,7 @@ inline constexpr std::array<DailyVariationTerm, 21> MEEUS_DAILY_VARIATION_TERMS 
  *       3548.193 is for the fixed J2000 frame (p. 168 note).
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, p. 168.
  */
-inline auto daily_λ_variation(const double jde) -> double {
+[[nodiscard]] inline auto daily_λ_variation(const double jde) -> double {
   using namespace std::ranges;
   const double τ = astro::julian_day::jde_to_jm(jde);
   const auto terms = MEEUS_DAILY_VARIATION_TERMS | views::transform([τ](const DailyVariationTerm& t) {
@@ -509,7 +509,7 @@ inline constexpr double LIGHT_TIME_DAYS_PER_AU = 0.0057755183;
  *       κ(1−e²), not the bare aberration constant κ = 20.49552″ (#66).
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, (25.10)-(25.11), p. 167-168.
  */
-inline auto compute(const double jde, const toolbox::DistanceAu r) -> toolbox::AngleDeg {
+[[nodiscard]] inline auto compute(const double jde, const toolbox::DistanceAu r) -> toolbox::AngleDeg {
   const double aberration_arcsec = LIGHT_TIME_DAYS_PER_AU * r.au() * daily_λ_variation(jde);
   return toolbox::AngleDeg::from_arcsec(aberration_arcsec);
 }

--- a/src/astro/elp2000_82b.hpp
+++ b/src/astro/elp2000_82b.hpp
@@ -229,7 +229,7 @@ struct Context {
  * @return The created context.
  * @see Astronomical Algorithms, Jean Meeus, 1998, Chapter 47.
  */
-inline auto create_context(const double jc) -> Context {
+[[nodiscard]] inline auto create_context(const double jc) -> Context {
   const double jc2 = jc * jc;
   const double jc3 = jc2 * jc;
   const double jc4 = jc3 * jc;
@@ -279,7 +279,7 @@ struct Evaluation {
  * @return The evaluated result.
  * @see Astronomical Algorithms, Jean Meeus, 1998, Chapter 47.
  */
-inline auto evaluate(const double jc) -> Evaluation {
+[[nodiscard]] inline auto evaluate(const double jc) -> Evaluation {
   using namespace std::ranges;
 
   const auto ctx = create_context(jc);

--- a/src/astro/elp2000_82b.hpp
+++ b/src/astro/elp2000_82b.hpp
@@ -258,7 +258,7 @@ struct Context {
     .A3 = A3.normalize(),
     .E  = E
   };
-};
+}
 
 
 /**
@@ -329,6 +329,6 @@ struct Evaluation {
     .Σr  = std::reduce(cbegin(rad_terms), cend(rad_terms)),
     .ctx = ctx
   };
-};
+}
 
 } // namespace astro::elp2000_82b

--- a/src/astro/julian_day.hpp
+++ b/src/astro/julian_day.hpp
@@ -280,7 +280,7 @@ inline constexpr double J2000 = 2451545.0;
 
 
 /**
- * @brief Converts a julian day number to julian millennium.
+ * @brief Converts a julian ephemeris day number to julian millennium.
  * @param jde The julian ephemeris day number, which is based on TT.
  * @return The julian millennium since J2000.
  */
@@ -289,7 +289,7 @@ inline constexpr double J2000 = 2451545.0;
 }
 
 /**
- * @brief Converts a julian millennium to julian day number.
+ * @brief Converts a julian millennium to julian ephemeris day number.
  * @param jm The julian millennium since J2000.
  * @return The julian ephemeris day number, which is based on TT.
  */
@@ -299,8 +299,8 @@ inline constexpr double J2000 = 2451545.0;
 
 
 /**
- * @brief Converts a julian day number to julian century.
- * @param jde The julian day number.
+ * @brief Converts a julian ephemeris day number to julian century.
+ * @param jde The julian ephemeris day number, which is based on TT.
  * @return The julian century since J2000.
  */
 [[nodiscard]] constexpr auto jde_to_jc(const double jde) -> double {
@@ -309,7 +309,7 @@ inline constexpr double J2000 = 2451545.0;
 
 
 /**
- * @brief Converts a julian century to julian day number.
+ * @brief Converts a julian century to julian ephemeris day number.
  * @param jc The julian century since J2000.
  * @return The julian ephemeris day number, which is based on TT.
  */

--- a/src/astro/julian_day.hpp
+++ b/src/astro/julian_day.hpp
@@ -94,9 +94,7 @@ inline constexpr double J2000 = 2451545.0;
   // `C` below is the part that looks wrong and is not: for any year past ~200 the true value of
   // `2 - A + B` is negative, so the `uint32_t` holds its mod-2^32 image. That image is only ever
   // consumed by `C + D + E + F`, which is evaluated in the same modular arithmetic and lands back
-  // on the exact value -- verified over years 1..9999 x 12 months: 116398 of 119988 cases have a
-  // negative true `2 - A + B`, and the uint32 sum matches the int64 sum in all 119988. The final
-  // sum peaks around 5.4e6, nowhere near 2^32.
+  // on the exact value. The final sum peaks around 5.4e6, nowhere near 2^32.
   //
   // Do not "fix" `C` into a signed type on its own: that breaks the cancellation.
   const uint32_t Y = (g_m <= 2) ? g_y - 1 : g_y;

--- a/src/astro/julian_day.hpp
+++ b/src/astro/julian_day.hpp
@@ -57,7 +57,7 @@ inline constexpr double J2000 = 2451545.0;
  * @note Years 1-400 convert forward, but sit below `jd_to_ut1`'s year-401 bound — round-trips
  *       only close from 401-01-01 onwards.
  */
-inline auto ut1_to_jd(const calendar::Datetime& ut1_dt) -> double {
+[[nodiscard]] inline auto ut1_to_jd(const calendar::Datetime& ut1_dt) -> double {
   /*
     Ref: https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
     The algorithm is as follows:
@@ -88,8 +88,17 @@ inline auto ut1_to_jd(const calendar::Datetime& ut1_dt) -> double {
   }
 
   // NOLINTBEGIN
-  // The following code is doing narrowing-conversions. 
+  // The following code is doing narrowing-conversions.
   // But keep it as-is for matching the original algorithm expressions.
+  //
+  // `C` below is the part that looks wrong and is not: for any year past ~200 the true value of
+  // `2 - A + B` is negative, so the `uint32_t` holds its mod-2^32 image. That image is only ever
+  // consumed by `C + D + E + F`, which is evaluated in the same modular arithmetic and lands back
+  // on the exact value -- verified over years 1..9999 x 12 months: 116398 of 119988 cases have a
+  // negative true `2 - A + B`, and the uint32 sum matches the int64 sum in all 119988. The final
+  // sum peaks around 5.4e6, nowhere near 2^32.
+  //
+  // Do not "fix" `C` into a signed type on its own: that breaks the cancellation.
   const uint32_t Y = (g_m <= 2) ? g_y - 1 : g_y;
   const uint32_t M = (g_m <= 2) ? g_m + 12 : g_m;
   const uint32_t D = g_d;
@@ -116,7 +125,7 @@ inline auto ut1_to_jd(const calendar::Datetime& ut1_dt) -> double {
  * @note `ut1_to_jd(32767-12-31, fraction ≈ 1)` rounds up to exactly the upper bound
  *       13689325.5, which this function rejects — a 1-ulp round-trip break callers must expect.
  */
-inline auto jd_to_ut1(const double jd) -> calendar::Datetime {
+[[nodiscard]] inline auto jd_to_ut1(const double jd) -> calendar::Datetime {
   /*
     Ref: https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
     The algorithm is as follows:
@@ -167,8 +176,12 @@ inline auto jd_to_ut1(const double jd) -> calendar::Datetime {
   }
 
   // NOLINTBEGIN
-  // The following code is doing narrowing-conversions. 
+  // The following code is doing narrowing-conversions.
   // But keep it as-is for matching the original algorithm expressions.
+  //
+  // Each `uint32_t` assignment is the book's integer-floor step. They are safe here because both
+  // ends of `jd` are already guarded above: below 1867522.5 and at or past 13689325.5 the function
+  // has thrown, so no intermediate goes negative or wraps.
   const double   Q = jd + 0.5;
   const uint32_t Z = Q;
   const uint32_t W = (Z - 1867216.25) / 36524.25;
@@ -205,7 +218,7 @@ inline auto jd_to_ut1(const double jd) -> calendar::Datetime {
  * @param tt_dt The date and time (TT).
  * @return The julian ephemeris day number, which is based on TT (not UT1).
  */
-inline auto tt_to_jde(const calendar::Datetime& tt_dt) -> double {
+[[nodiscard]] inline auto tt_to_jde(const calendar::Datetime& tt_dt) -> double {
   // In my understanding, the process of converting UT1->JD and TT->JDE is the same.
   return ut1_to_jd(tt_dt);
 }
@@ -216,7 +229,7 @@ inline auto tt_to_jde(const calendar::Datetime& tt_dt) -> double {
  * @param jde The julian ephemeris day number, which is based on TT (not UT1).
  * @return The date and time, in TT.
  */
-inline auto jde_to_tt(const double jde) -> calendar::Datetime {
+[[nodiscard]] inline auto jde_to_tt(const double jde) -> calendar::Datetime {
   // In my understanding, the process of converting UT1->JD and TT->JDE is the same.
   return jd_to_ut1(jde);
 }
@@ -227,7 +240,7 @@ inline auto jde_to_tt(const double jde) -> calendar::Datetime {
  * @param jde The julian ephemeris day number, which is based on TT.
  * @return The date and time, in UT1.
  */
-inline auto jde_to_ut1(const double jde) -> calendar::Datetime {
+[[nodiscard]] inline auto jde_to_ut1(const double jde) -> calendar::Datetime {
   const auto tt_dt = jde_to_tt(jde);
   return astro::delta_t::tt_to_ut1(tt_dt);
 }
@@ -238,7 +251,7 @@ inline auto jde_to_ut1(const double jde) -> calendar::Datetime {
  * @param ut1_dt The date and time, in UT1.
  * @return The julian ephemeris day number, which is based on TT.
  */
-inline auto ut1_to_jde(const calendar::Datetime& ut1_dt) -> double {
+[[nodiscard]] inline auto ut1_to_jde(const calendar::Datetime& ut1_dt) -> double {
   const auto tt_dt = astro::delta_t::ut1_to_tt(ut1_dt);
   return tt_to_jde(tt_dt);
 }
@@ -250,7 +263,7 @@ inline auto ut1_to_jde(const calendar::Datetime& ut1_dt) -> double {
  * @return The date and time, in UTC.
  * @note Before modern UTC (1972-01-01) this degrades to UT1; see `astro::leap_second::tt_to_utc`.
  */
-inline auto jde_to_utc(const double jde) -> calendar::Datetime {
+[[nodiscard]] inline auto jde_to_utc(const double jde) -> calendar::Datetime {
   return astro::leap_second::tt_to_utc(jde_to_tt(jde));
 }
 
@@ -261,7 +274,7 @@ inline auto jde_to_utc(const double jde) -> calendar::Datetime {
  * @return The julian ephemeris day number, which is based on TT.
  * @note Before modern UTC (1972-01-01) this degrades to UT1; see `astro::leap_second::utc_to_tt`.
  */
-inline auto utc_to_jde(const calendar::Datetime& utc_dt) -> double {
+[[nodiscard]] inline auto utc_to_jde(const calendar::Datetime& utc_dt) -> double {
   return tt_to_jde(astro::leap_second::utc_to_tt(utc_dt));
 }
 
@@ -271,7 +284,7 @@ inline auto utc_to_jde(const calendar::Datetime& utc_dt) -> double {
  * @param jde The julian ephemeris day number, which is based on TT.
  * @return The julian millennium since J2000.
  */
-constexpr auto jde_to_jm(const double jde) -> double {
+[[nodiscard]] constexpr auto jde_to_jm(const double jde) -> double {
   return (jde - J2000) / 365250.0;
 }
 
@@ -280,7 +293,7 @@ constexpr auto jde_to_jm(const double jde) -> double {
  * @param jm The julian millennium since J2000.
  * @return The julian ephemeris day number, which is based on TT.
  */
-constexpr auto jm_to_jde(const double jm) -> double {
+[[nodiscard]] constexpr auto jm_to_jde(const double jm) -> double {
   return jm * 365250.0 + J2000;
 }
 
@@ -290,7 +303,7 @@ constexpr auto jm_to_jde(const double jm) -> double {
  * @param jde The julian day number.
  * @return The julian century since J2000.
  */
-constexpr auto jde_to_jc(const double jde) -> double {
+[[nodiscard]] constexpr auto jde_to_jc(const double jde) -> double {
   return (jde - J2000) / 36525.0;
 }
 
@@ -300,7 +313,7 @@ constexpr auto jde_to_jc(const double jde) -> double {
  * @param jc The julian century since J2000.
  * @return The julian ephemeris day number, which is based on TT.
  */
-constexpr auto jc_to_jde(const double jc) -> double {
+[[nodiscard]] constexpr auto jc_to_jde(const double jc) -> double {
   return jc * 36525.0 + J2000;
 }
 

--- a/src/astro/julian_day.hpp
+++ b/src/astro/julian_day.hpp
@@ -94,7 +94,8 @@ inline constexpr double J2000 = 2451545.0;
   // `C` below is the part that looks wrong and is not: for any year past ~200 the true value of
   // `2 - A + B` is negative, so the `uint32_t` holds its mod-2^32 image. That image is only ever
   // consumed by `C + D + E + F`, which is evaluated in the same modular arithmetic and lands back
-  // on the exact value. The final sum peaks around 5.4e6, nowhere near 2^32.
+  // on the exact value -- checked exhaustively over years 1..9999 x 12 months. The final sum
+  // peaks around 5.4e6, nowhere near 2^32.
   //
   // Do not "fix" `C` into a signed type on its own: that breaks the cancellation.
   const uint32_t Y = (g_m <= 2) ? g_y - 1 : g_y;

--- a/src/astro/leap_second.hpp
+++ b/src/astro/leap_second.hpp
@@ -106,7 +106,7 @@ inline constexpr std::chrono::year_month_day MODERN_UTC_START = LEAP_SECOND_TABL
  * @return ΔAT, in seconds.
  * @throw std::invalid_argument if the date predates modern UTC (1972-01-01).
  */
-constexpr auto tai_minus_utc(const std::chrono::year_month_day& utc_ymd) -> double {
+[[nodiscard]] constexpr auto tai_minus_utc(const std::chrono::year_month_day& utc_ymd) -> double {
   if (utc_ymd < MODERN_UTC_START) {
     throw std::invalid_argument {
       std::vformat("ΔAT is undefined before modern UTC (1972-01-01), got {}",
@@ -127,7 +127,7 @@ constexpr auto tai_minus_utc(const std::chrono::year_month_day& utc_ymd) -> doub
  * @return TT − UTC, in seconds.
  * @throw std::invalid_argument if the date predates modern UTC (1972-01-01).
  */
-constexpr auto tt_minus_utc(const std::chrono::year_month_day& utc_ymd) -> double {
+[[nodiscard]] constexpr auto tt_minus_utc(const std::chrono::year_month_day& utc_ymd) -> double {
   return TT_MINUS_TAI_SEC + tai_minus_utc(utc_ymd);
 }
 
@@ -143,7 +143,7 @@ constexpr auto tt_minus_utc(const std::chrono::year_month_day& utc_ymd) -> doubl
  * @note A `Datetime` cannot carry an inserted second 23:59:60 itself; the conversion is
  *       defined on the representable instants around it.
  */
-constexpr auto utc_to_tt(const calendar::Datetime& utc_dt) -> calendar::Datetime {
+[[nodiscard]] constexpr auto utc_to_tt(const calendar::Datetime& utc_dt) -> calendar::Datetime {
   if (utc_dt.ymd < MODERN_UTC_START) {
     return delta_t::ut1_to_tt(utc_dt);
   }
@@ -169,7 +169,7 @@ constexpr auto utc_to_tt(const calendar::Datetime& utc_dt) -> calendar::Datetime
  *       conversion is not invertible, and `utc_to_tt(tt_to_utc(tt))` returns `tt` plus one
  *       second.
  */
-constexpr auto tt_to_utc(const calendar::Datetime& tt_dt) -> calendar::Datetime {
+[[nodiscard]] constexpr auto tt_to_utc(const calendar::Datetime& tt_dt) -> calendar::Datetime {
   if (tt_dt.ymd < MODERN_UTC_START) {
     return delta_t::tt_to_ut1(tt_dt);
   }

--- a/src/astro/moon.hpp
+++ b/src/astro/moon.hpp
@@ -41,7 +41,7 @@ namespace astro::moon::perturbation {
  * @return The perturbation of the Moon's geocentric longitude. Unit is 0.000001 degrees.
  * @see Astronomical Algorithms, Jean Meeus, 1998, Chapter 47.
  */
-inline auto longitude(const elp2000_82b::Context& ctx) -> double {
+[[nodiscard]] inline auto longitude(const elp2000_82b::Context& ctx) -> double {
   return 3958.0 * std::sin(ctx.A1.rad()) 
        + 1962.0 * std::sin(ctx.Lp.rad() - ctx.F.rad()) 
        + 318.0 * std::sin(ctx.A2.rad());
@@ -56,7 +56,7 @@ inline auto longitude(const elp2000_82b::Context& ctx) -> double {
  * @return The perturbation of the Moon's geocentric latitude. Unit is 0.000001 degrees.
  * @see Astronomical Algorithms, Jean Meeus, 1998, Chapter 47.
  */
-inline auto latitude(const elp2000_82b::Context& ctx) -> double {
+[[nodiscard]] inline auto latitude(const elp2000_82b::Context& ctx) -> double {
   return -2235.0 * std::sin(ctx.Lp.rad())
        + 382.0 * std::sin(ctx.A3.rad())
        + 175.0 * std::sin(ctx.A1.rad() - ctx.F.rad())
@@ -71,11 +71,18 @@ inline auto latitude(const elp2000_82b::Context& ctx) -> double {
 namespace astro::moon::geocentric_coord {
 
 /**
+ * @brief Earth's equatorial radius, in kilometers.
+ * @ref Astronomical Algorithms, Jean Meeus, 1998, Chapter 47 -- the equatorial horizontal parallax
+ *      is `asin(6378.14 / r)`, with `r` the Earth-Moon distance in the same unit.
+ */
+inline constexpr double EARTH_EQUATORIAL_RADIUS_KM = 6378.14;
+
+/**
  * @brief Calculate the apparent geocentric position of the Moon, using truncated ELP2000-82B.
  * @param jde The julian ephemeris day number, which is based on TT.
  * @return The geocentric ecliptic position of the Moon, calculated using truncated ELP2000-82B.
  */
-inline auto apparent(const double jde) -> toolbox::SphericalCoordinate {
+[[nodiscard]] inline auto apparent(const double jde) -> toolbox::SphericalCoordinate {
   const double jc = astro::julian_day::jde_to_jc(jde);
 
   const auto evaluated = elp2000_82b::evaluate(jc);
@@ -105,8 +112,8 @@ inline auto apparent(const double jde) -> toolbox::SphericalCoordinate {
  * @param distance The geocentric distance of the Moon.
  * @return The equatorial horizontal parallax of the Moon.
  */
-inline auto equatorial_horizontal_parallax(const toolbox::DistanceKm& distance) -> toolbox::AngleRad {
-  const auto ppi_rad = std::asin(6378.14 / distance.km());
+[[nodiscard]] inline auto equatorial_horizontal_parallax(const toolbox::DistanceKm& distance) -> toolbox::AngleRad {
+  const auto ppi_rad = std::asin(EARTH_EQUATORIAL_RADIUS_KM / distance.km());
   return toolbox::AngleRad { ppi_rad };
 }
 

--- a/src/astro/moon_phase.hpp
+++ b/src/astro/moon_phase.hpp
@@ -205,7 +205,7 @@ public:
     _root = first_root;
   }
 
-  auto next() -> double {
+  [[nodiscard]] auto next() -> double {
     const double root = _root;
     _root = next_root(_root);
     return root;

--- a/src/astro/moon_phase.hpp
+++ b/src/astro/moon_phase.hpp
@@ -188,7 +188,7 @@ inline constexpr double BRACKET_HALF_WIDTH_DAYS = 0.5;
   const auto next_root_range = first_root_range_after(jde + 1.0); // Add 1.0 in case `jde_lon_diff` falls into [359.0, 360.0).
   const auto [left, right] = next_root_range;
   return newton_method(left, right);
-};
+}
 
 /**
  * @brief Generator for finding the roots (i.e. conjunction moments of the Sun and Moon).

--- a/src/astro/moon_phase.hpp
+++ b/src/astro/moon_phase.hpp
@@ -51,7 +51,7 @@ namespace astro::moon_phase::new_moon {
  * @return The normalized difference between the apparent longitudes of the Moon and the Sun, in degrees.
  * @see VSOP87D, ELP2000-82B, and Astronomical Algorithms, Jean Meeus, 1998.
  */
-inline auto longitude_diff(const double jde) -> double {
+[[nodiscard]] inline auto longitude_diff(const double jde) -> double {
   const auto sun_apparent_lon = astro::sun::geocentric_coord::apparent(jde).λ;
   const auto moon_apparent_lon = astro::moon::geocentric_coord::apparent(jde).λ;
   const auto diff = moon_apparent_lon - sun_apparent_lon;
@@ -76,7 +76,7 @@ inline constexpr double BRACKET_TOLERANCE_DEG = 15.0;
  * @note It is the caller's responsibility to ensure the root exists in the range of [left_jde, right_jde).
  * @throw std::invalid_argument If no root exists in the range of [left_jde, right_jde).
  */
-inline auto newton_method(
+[[nodiscard]] inline auto newton_method(
   const double left_jde,
   const double right_jde,            // NOLINT(bugprone-easily-swappable-parameters)
   const std::size_t iterations = astro::toolbox::NEWTON_MAX_ITERATIONS
@@ -138,7 +138,7 @@ inline constexpr double BRACKET_HALF_WIDTH_DAYS = 0.5;
  * @throw std::invalid_argument If the extrapolation lands further than `ESTIMATE_TOLERANCE_DEG`
  *        from conjunction, i.e. too far off to be worth refining.
  */
-inline auto first_root_range_after(const double jde) -> std::pair<double, double> {
+[[nodiscard]] inline auto first_root_range_after(const double jde) -> std::pair<double, double> {
   const double cur_diff = longitude_diff(jde);
   const double gap = 360.0 - cur_diff;
 
@@ -177,7 +177,7 @@ inline auto first_root_range_after(const double jde) -> std::pair<double, double
  * @param jde The jde. This is expected to be a root.
  * @return The next root jde.
  */
-inline auto next_root(const double jde) -> double {
+[[nodiscard]] inline auto next_root(const double jde) -> double {
   const double jde_lon_diff = longitude_diff(jde);
   if (1.0 < jde_lon_diff and jde_lon_diff < 359.0) [[unlikely]] {
     throw std::invalid_argument {
@@ -205,7 +205,7 @@ public:
     _root = first_root;
   }
 
-  auto next() -> double {
+  [[nodiscard]] auto next() -> double {
     const double root = _root;
     _root = next_root(_root);
     return root;
@@ -223,7 +223,7 @@ public:
  * @details The Moon's position is calculated using truncated ELP2000-82B.
  * @see VSOP87D, ELP2000-82B, and Astronomical Algorithms, Jean Meeus, 1998.
  */
-inline auto moments(const int32_t year) -> std::vector<double> {
+[[nodiscard]] inline auto moments(const int32_t year) -> std::vector<double> {
   // The first moment of the year, inclusive.
   const calendar::Datetime start_moment_utc {
     util::to_ymd(year, 1, 1),

--- a/src/astro/moon_phase.hpp
+++ b/src/astro/moon_phase.hpp
@@ -205,7 +205,7 @@ public:
     _root = first_root;
   }
 
-  [[nodiscard]] auto next() -> double {
+  auto next() -> double {
     const double root = _root;
     _root = next_root(_root);
     return root;

--- a/src/astro/sidereal_time.hpp
+++ b/src/astro/sidereal_time.hpp
@@ -48,7 +48,7 @@ namespace astro::sidereal {
  *       is TT-based.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 12, Formulas (12.2)-(12.4).
  */
-inline auto greenwich_mean(const double jd_ut1) -> astro::toolbox::AngleDeg {
+[[nodiscard]] inline auto greenwich_mean(const double jd_ut1) -> astro::toolbox::AngleDeg {
   using astro::toolbox::AngleDeg;
 
   // Days and julian centuries of *universal* time since J2000.0 UT.
@@ -76,7 +76,7 @@ inline auto greenwich_mean(const double jd_ut1) -> astro::toolbox::AngleDeg {
  *       (|Δψ| itself can reach ~19").
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 12 (and Chapter 22 for Δψ, ε).
  */
-inline auto greenwich_apparent(
+[[nodiscard]] inline auto greenwich_apparent(
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters): the jd_ut1/jde_tt naming is the UT1/TT guard (issue #41).
   const double jd_ut1,
   const double jde_tt,
@@ -105,7 +105,7 @@ inline auto greenwich_apparent(
  *       consistent with Meeus's hour-angle formula H = θ₀ − L − α used from Chapter 13 onward.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapter 12.
  */
-inline auto local_apparent(
+[[nodiscard]] inline auto local_apparent(
   const double jd_ut1,
   const double jde_tt,
   const astro::toolbox::AngleDeg& longitude_west,

--- a/src/astro/solar_time.hpp
+++ b/src/astro/solar_time.hpp
@@ -52,7 +52,7 @@ namespace detail {
  * @return L0, unnormalized.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Formula (28.2).
  */
-constexpr auto sun_mean_longitude(const double jde_tt) -> astro::toolbox::AngleDeg {
+[[nodiscard]] constexpr auto sun_mean_longitude(const double jde_tt) -> astro::toolbox::AngleDeg {
   using astro::toolbox::AngleDeg;
 
   const double τ = astro::julian_day::jde_to_jm(jde_tt);
@@ -78,7 +78,7 @@ constexpr auto sun_mean_longitude(const double jde_tt) -> astro::toolbox::AngleD
  *          the mean longitude L0 can sit on opposite sides of the 0°/360° seam.
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Formula (28.1).
  */
-inline auto equation_of_time(const double jde_tt) -> astro::toolbox::AngleDeg {
+[[nodiscard]] inline auto equation_of_time(const double jde_tt) -> astro::toolbox::AngleDeg {
   using astro::toolbox::AngleDeg;
   using astro::toolbox::normalize_pm180;
 
@@ -108,7 +108,7 @@ inline auto equation_of_time(const double jde_tt) -> astro::toolbox::AngleDeg {
  *       longitude offset is a label shift, not a time shift), so no fixed-point
  *       evaluation is needed.
  */
-inline auto apparent(
+[[nodiscard]] inline auto apparent(
   const calendar::Datetime& utc_dt,
   const astro::toolbox::AngleDeg& longitude
 ) -> calendar::Datetime {

--- a/src/astro/sun.hpp
+++ b/src/astro/sun.hpp
@@ -43,7 +43,7 @@ namespace astro::sun::geocentric_coord {
  * @details The function invokes `astro::earth::heliocentric_coord::vsop87d`, and
  *          transforms the heliocentric coordinates to geocentric coordinates.
  */
-inline auto vsop87d(const double jde) -> toolbox::SphericalCoordinate {
+[[nodiscard]] inline auto vsop87d(const double jde) -> toolbox::SphericalCoordinate {
   const auto& [λ_helio, β_helio, r_helio] = astro::earth::heliocentric_coord::vsop87d(jde);
   return {
     // Convert the heliocentric ecliptic longitude of Earth to geocentric ecliptic longitude of Sun.
@@ -77,7 +77,7 @@ struct Fk5Correction {
  * @return The correction (i.e. Δlongitude and Δlatitude).
  * @details As per Jean Meeus's Astronomical Algorithms, this correction is applied for accuracy.
  */
-inline auto fk5_correction(const double jde, const toolbox::SphericalCoordinate& vsop87d_coord) -> Fk5Correction {
+[[nodiscard]] inline auto fk5_correction(const double jde, const toolbox::SphericalCoordinate& vsop87d_coord) -> Fk5Correction {
   const double jc = astro::julian_day::jde_to_jc(jde);
   const auto& [vsop_λ, vsop_β, vsop_r] = vsop87d_coord;
 
@@ -101,7 +101,7 @@ inline auto fk5_correction(const double jde, const toolbox::SphericalCoordinate&
  * @param jde The julian ephemeris day number, which is based on TT.
  * @return The geocentric ecliptic position of the Sun, after correction.
  */
-inline auto apparent(const double jde) -> toolbox::SphericalCoordinate {
+[[nodiscard]] inline auto apparent(const double jde) -> toolbox::SphericalCoordinate {
   // Use VSOP87D to calculate the geocentric ecliptic position of the Sun.
   const auto vsop_coord = vsop87d(jde);
 
@@ -142,7 +142,7 @@ namespace astro::sun::equatorial_coord {
  *          sunrise/sunset hour-angle calculations (Phase 5).
  * @ref Jean Meeus, "Astronomical Algorithms", Second Edition, Chapters 13 and 25.
  */
-inline auto apparent(const double jde) -> astro::coords::EquatorialCoord {
+[[nodiscard]] inline auto apparent(const double jde) -> astro::coords::EquatorialCoord {
   const auto ecl = astro::sun::geocentric_coord::apparent(jde);
   const auto ε = astro::earth::obliquity::true_obliquity(jde);
   return astro::coords::ecliptic_to_equatorial(ecl.λ, ecl.β, ε);
@@ -183,7 +183,7 @@ namespace detail {
  *       where the typed astronomy layer is handed over to it. Callers after a solar longitude
  *       want `geocentric_coord::apparent(jde).λ`, which keeps the unit in the type (#125).
  */
-inline auto solar_longitude(const double jde) -> double {
+[[nodiscard]] inline auto solar_longitude(const double jde) -> double {
   return astro::sun::geocentric_coord::apparent(jde).λ.deg();
 }
 
@@ -192,22 +192,22 @@ inline auto solar_longitude(const double jde) -> double {
 // path, matching `moments()` (#84). The UT1/UTC model gap (DUT1 ≤ 0.9 s in the leap era;
 // ≤ ~21 h at year 6772 with the ΔAT table frozen) stays well under the ~4-day clearance
 // between any jieqi and New Year — no year's attribution can move.
-inline auto get_start_jde(const int32_t year) -> double {
+[[nodiscard]] inline auto get_start_jde(const int32_t year) -> double {
   return astro::julian_day::utc_to_jde(calendar::Datetime { util::to_ymd(year, 1, 1), 0.0 });
 }
 
 /** @brief Return the JDE of the end of the year. */
-inline auto get_end_jde(const int32_t year) -> double {
+[[nodiscard]] inline auto get_end_jde(const int32_t year) -> double {
   return astro::julian_day::utc_to_jde(calendar::Datetime { util::to_ymd(year + 1, 1, 1), 0.0 });
 }
 
 /** @brief Return the apparent geocentric longitude of the Sun at the start of the year. */
-inline auto get_start_lon(const int32_t year) -> double {
+[[nodiscard]] inline auto get_start_lon(const int32_t year) -> double {
   return solar_longitude(get_start_jde(year));
 }
 
 /** @brief Return the apparent geocentric longitude of the Sun at the end of the year. */
-inline auto get_end_lon(const int32_t year) -> double {
+[[nodiscard]] inline auto get_end_lon(const int32_t year) -> double {
   return solar_longitude(get_end_jde(year));
 }
 
@@ -215,13 +215,13 @@ inline auto get_end_lon(const int32_t year) -> double {
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 
 /** @brief Return true if the given year has a root for the given `lon` before the spring equinox. */
-inline auto has_root_before_spring_equinox(const int32_t year, const double lon) -> bool {
+[[nodiscard]] inline auto has_root_before_spring_equinox(const int32_t year, const double lon) -> bool {
   const double start_lon = get_start_lon(year);
   return start_lon <= lon and lon < 360.0;
 }
 
 /** @brief Return true if the given year has a root for the given `lon` after the spring equinox. */
-inline auto has_root_after_spring_equinox(const int32_t year, const double lon) -> bool {
+[[nodiscard]] inline auto has_root_after_spring_equinox(const int32_t year, const double lon) -> bool {
   const double end_lon = get_end_lon(year);
   return 0.0 <= lon and lon < end_lon;
 }
@@ -246,7 +246,7 @@ inline auto has_root_after_spring_equinox(const int32_t year, const double lon) 
 // f(jde) = modified_solar_longitude(jde) - expected_lon
 
 /** @brief Return a `f` that we can apply Newton's method to. */
-inline auto make_f(const int32_t year, const double expected_lon) {
+[[nodiscard]] inline auto make_f(const int32_t year, const double expected_lon) {
   const double apr_1st_jde = astro::julian_day::ut1_to_jde(calendar::Datetime { util::to_ymd(year, 4, 1), 0.0 });
 
   const auto modified_solar_longitude = [=](const double jde) -> double {
@@ -281,7 +281,7 @@ inline auto make_f(const int32_t year, const double expected_lon) {
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 
 /** @brief Return the count of the roots for the given `year` and `lon`. */
-inline auto discriminant(const int32_t year, const double lon) -> uint32_t {
+[[nodiscard]] inline auto discriminant(const int32_t year, const double lon) -> uint32_t {
   uint32_t count = 0;
 
   if (detail::has_root_before_spring_equinox(year, lon)) {
@@ -300,7 +300,7 @@ inline auto discriminant(const int32_t year, const double lon) -> uint32_t {
  * @param expected_lon The expected solar longitude, in degrees.
  * @return The roots (i.e. JDEs). There can be 0, 1 or 2 roots.
  */
-inline auto find_roots(const int32_t year, const double expected_lon) -> std::vector<double> {
+[[nodiscard]] inline auto find_roots(const int32_t year, const double expected_lon) -> std::vector<double> {
   // Each predicate costs a full apparent-position evaluation at a year boundary. Going through
   // `discriminant` first would put the very same two questions a second time (#81).
   const bool root_before_equinox = detail::has_root_before_spring_equinox(year, expected_lon);

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -426,8 +426,8 @@ requires std::invocable<const Func&, double>
 
   double step = NEWTON_INITIAL_STEP_DAYS;
 
-  // `std::midpoint` is the correctly-rounded half-sum -- the same value the `(a + b) / 2` it
-  // replaced produced at JDE magnitudes. The swap buys overflow safety, not different numbers.
+  // `std::midpoint` is the correctly-rounded half-sum -- the same double the `(a + b) / 2` it
+  // replaced produced.
   double jde = std::midpoint(start_jde, end_jde);
 
   // Newton can walk away from a root it has already reached, so keep the best iterate rather

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -28,6 +28,7 @@
 #include <limits>
 #include <cstddef>
 #include <numbers>
+#include <numeric>
 #include <cstdint>
 #include <concepts>
 #include <algorithm>
@@ -424,7 +425,7 @@ inline auto newton_method(
   };
 
   double step = NEWTON_INITIAL_STEP_DAYS;
-  double jde  = (start_jde + end_jde) / 2.0;
+  double jde  = std::midpoint(start_jde, end_jde);
 
   // Newton can walk away from a root it has already reached, so keep the best iterate rather
   // than the last one — otherwise one bad late round overwrites a correct answer.

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -425,7 +425,10 @@ requires std::invocable<const Func&, double>
   };
 
   double step = NEWTON_INITIAL_STEP_DAYS;
-  double jde  = std::midpoint(start_jde, end_jde);
+
+  // `std::midpoint` is the correctly-rounded half-sum -- the same value the `(a + b) / 2` it
+  // replaced produced at JDE magnitudes. The swap buys overflow safety, not different numbers.
+  double jde = std::midpoint(start_jde, end_jde);
 
   // Newton can walk away from a root it has already reached, so keep the best iterate rather
   // than the last one — otherwise one bad late round overwrites a correct answer.

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -44,7 +44,7 @@ namespace astro::toolbox {
  * @throw std::invalid_argument If `deg` is not finite — a non-finite angle has no normal form,
  *        and returning one would pass it off as already normalized (#88).
  */
-constexpr auto normalize_deg(const double deg) -> double {
+[[nodiscard]] constexpr auto normalize_deg(const double deg) -> double {
   if (not std::isfinite(deg)) [[unlikely]] {
     throw std::invalid_argument {
       std::format("Argument `deg` is not finite, whose value is {}", deg)
@@ -64,7 +64,7 @@ constexpr auto normalize_deg(const double deg) -> double {
  * @throw std::invalid_argument If `rad` is not finite.
  * @note Twin of `normalize_deg` — same three edges, same order; the reasoning is written out there.
  */
-constexpr auto normalize_rad(const double rad) -> double {
+[[nodiscard]] constexpr auto normalize_rad(const double rad) -> double {
   if (not std::isfinite(rad)) [[unlikely]] {
     throw std::invalid_argument {
       std::format("Argument `rad` is not finite, whose value is {}", rad)
@@ -83,7 +83,7 @@ constexpr auto normalize_rad(const double rad) -> double {
  * @brief Normalize degree to [-180, 180). Useful for hour angles, where sign carries meaning.
  * @throw std::invalid_argument If `deg` is not finite — inherited from `normalize_deg`.
  */
-constexpr auto normalize_pm180(const double deg) -> double {
+[[nodiscard]] constexpr auto normalize_pm180(const double deg) -> double {
   const double _deg = normalize_deg(deg);
   return _deg >= 180.0 ? _deg - 360.0 : _deg;
 }
@@ -92,12 +92,12 @@ constexpr auto normalize_pm180(const double deg) -> double {
 inline constexpr double DEG_PER_RAD = 180.0 / std::numbers::pi;
 
 /** @brief Convert degree to radian. */
-constexpr auto deg_to_rad(const double deg) -> double {
+[[nodiscard]] constexpr auto deg_to_rad(const double deg) -> double {
   return deg / DEG_PER_RAD;
 }
 
 /** @brief Convert radian to degree. */
-constexpr auto rad_to_deg(const double rad) -> double {
+[[nodiscard]] constexpr auto rad_to_deg(const double rad) -> double {
   return rad * DEG_PER_RAD;
 }
 
@@ -133,12 +133,12 @@ inline constexpr uint32_t SEC_PER_MIN = 60;
 inline constexpr uint32_t SEC_PER_DEG = SEC_PER_MIN * MIN_PER_DEG;
 
 /** @brief Convert minutes to degrees. */
-constexpr auto arcmin_to_deg(const double arcmin) -> double {
+[[nodiscard]] constexpr auto arcmin_to_deg(const double arcmin) -> double {
   return arcmin / MIN_PER_DEG;
 }
 
 /** @brief Convert seconds to degrees. */
-constexpr auto arcsec_to_deg(const double arcsec) -> double {
+[[nodiscard]] constexpr auto arcsec_to_deg(const double arcsec) -> double {
   return arcsec / SEC_PER_DEG;
 }
 
@@ -158,12 +158,12 @@ struct Angle {
    * @brief Build an angle from a count of arcminutes, carried in this angle's own unit.
    * @note Arcminutes subdivide the degree, so the count lands in DEG and converts from there.
    */
-  constexpr static auto from_arcmin(const double value) -> Angle<Unit> {
+  [[nodiscard]] constexpr static auto from_arcmin(const double value) -> Angle<Unit> {
     return Angle<Unit> { Angle<AngleUnit::DEG> { arcmin_to_deg(value) } };
   }
 
   /** @brief Build an angle from a count of arcseconds, carried in this angle's own unit. */
-  constexpr static auto from_arcsec(const double value) -> Angle<Unit> {
+  [[nodiscard]] constexpr static auto from_arcsec(const double value) -> Angle<Unit> {
     return Angle<Unit> { Angle<AngleUnit::DEG> { arcsec_to_deg(value) } };
   }
 
@@ -173,19 +173,19 @@ struct Angle {
     return Angle<As> { as<As>() };
   }
 
-  constexpr auto operator+(const Angle<Unit>& other) const -> Angle<Unit> {
+  [[nodiscard]] constexpr auto operator+(const Angle<Unit>& other) const -> Angle<Unit> {
     return Angle<Unit> { _value + other._value };
   }
 
-  constexpr auto operator-(const Angle<Unit>& other) const -> Angle<Unit> {
+  [[nodiscard]] constexpr auto operator-(const Angle<Unit>& other) const -> Angle<Unit> {
     return Angle<Unit> { _value - other._value };
   }
 
-  constexpr auto operator-() const -> Angle<Unit> {
+  [[nodiscard]] constexpr auto operator-() const -> Angle<Unit> {
     return Angle<Unit> { -_value };
   }
 
-  constexpr auto operator*(const double other) const -> Angle<Unit> {
+  [[nodiscard]] constexpr auto operator*(const double other) const -> Angle<Unit> {
     return Angle<Unit> { _value * other };
   }
 
@@ -193,7 +193,7 @@ struct Angle {
    * @brief Divide the angle by a bare (dimensionless) factor.
    * @throws std::runtime_error if the divisor is zero — an infinite angle is never the intent (#48).
    */
-  constexpr auto operator/(const double other) const -> Angle<Unit> {
+  [[nodiscard]] constexpr auto operator/(const double other) const -> Angle<Unit> {
     if (other == 0.0) {
       throw std::runtime_error { "Division by zero." };
     }
@@ -265,19 +265,19 @@ using AngleRad = Angle<AngleUnit::RAD>;
 
 namespace literals {
 
-constexpr auto operator""_deg(const long double value) -> AngleDeg {
+[[nodiscard]] constexpr auto operator""_deg(const long double value) -> AngleDeg {
   return AngleDeg { static_cast<double>(value) };
 }
 
-constexpr auto operator""_arcmin(const long double value) -> AngleDeg {
+[[nodiscard]] constexpr auto operator""_arcmin(const long double value) -> AngleDeg {
   return AngleDeg::from_arcmin(static_cast<double>(value));
 }
 
-constexpr auto operator""_arcsec(const long double value) -> AngleDeg {
+[[nodiscard]] constexpr auto operator""_arcsec(const long double value) -> AngleDeg {
   return AngleDeg::from_arcsec(static_cast<double>(value));
 }
 
-constexpr auto operator""_rad(const long double value) -> AngleRad {
+[[nodiscard]] constexpr auto operator""_rad(const long double value) -> AngleRad {
   return AngleRad { static_cast<double>(value) };
 }
 
@@ -295,12 +295,12 @@ enum class DistanceUnit : uint8_t { AU, KM };
 inline constexpr double au_km_scale = 149597870.691; 
 
 /** @brief Convert from AU to KM. */
-constexpr auto au_to_km(const double au) -> double { 
+[[nodiscard]] constexpr auto au_to_km(const double au) -> double { 
   return au * au_km_scale; 
 }
 
 /** @brief Convert from KM to AU. */
-constexpr auto km_to_au(const double km) -> double { 
+[[nodiscard]] constexpr auto km_to_au(const double km) -> double { 
   return km / au_km_scale; 
 }
 
@@ -368,7 +368,7 @@ struct SphericalCoordinate {
  *       At JDE 2451545 (J2000.0) it is 4.7e-10 day (~40 μs); once `jde` crosses
  *       2^22 = 4194304 — that is 6771-07-07 — it steps up to 9.3e-10 day.
  */
-inline auto ulp(const double x) -> double {
+[[nodiscard]] inline auto ulp(const double x) -> double {
   const double magnitude = std::fabs(x);
   return std::nextafter(magnitude, std::numeric_limits<double>::infinity()) - magnitude;
 }
@@ -405,7 +405,7 @@ inline constexpr std::size_t NEWTON_MAX_ITERATIONS = 30;
 template <typename Func>
 requires std::invocable<const Func&, double>
      and std::convertible_to<std::invoke_result_t<const Func&, double>, double>
-inline auto newton_method(
+[[nodiscard]] inline auto newton_method(
   const Func& f,
   const double start_jde,
   const double end_jde,

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -426,8 +426,9 @@ requires std::invocable<const Func&, double>
 
   double step = NEWTON_INITIAL_STEP_DAYS;
 
-  // `std::midpoint` is the correctly-rounded half-sum -- the same double the `(a + b) / 2` it
-  // replaced produced.
+  // `std::midpoint` is the correctly-rounded half-sum. Where `a + b` cannot overflow -- JDE sits
+  // near 2.4e6, three hundred orders clear of it -- that is bit-for-bit what the `(a + b) / 2` it
+  // replaced produced. The two part company only at the extremes midpoint exists to survive.
   double jde = std::midpoint(start_jde, end_jde);
 
   // Newton can walk away from a root it has already reached, so keep the best iterate rather

--- a/src/astro/vsop87d/defines.hpp
+++ b/src/astro/vsop87d/defines.hpp
@@ -64,7 +64,7 @@ inline constexpr double SCALING_FACTOR = 1e8;
  * @return The sum of the terms in the table.
  * @example `evaluate_table(astro::vsop87d::earth::L0, 0.0)` means apply the Earth's L0 table on the given julian millennium 0.0.
  */
-inline auto evaluate_table(const Vsop87dTable& vsop_table, const double jm) -> double {
+[[nodiscard]] inline auto evaluate_table(const Vsop87dTable& vsop_table, const double jm) -> double {
   const auto calc_term = [jm](const auto& term) constexpr -> double {
     return term.A * std::cos(term.B + term.C * jm);
   };
@@ -83,7 +83,7 @@ inline auto evaluate_table(const Vsop87dTable& vsop_table, const double jm) -> d
  * @return The evaluated result. As per the VSOP87D model, the result is in radians.
  * @example `evaluate_tables(astro::vsop87d::earth::L, 0.0)` means apply all Earth's L tables on the given julian millennium 0.0.
  */
-inline auto evaluate_tables(const Vsop87dTables& vsop_tables, const double jm) -> double {
+[[nodiscard]] inline auto evaluate_tables(const Vsop87dTables& vsop_tables, const double jm) -> double {
   // Evaluate the result for each table in `vsop_tables`.
   const auto values = vsop_tables | std::views::transform([jm](const Vsop87dTable& vsop_table) {
     return evaluate_table(vsop_table, jm);
@@ -126,7 +126,7 @@ struct Evaluation {
  * @example `evaluate<Planet::EAR>(0.0)` means evaluating the Earth's L, B, and R tables on the given julian millennium 0.0.
  */
 template <Planet planet>
-inline auto evaluate(const double jm) -> Evaluation {
+[[nodiscard]] inline auto evaluate(const double jm) -> Evaluation {
   const auto& L = PlanetTables<planet>::L;
   const auto& B = PlanetTables<planet>::B;
   const auto& R = PlanetTables<planet>::R;

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -265,26 +265,24 @@ struct Datetime {
    * @return The fraction of a day, expected to be in the range [0.0, 1.0).
    */
   [[nodiscard]] constexpr auto fraction() const noexcept -> double {
-    const nanoseconds&& elapsed = time_of_day.to_duration();
+    const auto elapsed = time_of_day.to_duration();
     return to_fraction(elapsed);
   }
 
   // Define some operators as well in order to use `Datetime` in some STL containers.
 
-  auto operator==(const Datetime& other) const noexcept -> bool {
+  [[nodiscard]] constexpr auto operator==(const Datetime& other) const noexcept -> bool {
     return ymd == other.ymd and time_of_day.to_duration() == other.time_of_day.to_duration();
   }
 
-  auto operator!=(const Datetime& other) const noexcept -> bool {
-    return not (*this == other);
-  }
+  // `operator!=` is not spelled out: C++20 rewrites `a != b` as `!(a == b)`.
 
-  auto operator<=>(const Datetime& other) const noexcept {
+  [[nodiscard]] constexpr auto operator<=>(const Datetime& other) const noexcept {
     if (auto cmp = ymd <=> other.ymd; cmp != 0) {
       return cmp;
     }
     return time_of_day.to_duration() <=> other.time_of_day.to_duration();
-  };
+  }
 };
 
 

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -58,7 +58,7 @@ concept IsDuration = requires {
  * @example `in_a_day<seconds>() == 86400` (There are 86400 seconds in a day.)
  */
 template <IsDuration Duration>
-consteval auto in_a_day() -> uint64_t {
+[[nodiscard]] consteval auto in_a_day() -> uint64_t {
   return duration_cast<Duration>(days { 1 }).count();
 }
 

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -82,7 +82,7 @@ concept Fractionable = requires (T t) {
  * @warning No check on the input `elapsed`, so it can be negative or greater than `in_a_day<nanoseconds>()`.
  *          Thus, the returned result may be < 0.0 or >= 1.0.
  */
-constexpr auto to_fraction(const Fractionable auto& elapsed) -> double {
+[[nodiscard]] constexpr auto to_fraction(const Fractionable auto& elapsed) -> double {
   const auto& ns_duration = duration_cast<nanoseconds>(elapsed);
   const double ns_elapsed = ns_duration.count();
   return ns_elapsed / in_a_day<nanoseconds>();
@@ -99,7 +99,7 @@ constexpr auto to_fraction(const Fractionable auto& elapsed) -> double {
  * @example `from_fraction(2.0) == 48:00:00.000000000`
  * @note The precision of the returned value is `std::chrono::nanoseconds`.
  */
-constexpr auto from_fraction(const double fraction) -> hh_mm_ss<nanoseconds> {
+[[nodiscard]] constexpr auto from_fraction(const double fraction) -> hh_mm_ss<nanoseconds> {
   return hh_mm_ss {
     nanoseconds {
       static_cast<int64_t>(
@@ -119,7 +119,7 @@ constexpr auto from_fraction(const double fraction) -> hh_mm_ss<nanoseconds> {
  *       `fraction < 0.0 or fraction >= 1.0` test is always false for NaN and lets it through
  *       to the undefined double→int64 cast in `from_fraction`.
  */
-constexpr auto validate_fraction(const double fraction) -> double {
+[[nodiscard]] constexpr auto validate_fraction(const double fraction) -> double {
   if (not (fraction >= 0.0 and fraction < 1.0)) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#67).
     throw std::invalid_argument {
       std::vformat(
@@ -294,7 +294,7 @@ struct Datetime {
  * @throw std::invalid_argument if `offset_sec` is not finite, or if the shifted date leaves
  *        `std::chrono::year_month_day`'s representable years.
  */
-constexpr auto add_seconds(const Datetime& dt, const double offset_sec) -> Datetime {
+[[nodiscard]] constexpr auto add_seconds(const Datetime& dt, const double offset_sec) -> Datetime {
   // Beyond ±2e9 days the day carry below overflows `int32_t`; NaN fails the comparison too.
   if (not (std::fabs(offset_sec) < 2.0e9 * in_a_day<seconds>())) {
     throw std::invalid_argument {
@@ -334,7 +334,7 @@ namespace std {
 // This function may be an overkill though.
 template <>
 struct hash<calendar::Datetime> {
-  auto operator()(const calendar::Datetime& dt) const -> std::size_t {
+  [[nodiscard]] auto operator()(const calendar::Datetime& dt) const -> std::size_t {
     const auto [y, m, d] = util::from_ymd(dt.ymd);
     const double fraction = dt.fraction();
     return util::hash::hash(y, m, d, fraction);

--- a/src/calendar/jieqi.hpp
+++ b/src/calendar/jieqi.hpp
@@ -246,9 +246,7 @@ public:
   struct JieqiPair { 
     Jieqi jieqi;
     double jde; 
-    auto operator==(const JieqiPair& rhs) const -> bool { 
-      return jieqi == rhs.jieqi and jde == rhs.jde; 
-    }
+    auto operator==(const JieqiPair& rhs) const -> bool = default;
   };
 
   auto next() -> JieqiPair {

--- a/src/calendar/jieqi.hpp
+++ b/src/calendar/jieqi.hpp
@@ -92,9 +92,10 @@ static_assert(24U == JIEQI_COUNT);
 
 
 /**
- * @brief Get the index of the given `jq`.
- * @param jq The jieqi.
- * @return The index of the given `jq`.
+ * @brief Get the Jieqi at a 0-based index counted from 立春.
+ * @param index The index, in `[0, JIEQI_COUNT)`.
+ * @return The jieqi.
+ * @throw std::out_of_range if `index` is not a valid index.
  */
 [[nodiscard]] constexpr auto from_index(const uint8_t index) -> Jieqi {
   if (index >= JIEQI_COUNT) {
@@ -117,10 +118,8 @@ inline constexpr auto GREGORIAN_YEAR_JIEQI_LIST = std::views::iota(uint8_t { 0 }
 
 
 /**
- * @brief Name of each Jieqi, indexed by `to_index`.
- * @note Read it with `.at()`, not `operator[]` -- `.at()` throws `std::out_of_range` for a `Jieqi`
- *       outside `[0, 24)`, which the enum's fixed underlying type makes reachable from outside the
- *       library (`static_cast<Jieqi>(25)`, or `Jieqi::COUNT` itself).
+ * @brief Name of each Jieqi, positioned by `to_index`.
+ * @note Read it through `name_of`, not directly -- a bare index is the wrong key here. See `name_of`.
  */
 inline constexpr std::array<std::string_view, JIEQI_COUNT> JIEQI_NAME {{
   "立春", "雨水", "惊蛰",
@@ -135,8 +134,8 @@ inline constexpr std::array<std::string_view, JIEQI_COUNT> JIEQI_NAME {{
 
 
 /**
- * @brief Solar longitude (in degrees) at which each Jieqi begins, indexed by `to_index`.
- * @note Read it with `.at()` -- see `JIEQI_NAME`.
+ * @brief Solar longitude (in degrees) at which each Jieqi begins, positioned by `to_index`.
+ * @note Read it through `longitude_of` -- see `name_of`.
  */
 inline constexpr std::array<double, JIEQI_COUNT> JIEQI_SOLAR_LONGITUDE {{
   315.0, 330.0, 345.0,
@@ -150,8 +149,7 @@ inline constexpr std::array<double, JIEQI_COUNT> JIEQI_SOLAR_LONGITUDE {{
 }};
 
 
-// Both tables key off position now, where they used to carry `Jieqi::清明` next to each value.
-// A mis-ordered edit is therefore silent, so pin the order at compile time.
+// The tables are position-keyed, so a mis-ordered edit is silent. Pin the order at compile time.
 //
 // The longitudes are pinned exactly: they advance 15 degrees per Jieqi starting from 315 at 立春,
 // so the whole table has a closed form and any reorder breaks it.
@@ -171,6 +169,39 @@ static_assert("立春" == JIEQI_NAME.at(to_index(Jieqi::立春)));
 static_assert("夏至" == JIEQI_NAME.at(to_index(Jieqi::夏至)));
 static_assert("大寒" == JIEQI_NAME.at(to_index(Jieqi::大寒)));
 
+
+// Both tables are read through these two, never by bare subscript. Two different index spaces
+// live in this codebase -- `to_index` counts from 立春, while the HKO almanac and
+// `GREGORIAN_YEAR_JIEQI_LIST` count from 小寒 -- and a subscript cannot tell them apart, so
+// indexing the wrong one yields a plausible wrong answer in silence. Taking a `Jieqi` makes
+// that a compile error again.
+//
+// `.at()` stays on the read path: it throws `std::out_of_range` for a `Jieqi` outside `[0, 24)`,
+// which the enum's fixed underlying type makes reachable from outside the library
+// (`static_cast<Jieqi>(25)`, or `Jieqi::COUNT` itself).
+
+/**
+ * @brief Get the name of the given `jq`.
+ * @param jq The jieqi.
+ * @return The name.
+ * @throw std::out_of_range if `jq` is not a valid Jieqi.
+ */
+[[nodiscard]] constexpr auto name_of(const Jieqi jq) -> std::string_view {
+  return JIEQI_NAME.at(to_index(jq));
+}
+
+
+/**
+ * @brief Get the solar longitude (in degrees) at which the given `jq` begins.
+ * @param jq The jieqi.
+ * @return The solar longitude.
+ * @throw std::out_of_range if `jq` is not a valid Jieqi.
+ */
+[[nodiscard]] constexpr auto longitude_of(const Jieqi jq) -> double {
+  return JIEQI_SOLAR_LONGITUDE.at(to_index(jq));
+}
+
+
 /**
  * @brief Get the JDE for the given `year` and `jieqi`.
  * @param year The year, in gregorian calendar.
@@ -178,13 +209,15 @@ static_assert("大寒" == JIEQI_NAME.at(to_index(Jieqi::大寒)));
  * @return The JDE (Julian Ephemeris Day).
  */
 [[nodiscard]] inline auto calc_jieqi_jde(const int32_t year, const Jieqi jq) -> double {
-  const auto lon = JIEQI_SOLAR_LONGITUDE.at(to_index(jq));
+  const auto lon = longitude_of(jq);
   const auto roots = astro::sun::geocentric_coord::math::find_roots(year, lon);
 
   if (roots.size() != 1) {
+    // `make_format_args` binds lvalue references, so the name needs a home of its own.
+    const auto name = name_of(jq);
     throw std::runtime_error {
-      std::vformat("Unexpected roots size for year {}, jieqi {}", 
-                   std::make_format_args(year, JIEQI_NAME.at(to_index(jq))))
+      std::vformat("Unexpected roots size for year {}, jieqi {}",
+                   std::make_format_args(year, name))
     };
   }
 
@@ -249,7 +282,7 @@ public:
     [[nodiscard]] auto operator==(const JieqiPair& rhs) const -> bool = default;
   };
 
-  [[nodiscard]] auto next() -> JieqiPair {
+  auto next() -> JieqiPair {
     const auto jq = from_index(_jq_index);
     const auto jde = jieqi_jde(_year, jq);
 

--- a/src/calendar/jieqi.hpp
+++ b/src/calendar/jieqi.hpp
@@ -213,7 +213,6 @@ static_assert("大寒" == JIEQI_NAME.at(to_index(Jieqi::大寒)));
   const auto roots = astro::sun::geocentric_coord::math::find_roots(year, lon);
 
   if (roots.size() != 1) {
-    // `make_format_args` binds lvalue references, so the name needs a home of its own.
     const auto name = name_of(jq);
     throw std::runtime_error {
       std::vformat("Unexpected roots size for year {}, jieqi {}",

--- a/src/calendar/jieqi.hpp
+++ b/src/calendar/jieqi.hpp
@@ -23,11 +23,13 @@
 
 #pragma once
 
+#include <array>
 #include <format>
 #include <ranges>
 #include <cstdint>
+#include <utility>
+#include <stdexcept>
 #include <string_view>
-#include <unordered_map>
 
 #include "sun.hpp"
 #include "util.hpp"
@@ -53,7 +55,7 @@ enum class Jieqi : uint8_t {
   LIDONG = 立冬, XIAOXUE = 小雪, DAXUE = 大雪, DONGZHI = 冬至, XIAOHAN = 小寒, DAHAN = 大寒,
 };
 
-inline constexpr uint8_t JIEQI_COUNT = static_cast<uint8_t>(Jieqi::COUNT);
+inline constexpr uint8_t JIEQI_COUNT = std::to_underlying(Jieqi::COUNT);
 static_assert(24U == JIEQI_COUNT);
 
 
@@ -63,7 +65,7 @@ static_assert(24U == JIEQI_COUNT);
  * @return `true` if the given `jq` is a Jie (节), `false` otherwise.
  */
 constexpr auto is_jie(const Jieqi jq) -> bool {
-  const auto index = static_cast<uint8_t>(jq);
+  const auto index = std::to_underlying(jq);
   return index % 2 == 0;
 }
 
@@ -74,7 +76,7 @@ constexpr auto is_jie(const Jieqi jq) -> bool {
  * @return `true` if the given `jq` is a Qi (气), `false` otherwise.
  */
 constexpr auto is_qi(const Jieqi jq) -> bool {
-  const auto index = static_cast<uint8_t>(jq);
+  const auto index = std::to_underlying(jq);
   return index % 2 == 1;
 }
 
@@ -85,7 +87,7 @@ constexpr auto is_qi(const Jieqi jq) -> bool {
  * @return The index of the given `jq`.
  */
 constexpr auto to_index(const Jieqi jq) -> uint8_t {
-  return static_cast<uint8_t>(jq);
+  return std::to_underlying(jq);
 }
 
 
@@ -103,41 +105,71 @@ constexpr auto from_index(const uint8_t index) -> Jieqi {
 
 
 /** @brief A view of all enum values of `Jieqi`. */
-inline constexpr auto JIEQI_LIST = std::views::iota(0, static_cast<int8_t>(JIEQI_COUNT)) 
+inline constexpr auto JIEQI_LIST = std::views::iota(uint8_t { 0 }, JIEQI_COUNT)
                           | std::views::transform([](const auto i) { return from_index(i); });
 
 /** @brief A view of all enum values of `Jieqi`, but ordered by their occurrence in a gregorian year.
  *         That means the first value is "小寒", since it is the first Jieqi in any gregorian year.
  */
-inline constexpr auto GREGORIAN_YEAR_JIEQI_LIST = std::views::iota(0, static_cast<int8_t>(JIEQI_COUNT)) 
+inline constexpr auto GREGORIAN_YEAR_JIEQI_LIST = std::views::iota(uint8_t { 0 }, JIEQI_COUNT)
                                          | std::views::transform([](const auto i) { return (i + to_index(Jieqi::小寒)) % JIEQI_COUNT; })
                                          | std::views::transform([](const auto i) { return from_index(i); });
 
 
-/** @brief Mapping table to get the name of the given `jieqi`. */
-const inline std::unordered_map<Jieqi, std::string_view> JIEQI_NAME = {
-  { Jieqi::立春, "立春" }, { Jieqi::雨水, "雨水" }, { Jieqi::惊蛰, "惊蛰" },
-  { Jieqi::春分, "春分" }, { Jieqi::清明, "清明" }, { Jieqi::谷雨, "谷雨" },
-  { Jieqi::立夏, "立夏" }, { Jieqi::小满, "小满" }, { Jieqi::芒种, "芒种" },
-  { Jieqi::夏至, "夏至" }, { Jieqi::小暑, "小暑" }, { Jieqi::大暑, "大暑" },
-  { Jieqi::立秋, "立秋" }, { Jieqi::处暑, "处暑" }, { Jieqi::白露, "白露" },
-  { Jieqi::秋分, "秋分" }, { Jieqi::寒露, "寒露" }, { Jieqi::霜降, "霜降" },
-  { Jieqi::立冬, "立冬" }, { Jieqi::小雪, "小雪" }, { Jieqi::大雪, "大雪" },
-  { Jieqi::冬至, "冬至" }, { Jieqi::小寒, "小寒" }, { Jieqi::大寒, "大寒" },
-};
+/**
+ * @brief Name of each Jieqi, indexed by `to_index`.
+ * @note Read it with `.at()`, not `operator[]` -- `.at()` throws `std::out_of_range` for a `Jieqi`
+ *       outside `[0, 24)`, which the enum's fixed underlying type makes reachable from outside the
+ *       library (`static_cast<Jieqi>(25)`, or `Jieqi::COUNT` itself).
+ */
+inline constexpr std::array<std::string_view, JIEQI_COUNT> JIEQI_NAME {{
+  "立春", "雨水", "惊蛰",
+  "春分", "清明", "谷雨",
+  "立夏", "小满", "芒种",
+  "夏至", "小暑", "大暑",
+  "立秋", "处暑", "白露",
+  "秋分", "寒露", "霜降",
+  "立冬", "小雪", "大雪",
+  "冬至", "小寒", "大寒",
+}};
 
 
-/** @brief Mapping table to get the solar longitude of the given `Jieqi`. */
-const inline std::unordered_map<Jieqi, double> JIEQI_SOLAR_LONGITUDE = {
-  { Jieqi::立春, 315.0 }, { Jieqi::雨水, 330.0 }, { Jieqi::惊蛰, 345.0 },
-  { Jieqi::春分,   0.0 }, { Jieqi::清明,  15.0 }, { Jieqi::谷雨,  30.0 },
-  { Jieqi::立夏,  45.0 }, { Jieqi::小满,  60.0 }, { Jieqi::芒种,  75.0 },
-  { Jieqi::夏至,  90.0 }, { Jieqi::小暑, 105.0 }, { Jieqi::大暑, 120.0 },
-  { Jieqi::立秋, 135.0 }, { Jieqi::处暑, 150.0 }, { Jieqi::白露, 165.0 },
-  { Jieqi::秋分, 180.0 }, { Jieqi::寒露, 195.0 }, { Jieqi::霜降, 210.0 },
-  { Jieqi::立冬, 225.0 }, { Jieqi::小雪, 240.0 }, { Jieqi::大雪, 255.0 },
-  { Jieqi::冬至, 270.0 }, { Jieqi::小寒, 285.0 }, { Jieqi::大寒, 300.0 },
-};
+/**
+ * @brief Solar longitude (in degrees) at which each Jieqi begins, indexed by `to_index`.
+ * @note Read it with `.at()` -- see `JIEQI_NAME`.
+ */
+inline constexpr std::array<double, JIEQI_COUNT> JIEQI_SOLAR_LONGITUDE {{
+  315.0, 330.0, 345.0,
+    0.0,  15.0,  30.0,
+   45.0,  60.0,  75.0,
+   90.0, 105.0, 120.0,
+  135.0, 150.0, 165.0,
+  180.0, 195.0, 210.0,
+  225.0, 240.0, 255.0,
+  270.0, 285.0, 300.0,
+}};
+
+
+// Both tables key off position now, where they used to carry `Jieqi::清明` next to each value.
+// A mis-ordered edit is therefore silent, so pin the order at compile time.
+//
+// The longitudes are pinned exactly: they advance 15 degrees per Jieqi starting from 315 at 立春,
+// so the whole table has a closed form and any reorder breaks it.
+static_assert([] {
+  for (uint8_t i = 0; i < JIEQI_COUNT; ++i) {
+    if (JIEQI_SOLAR_LONGITUDE.at(i) != static_cast<double>((i * 15 + 315) % 360)) {
+      return false;
+    }
+  }
+  return true;
+}());
+
+// The names have no closed form, so these pin the ends and one interior point. That catches a
+// shift (an entry added or dropped), which is the likely edit accident; it does not catch two
+// interior names swapped with each other.
+static_assert("立春" == JIEQI_NAME.at(to_index(Jieqi::立春)));
+static_assert("夏至" == JIEQI_NAME.at(to_index(Jieqi::夏至)));
+static_assert("大寒" == JIEQI_NAME.at(to_index(Jieqi::大寒)));
 
 /**
  * @brief Get the JDE for the given `year` and `jieqi`.
@@ -146,13 +178,13 @@ const inline std::unordered_map<Jieqi, double> JIEQI_SOLAR_LONGITUDE = {
  * @return The JDE (Julian Ephemeris Day).
  */
 inline auto calc_jieqi_jde(const int32_t year, const Jieqi jq) -> double {
-  const auto lon = JIEQI_SOLAR_LONGITUDE.at(jq);
+  const auto lon = JIEQI_SOLAR_LONGITUDE.at(to_index(jq));
   const auto roots = astro::sun::geocentric_coord::math::find_roots(year, lon);
 
   if (roots.size() != 1) {
     throw std::runtime_error {
       std::vformat("Unexpected roots size for year {}, jieqi {}", 
-                   std::make_format_args(year, JIEQI_NAME.at(jq)))
+                   std::make_format_args(year, JIEQI_NAME.at(to_index(jq))))
     };
   }
 

--- a/src/calendar/jieqi.hpp
+++ b/src/calendar/jieqi.hpp
@@ -64,7 +64,7 @@ static_assert(24U == JIEQI_COUNT);
  * @param jq The jieqi.
  * @return `true` if the given `jq` is a Jie (节), `false` otherwise.
  */
-constexpr auto is_jie(const Jieqi jq) -> bool {
+[[nodiscard]] constexpr auto is_jie(const Jieqi jq) -> bool {
   const auto index = std::to_underlying(jq);
   return index % 2 == 0;
 }
@@ -75,7 +75,7 @@ constexpr auto is_jie(const Jieqi jq) -> bool {
  * @param jq The jieqi.
  * @return `true` if the given `jq` is a Qi (气), `false` otherwise.
  */
-constexpr auto is_qi(const Jieqi jq) -> bool {
+[[nodiscard]] constexpr auto is_qi(const Jieqi jq) -> bool {
   const auto index = std::to_underlying(jq);
   return index % 2 == 1;
 }
@@ -86,7 +86,7 @@ constexpr auto is_qi(const Jieqi jq) -> bool {
  * @param jq The jieqi.
  * @return The index of the given `jq`.
  */
-constexpr auto to_index(const Jieqi jq) -> uint8_t {
+[[nodiscard]] constexpr auto to_index(const Jieqi jq) -> uint8_t {
   return std::to_underlying(jq);
 }
 
@@ -96,7 +96,7 @@ constexpr auto to_index(const Jieqi jq) -> uint8_t {
  * @param jq The jieqi.
  * @return The index of the given `jq`.
  */
-constexpr auto from_index(const uint8_t index) -> Jieqi {
+[[nodiscard]] constexpr auto from_index(const uint8_t index) -> Jieqi {
   if (index >= JIEQI_COUNT) {
     throw std::out_of_range { "index must be less than 24" };
   }
@@ -177,7 +177,7 @@ static_assert("大寒" == JIEQI_NAME.at(to_index(Jieqi::大寒)));
  * @param jq The jieqi.
  * @return The JDE (Julian Ephemeris Day).
  */
-inline auto calc_jieqi_jde(const int32_t year, const Jieqi jq) -> double {
+[[nodiscard]] inline auto calc_jieqi_jde(const int32_t year, const Jieqi jq) -> double {
   const auto lon = JIEQI_SOLAR_LONGITUDE.at(to_index(jq));
   const auto roots = astro::sun::geocentric_coord::math::find_roots(year, lon);
 
@@ -208,7 +208,7 @@ const inline auto jieqi_jde = util::cache::cache_func(calc_jieqi_jde);
  *       for contract stability. The UT1/UTC gap is DUT1 (≤ 0.9 s while leap seconds are
  *       applied); past the ΔAT table freeze it follows ΔT−(ΔAT+32.184) (#115).
  */
-inline auto jieqi_ut1_moment(const int32_t year, const Jieqi jq) -> calendar::Datetime {
+[[nodiscard]] inline auto jieqi_ut1_moment(const int32_t year, const Jieqi jq) -> calendar::Datetime {
   return astro::julian_day::jde_to_ut1(jieqi_jde(year, jq));
 }
 
@@ -246,10 +246,10 @@ public:
   struct JieqiPair { 
     Jieqi jieqi;
     double jde; 
-    auto operator==(const JieqiPair& rhs) const -> bool = default;
+    [[nodiscard]] auto operator==(const JieqiPair& rhs) const -> bool = default;
   };
 
-  auto next() -> JieqiPair {
+  [[nodiscard]] auto next() -> JieqiPair {
     const auto jq = from_index(_jq_index);
     const auto jde = jieqi_jde(_year, jq);
 

--- a/src/calendar/jieqi.hpp
+++ b/src/calendar/jieqi.hpp
@@ -119,7 +119,7 @@ inline constexpr auto GREGORIAN_YEAR_JIEQI_LIST = std::views::iota(uint8_t { 0 }
 
 /**
  * @brief Name of each Jieqi, positioned by `to_index`.
- * @note Read it through `name_of`, not directly -- a bare index is the wrong key here. See `name_of`.
+ * @note Read it through `name_of` -- a bare index cannot say which space it came from. See `name_of`.
  */
 inline constexpr std::array<std::string_view, JIEQI_COUNT> JIEQI_NAME {{
   "立春", "雨水", "惊蛰",
@@ -170,11 +170,11 @@ static_assert("夏至" == JIEQI_NAME.at(to_index(Jieqi::夏至)));
 static_assert("大寒" == JIEQI_NAME.at(to_index(Jieqi::大寒)));
 
 
-// Both tables are read through these two, never by bare subscript. Two different index spaces
-// live in this codebase -- `to_index` counts from 立春, while the HKO almanac and
-// `GREGORIAN_YEAR_JIEQI_LIST` count from 小寒 -- and a subscript cannot tell them apart, so
-// indexing the wrong one yields a plausible wrong answer in silence. Taking a `Jieqi` makes
-// that a compile error again.
+// Consumers read both tables through these two; the order-pinning asserts above are the one
+// exception, and they have to read by position. Two different index spaces live in this codebase
+// -- `to_index` counts from 立春, while the HKO almanac and `GREGORIAN_YEAR_JIEQI_LIST` count from
+// 小寒 -- and a subscript cannot tell them apart, so indexing the wrong one yields a plausible
+// wrong answer in silence. Taking a `Jieqi` makes that a compile error again.
 //
 // `.at()` stays on the read path: it throws `std::out_of_range` for a `Jieqi` outside `[0, 24)`,
 // which the enum's fixed underlying type makes reachable from outside the library
@@ -281,7 +281,7 @@ public:
     [[nodiscard]] auto operator==(const JieqiPair& rhs) const -> bool = default;
   };
 
-  auto next() -> JieqiPair {
+  [[nodiscard]] auto next() -> JieqiPair {
     const auto jq = from_index(_jq_index);
     const auto jde = jieqi_jde(_year, jq);
 

--- a/src/calendar/lunar/algo1.hpp
+++ b/src/calendar/lunar/algo1.hpp
@@ -76,7 +76,7 @@ inline constexpr std::array<uint32_t, (END_YEAR - START_YEAR + 1)> LUNAR_DATA = 
  * @param year The Lunar year. 阴历年份。
  * @return The lunar year information. 阴历年信息。
  */
-inline auto calc_lunar_year(int32_t year) -> LunarYear {
+[[nodiscard]] inline auto calc_lunar_year(int32_t year) -> LunarYear {
   if (year < START_YEAR or year > END_YEAR) {
     throw std::out_of_range {
       std::format("year {} is out of range [{}, {}]", year, START_YEAR, END_YEAR)
@@ -98,8 +98,8 @@ namespace calendar::lunar::common {
 template <>
 struct AlgoMetadata<Algo::ALGO_1> {
   // Not memoized: a `LUNAR_DATA[]` lookup is cheaper than the cache wrapper (#75).
-  static auto get_info_for_year(const int32_t year) -> LunarYear { return algo1::calc_lunar_year(year); }
-  static auto bounds() -> const common::AlgoBounds& { return algo1::bounds; }
+  [[nodiscard]] static auto get_info_for_year(const int32_t year) -> LunarYear { return algo1::calc_lunar_year(year); }
+  [[nodiscard]] static auto bounds() -> const common::AlgoBounds& { return algo1::bounds; }
 };
 
 } // namespace calendar::lunar::common

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -70,7 +70,7 @@ inline constexpr int32_t END_YEAR = 5000;
  * @note Leap seconds step at UTC midnight, i.e. 08:00 in UTC+8 — the non-invertible second of
  *       `leap_second::tt_to_utc` never lands on a civil-day boundary here.
  */
-inline auto jde_to_utc8(const double jde) -> calendar::Datetime {
+[[nodiscard]] inline auto jde_to_utc8(const double jde) -> calendar::Datetime {
   return calendar::add_seconds(
     astro::julian_day::jde_to_utc(jde),
     8.0 * 3600.0
@@ -89,7 +89,7 @@ struct LunarMonth {
   // Jieqis that fall in this lunar month.
   std::vector<JieqiGenerator::JieqiPair> contained_jieqis;
 
-  auto operator==(const LunarMonth& other) const -> bool = default;
+  [[nodiscard]] auto operator==(const LunarMonth& other) const -> bool = default;
 };
 
 /**
@@ -108,7 +108,7 @@ private:
 
   std::optional<LunarMonth> _next_month;
 
-  auto next_new_moon() -> double {
+  [[nodiscard]] auto next_new_moon() -> double {
     if (_next_new_moon.has_value()) {
       const double jde = *_next_new_moon;
       _next_new_moon = std::nullopt;
@@ -123,7 +123,7 @@ private:
     _next_new_moon = jde;
   }
 
-  auto next_jieqi() -> JieqiGenerator::JieqiPair {
+  [[nodiscard]] auto next_jieqi() -> JieqiGenerator::JieqiPair {
     if (_next_jieqi.has_value()) {
       auto jieqi = *_next_jieqi;
       _next_jieqi = std::nullopt;
@@ -138,7 +138,7 @@ private:
     _next_jieqi = jieqi;
   }
 
-  auto next_month() -> LunarMonth {
+  [[nodiscard]] auto next_month() -> LunarMonth {
     if (_next_month.has_value()) {
       auto month = *_next_month;
       _next_month = std::nullopt;
@@ -197,12 +197,12 @@ public:
   {}
 
   /** @brief Get the metadata of the next lunar month. */
-  auto next() -> LunarMonth {
+  [[nodiscard]] auto next() -> LunarMonth {
     return next_month();
   }
 
   /** @brief Peek the metadata of the next lunar month, without advancing. */
-  auto peek() -> LunarMonth {
+  [[nodiscard]] auto peek() -> LunarMonth {
     auto month = next_month();
     put_back_month(month);
     return month;
@@ -224,7 +224,7 @@ using LunarMonthChunk = std::vector<LunarMonth>;
  *         The first chunk is from 11th month in the previous year to 11th month in the current year.
  *         The second chunk is from 11th month in the current year to 11th month in the next year.
  */
-inline auto calc_lunar_month_chunks(int32_t year) -> std::pair<LunarMonthChunk, LunarMonthChunk> {
+[[nodiscard]] inline auto calc_lunar_month_chunks(int32_t year) -> std::pair<LunarMonthChunk, LunarMonthChunk> {
   // The lunar month where Winter Solstice (i.e. Jieqi::冬至) occurs is defined as the 11th month.
   const auto winter_solstice_last_year = jieqi_jde(year - 1, Jieqi::冬至);
 
@@ -264,7 +264,7 @@ inline auto calc_lunar_month_chunks(int32_t year) -> std::pair<LunarMonthChunk, 
  * @param chunk The chunk of lunar months.
  * @return The index of the leap month in the given chunk. `std::nullopt` if there is no leap month.
  */
-inline auto leap_month_in_chunk(const LunarMonthChunk& chunk) -> std::optional<int32_t> {
+[[nodiscard]] inline auto leap_month_in_chunk(const LunarMonthChunk& chunk) -> std::optional<int32_t> {
   assert(size(chunk) == 12 or size(chunk) == 13);
 
   // As per the rules, for 12-month chunks, there is no leap month.
@@ -295,7 +295,7 @@ inline auto leap_month_in_chunk(const LunarMonthChunk& chunk) -> std::optional<i
  * @param leap_month The index of the leap month in the given chunk. `std::nullopt` if there is no leap month.
  * @return The start moment of the lunar year.
  */
-inline auto calc_lunar_year_start_moment(const LunarMonthChunk& chunk, std::optional<int32_t> leap_month) -> calendar::Datetime {
+[[nodiscard]] inline auto calc_lunar_year_start_moment(const LunarMonthChunk& chunk, std::optional<int32_t> leap_month) -> calendar::Datetime {
   if (leap_month.has_value() and (*leap_month <= 2)) {
     // The lunar year starts from the third month after the 11th month in previous year,
     // because of the leap month.
@@ -323,7 +323,7 @@ struct LunarYearContext {
  * @param year The year to create the context for.
  * @return The `LunarYearContext` for the given year.
  */
-inline auto create_lunar_year_context(int32_t year) -> LunarYearContext {
+[[nodiscard]] inline auto create_lunar_year_context(int32_t year) -> LunarYearContext {
   const auto& [chunk1, chunk2] = calc_lunar_month_chunks(year);
 
   const auto chunk1_leap_month = leap_month_in_chunk(chunk1);
@@ -396,7 +396,7 @@ inline auto create_lunar_year_context(int32_t year) -> LunarYearContext {
  * @return The lunar year information. 阴历年信息。
  * @see https://ytliu0.github.io/ChineseCalendar/rules_simp.html
  */
-inline auto calc_lunar_year(int32_t year) -> LunarYear {
+[[nodiscard]] inline auto calc_lunar_year(int32_t year) -> LunarYear {
   if (year < START_YEAR or year > END_YEAR) {
     throw std::out_of_range {
       std::format("year {} is out of range [{}, {}]", year, START_YEAR, END_YEAR)
@@ -466,7 +466,7 @@ const inline auto get_info_for_year = util::cache::cache_func(calc_lunar_year);
  *       while the shared library is still being loaded, where an escaping exception would
  *       terminate the host before `main`.
  */
-inline auto bounds() -> const common::AlgoBounds& {
+[[nodiscard]] inline auto bounds() -> const common::AlgoBounds& {
   static const common::AlgoBounds value = calc_bounds(START_YEAR, END_YEAR, get_info_for_year);
   return value;
 }
@@ -482,7 +482,7 @@ struct AlgoMetadata<Algo::ALGO_2> {
   static const inline auto& get_info_for_year = algo2::get_info_for_year;
   // #67: an accessor, not an eager binding — an `inline` static member would initialize at
   // image load, running the whole astro pipeline before `main` and defeating `algo2::bounds()`.
-  static auto bounds() -> const common::AlgoBounds& { return algo2::bounds(); }
+  [[nodiscard]] static auto bounds() -> const common::AlgoBounds& { return algo2::bounds(); }
 };
 
 } // namespace calendar::lunar::common

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -89,11 +89,7 @@ struct LunarMonth {
   // Jieqis that fall in this lunar month.
   std::vector<JieqiGenerator::JieqiPair> contained_jieqis;
 
-  auto operator==(const LunarMonth& other) const -> bool {
-    return start_moment_utc8 == other.start_moment_utc8
-       and end_moment_utc8 == other.end_moment_utc8
-       and contained_jieqis == other.contained_jieqis;
-  }
+  auto operator==(const LunarMonth& other) const -> bool = default;
 };
 
 /**
@@ -239,7 +235,7 @@ inline auto calc_lunar_month_chunks(int32_t year) -> std::pair<LunarMonthChunk, 
   const auto is_11th = [](const auto& month) {
     const auto& jieqis = month.contained_jieqis;
     const auto is_winter_solstice = [](const auto& jq) { return jq.jieqi == Jieqi::冬至; };
-    return std::any_of(cbegin(jieqis), cend(jieqis), is_winter_solstice); 
+    return std::ranges::any_of(jieqis, is_winter_solstice);
   };
 
   // Define a helper function to get the next chunk.
@@ -280,7 +276,7 @@ inline auto leap_month_in_chunk(const LunarMonthChunk& chunk) -> std::optional<i
   // TODO: Use `std::views::enumerate` once every CI leg has it (./linter.py --features).
   for (const auto& [index, month] : std::views::zip(std::views::iota(0), chunk)) {
     const auto& jq_pairs = month.contained_jieqis;
-    const bool has_qi = std::any_of(cbegin(jq_pairs), cend(jq_pairs), [](const auto& pair) {
+    const bool has_qi = std::ranges::any_of(jq_pairs, [](const auto& pair) {
       return is_qi(pair.jieqi);
     });
     if (not has_qi) {
@@ -368,12 +364,7 @@ inline auto create_lunar_year_context(int32_t year) -> LunarYearContext {
   }
 
   // Finally, get the start moment of the leap month.
-  std::optional<calendar::Datetime> leap_month_moment = std::nullopt;
-  if (chunk1_leap_moment.has_value()) {
-    leap_month_moment = chunk1_leap_moment;
-  } else if (chunk2_leap_moment.has_value()) {
-    leap_month_moment = chunk2_leap_moment;
-  }
+  const auto leap_month_moment = chunk1_leap_moment.or_else([&] { return chunk2_leap_moment; });
 
   // Figure out the months in the lunar year.
   // TODO: Use `std::views::concat` once C++26 is in reach (./linter.py --features).
@@ -421,21 +412,21 @@ inline auto calc_lunar_year(int32_t year) -> LunarYear {
   const auto is_leap = [&](const auto& m) {
     return m.start_moment_utc8 == context.leap_month_moment_utc8;
   };
-  const auto leap_month_vec = context.months 
-                            | std::views::filter(is_leap)
-                            | std::ranges::to<std::vector>();
-
   // Check if there is only one or zero leap month in the lunar year.
-  if (size(leap_month_vec) > 1) {
+  if (std::ranges::count_if(context.months, is_leap) > 1) {
     throw std::runtime_error {
       std::format("Too many leap months in lunar year: {}", year)
     };
   }
 
   // Get the leap month's index.
-  const uint8_t leap_month = std::invoke([&] {
+  const uint8_t leap_month = std::invoke([&] -> uint8_t {
     const auto found = std::ranges::find_if(context.months, is_leap);
-    return found == std::end(context.months) ? 0 : std::distance(std::begin(context.months), found);
+    if (found == std::end(context.months)) {
+      return 0;
+    }
+    // A lunar year holds at most 13 months, so the index fits — say so instead of narrowing silently.
+    return static_cast<uint8_t>(std::ranges::distance(std::begin(context.months), found));
   });
   
   // Then, figure out if the months are big (30 days) or small (29 days).

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -95,8 +95,11 @@ struct LunarMonth {
 /**
  * @brief A generator that generates some metadata of lunar months, including Jieqi and length of the month.
  * @note Generated lunar and jieqi information starts after the given JDE.
- * @details The new moon moments and jieqi can be put back to the generator for future use. So I don't think
- *          `std::generator` can be used here... Since `std::generator` doesn't support put back?
+ * @details New moons and jieqi are read one ahead and pushed back when they turn out to belong to the
+ *          next month. That push-back is an artifact of hand-rolling the generator: a coroutine would
+ *          keep the read-ahead value in a local across the suspension instead (#99). What a coroutine
+ *          would not give us is `peek` -- `std::generator` yields a single-pass input range, so the
+ *          one-slot buffer below outlives that migration.
  */
 struct LunarMonthGenerator {
 private:
@@ -183,11 +186,6 @@ private:
     };
   }
 
-  auto put_back_month(const LunarMonth& month) -> void {
-    assert(!_next_month.has_value());
-    _next_month = month;
-  }
-
 public:
   explicit LunarMonthGenerator(const double start_jde) 
     : _new_moon_gen(start_jde),
@@ -197,15 +195,16 @@ public:
   {}
 
   /** @brief Get the metadata of the next lunar month. */
-  [[nodiscard]] auto next() -> LunarMonth {
+  auto next() -> LunarMonth {
     return next_month();
   }
 
   /** @brief Peek the metadata of the next lunar month, without advancing. */
   [[nodiscard]] auto peek() -> LunarMonth {
-    auto month = next_month();
-    put_back_month(month);
-    return month;
+    if (not _next_month.has_value()) {
+      _next_month = next_month();
+    }
+    return *_next_month;
   }
 };
 

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -95,11 +95,12 @@ struct LunarMonth {
 /**
  * @brief A generator that generates some metadata of lunar months, including Jieqi and length of the month.
  * @note Generated lunar and jieqi information starts after the given JDE.
- * @details New moons and jieqi are read one ahead and pushed back when they turn out to belong to the
- *          next month. That push-back is an artifact of hand-rolling the generator: a coroutine would
- *          keep the read-ahead value in a local across the suspension instead (#99). What a coroutine
- *          would not give us is `peek` -- `std::generator` yields a single-pass input range, so the
- *          one-slot buffer below outlives that migration.
+ * @details New moons and jieqi are read one ahead: this month's end is next month's start, and jieqi
+ *          are read until one falls past it. Both are pushed back because the upstream generators only
+ *          hand out values by advancing -- there is no way to look without taking. #99 pilots
+ *          `std::generator` for those two; an input iterator reads `*it` without advancing, so that
+ *          migration would retire both put-backs here. `_next_month` is a separate thing: it backs
+ *          `peek`, and only `next` empties it.
  */
 struct LunarMonthGenerator {
 private:
@@ -195,7 +196,7 @@ public:
   {}
 
   /** @brief Get the metadata of the next lunar month. */
-  auto next() -> LunarMonth {
+  [[nodiscard]] auto next() -> LunarMonth {
     return next_month();
   }
 

--- a/src/calendar/lunar/algo3.hpp
+++ b/src/calendar/lunar/algo3.hpp
@@ -120,7 +120,7 @@ inline constexpr std::array<uint32_t, (END_YEAR - START_YEAR + 1)> LUNAR_DATA = 
  * @param year The Lunar year. 阴历年份。
  * @return The lunar year information. 阴历年信息。
  */
-inline auto calc_lunar_year(int32_t year) -> LunarYear {
+[[nodiscard]] inline auto calc_lunar_year(int32_t year) -> LunarYear {
   if (year < START_YEAR or year > END_YEAR) {
     throw std::out_of_range {
       std::format("year {} is out of range [{}, {}]", year, START_YEAR, END_YEAR)
@@ -142,8 +142,8 @@ namespace calendar::lunar::common {
 template <>
 struct AlgoMetadata<Algo::ALGO_3> {
   // Not memoized: a `LUNAR_DATA[]` lookup is cheaper than the cache wrapper (#75).
-  static auto get_info_for_year(const int32_t year) -> LunarYear { return algo3::calc_lunar_year(year); }
-  static auto bounds() -> const common::AlgoBounds& { return algo3::bounds; }
+  [[nodiscard]] static auto get_info_for_year(const int32_t year) -> LunarYear { return algo3::calc_lunar_year(year); }
+  [[nodiscard]] static auto bounds() -> const common::AlgoBounds& { return algo3::bounds; }
 };
 
 } // namespace calendar::lunar::common

--- a/src/calendar/lunar/common.hpp
+++ b/src/calendar/lunar/common.hpp
@@ -67,7 +67,7 @@ struct LunarYear {
  * @param encoded The encoded lunar year information. 阴历年信息的编码。
  * @return The lunar year information. 阴历年信息。
  */
-inline auto parse_lunar_year(int32_t year, uint32_t encoded) -> LunarYear { // NOLINT(bugprone-easily-swappable-parameters)
+[[nodiscard]] inline auto parse_lunar_year(int32_t year, uint32_t encoded) -> LunarYear { // NOLINT(bugprone-easily-swappable-parameters)
   const uint32_t days_offset    = encoded >> 17;
   const uint8_t  leap_month     = (encoded >> 13) & 0xf;
   const uint16_t month_len_info = encoded & 0x1fff;
@@ -114,7 +114,7 @@ struct AlgoBounds {
 template <typename Func>
 requires std::invocable<const Func&, int32_t>
      and std::convertible_to<std::invoke_result_t<const Func&, int32_t>, LunarYear>
-inline auto calc_bounds(
+[[nodiscard]] inline auto calc_bounds(
   const int32_t start_lunar_year,
   const int32_t end_lunar_year,
   const Func& algo_f

--- a/src/calendar/lunar/converter.hpp
+++ b/src/calendar/lunar/converter.hpp
@@ -56,7 +56,7 @@ struct Converter {
    * @param date The date. 公历日期。
    * @return `true` if valid, otherwise `false`. 如果有效，返回 `true`，否则返回 `false`。
    */
-  static auto is_valid_gregorian(const year_month_day& date) -> bool {
+  [[nodiscard]] static auto is_valid_gregorian(const year_month_day& date) -> bool {
     if (not date.ok()) {
       return false;
     }
@@ -73,7 +73,7 @@ struct Converter {
    * @param lunar_date The lunar date. 阴历日期。
    * @return `true` if valid, otherwise `false`. 如果有效，返回 `true`，否则返回 `false`。
    */
-  static auto is_valid_lunar(const year_month_day& lunar_date) -> bool {
+  [[nodiscard]] static auto is_valid_lunar(const year_month_day& lunar_date) -> bool {
     if (lunar_date < AlgoMetadata::bounds().first_lunar_date or 
         lunar_date > AlgoMetadata::bounds().last_lunar_date) {
       return false;
@@ -103,7 +103,7 @@ struct Converter {
   * @attention `std::nullopt` is returned if the input date is invalid. No exception is thrown.
                输入的日期无效时返回 `std::nullopt`。不会抛出异常。
   */
-  static auto gregorian_to_lunar(const year_month_day& gregorian_date) -> std::optional<year_month_day> {
+  [[nodiscard]] static auto gregorian_to_lunar(const year_month_day& gregorian_date) -> std::optional<year_month_day> {
     if (not is_valid_gregorian(gregorian_date)) {
       return std::nullopt;
     }
@@ -163,7 +163,7 @@ struct Converter {
   * @attention `std::nullopt` is returned if the input date is invalid. No exception is thrown.
                输入的日期无效时返回 `std::nullopt`。不会抛出异常。
   */
-  static auto lunar_to_gregorian(const year_month_day& lunar_date) -> std::optional<year_month_day> {
+  [[nodiscard]] static auto lunar_to_gregorian(const year_month_day& lunar_date) -> std::optional<year_month_day> {
     if (not is_valid_lunar(lunar_date)) {
       return std::nullopt;
     }

--- a/src/shared_lib/lib.hpp
+++ b/src/shared_lib/lib.hpp
@@ -55,7 +55,7 @@ inline std::atomic<Verbosity> GLOBAL_VERBOSITY = Verbosity::DEBUG; // NOLINT(cpp
 /** @brief Set the verbosity level of log printing.
  *  @return `true` if the level was stored, `false` if `new_verbosity` is out of range.
  */
-inline auto set_verbosity(const Verbosity new_verbosity) -> bool {
+[[nodiscard]] inline auto set_verbosity(const Verbosity new_verbosity) -> bool {
   if (new_verbosity >= Verbosity::COUNT) {
     return false;
   }
@@ -123,7 +123,7 @@ inline auto set_last_error(const std::string& message) noexcept -> void {
 }
 
 /** @brief Read the calling thread's last-error message (empty if none). */
-inline auto last_error_message() -> const char* {
+[[nodiscard]] inline auto last_error_message() -> const char* {
   return LAST_ERROR.c_str();
 }
 

--- a/src/shared_lib/lib_jieqi.cpp
+++ b/src/shared_lib/lib_jieqi.cpp
@@ -34,7 +34,7 @@ extern "C" {
 
 auto query_jieqi_moment(const int32_t year, const uint8_t jq_idx) -> JieqiMomentQuery { // NOLINT(bugprone-easily-swappable-parameters)
   // Validate the input.
-  if (jq_idx >= 24) [[unlikely]] {
+  if (jq_idx >= calendar::jieqi::JIEQI_COUNT) [[unlikely]] {
     return {};
   }
 
@@ -69,7 +69,7 @@ auto query_jieqi_moment(const int32_t year, const uint8_t jq_idx) -> JieqiMoment
 
 auto get_jieqi_name(const uint8_t jq_idx, char * const buf, const uint32_t buf_size) -> bool {
   // Validate the input.
-  if (jq_idx >= 24) [[unlikely]] {
+  if (jq_idx >= calendar::jieqi::JIEQI_COUNT) [[unlikely]] {
     lib::info("Error in get_jieqi_name: jq_idx is {}, but expected to be in the range [0, 24).", jq_idx);
     return false;
   }
@@ -80,7 +80,7 @@ auto get_jieqi_name(const uint8_t jq_idx, char * const buf, const uint32_t buf_s
 
   try {
     using namespace calendar::jieqi;
-    const std::string_view name = JIEQI_NAME.at(jq_idx);
+    const std::string_view name = name_of(from_index(jq_idx));
 
     // Check if the buffer is large enough to hold the name and the null terminator
     if (buf_size < name.size() + 1) {

--- a/src/shared_lib/lib_jieqi.cpp
+++ b/src/shared_lib/lib_jieqi.cpp
@@ -41,7 +41,7 @@ auto query_jieqi_moment(const int32_t year, const uint8_t jq_idx) -> JieqiMoment
   using namespace calendar::jieqi;
 
   try {
-    const auto jq = static_cast<Jieqi>(jq_idx);
+    const auto jq = from_index(jq_idx);
 
     const calendar::Datetime ut1_dt = jieqi_ut1_moment(year, jq);
 

--- a/src/shared_lib/lib_jieqi.cpp
+++ b/src/shared_lib/lib_jieqi.cpp
@@ -80,7 +80,7 @@ auto get_jieqi_name(const uint8_t jq_idx, char * const buf, const uint32_t buf_s
 
   try {
     using namespace calendar::jieqi;
-    const std::string_view name = JIEQI_NAME.at(static_cast<Jieqi>(jq_idx));
+    const std::string_view name = JIEQI_NAME.at(jq_idx);
 
     // Check if the buffer is large enough to hold the name and the null terminator
     if (buf_size < name.size() + 1) {

--- a/src/test/astro/delta_t_test.cpp
+++ b/src/test/astro/delta_t_test.cpp
@@ -22,6 +22,8 @@
  */
 
 #include <gtest/gtest.h>
+
+#include <tuple>
 #include <numeric>
 #include "util.hpp"
 #include "datetime.hpp"
@@ -33,7 +35,7 @@ namespace astro::delta_t_test {
 using namespace astro::delta_t;
 
 TEST(DeltaT, Algo1) {
-  ASSERT_THROW(algo1::compute(-4001), std::out_of_range);
+  ASSERT_THROW(std::ignore = algo1::compute(-4001), std::out_of_range);
 
   // Following data points are not very accurate.
   // Use them just to ensure the function is invokable.
@@ -58,7 +60,7 @@ TEST(DeltaT, Algo2) {
 }
 
 TEST(DeltaT, Algo3) {
-  ASSERT_THROW(algo3::compute(3000.1), std::out_of_range);
+  ASSERT_THROW(std::ignore = algo3::compute(3000.1), std::out_of_range);
 
   // Following data points are not very accurate.
   // Use them just to ensure the function is invokable.
@@ -68,7 +70,7 @@ TEST(DeltaT, Algo3) {
 }
 
 TEST(DeltaT, Algo4) {
-  ASSERT_THROW(algo4::compute(2035.1), std::out_of_range);
+  ASSERT_THROW(std::ignore = algo4::compute(2035.1), std::out_of_range);
 
   // Following data points are not very accurate.
   // Use them just to ensure the function is invokable.

--- a/src/test/astro/julian_day_test.cpp
+++ b/src/test/astro/julian_day_test.cpp
@@ -22,6 +22,8 @@
  */
 
 #include <gtest/gtest.h>
+
+#include <tuple>
 #include <limits>
 #include <unordered_map>
 #include "util.hpp"
@@ -129,31 +131,31 @@ TEST(JulianDay, Consistency) {
 TEST(JulianDay, InvalidInput) {
   // #77: `ut1_to_jd` rejects year < 1 explicitly — its unsigned arithmetic would otherwise
   // wrap around and silently produce a garbage JD (release builds included).
-  ASSERT_THROW(ut1_to_jd(Datetime { to_ymd(0, 1, 1), 0.0 }), std::runtime_error);
-  ASSERT_THROW(ut1_to_jd(Datetime { to_ymd(0, 2, 29), 0.5 }), std::runtime_error);
-  ASSERT_THROW(ut1_to_jd(Datetime { to_ymd(-1, 12, 31), 0.99 }), std::runtime_error);
-  ASSERT_THROW(ut1_to_jd(Datetime { to_ymd(-4712, 1, 1), 0.0 }), std::runtime_error);
+  ASSERT_THROW(std::ignore = ut1_to_jd(Datetime { to_ymd(0, 1, 1), 0.0 }), std::runtime_error);
+  ASSERT_THROW(std::ignore = ut1_to_jd(Datetime { to_ymd(0, 2, 29), 0.5 }), std::runtime_error);
+  ASSERT_THROW(std::ignore = ut1_to_jd(Datetime { to_ymd(-1, 12, 31), 0.99 }), std::runtime_error);
+  ASSERT_THROW(std::ignore = ut1_to_jd(Datetime { to_ymd(-4712, 1, 1), 0.0 }), std::runtime_error);
 
   // The wrappers propagate the throw (this is what turns the C-ABI garbage into an error).
-  ASSERT_THROW(tt_to_jde(Datetime { to_ymd(0, 1, 1), 0.0 }), std::runtime_error);
+  ASSERT_THROW(std::ignore = tt_to_jde(Datetime { to_ymd(0, 1, 1), 0.0 }), std::runtime_error);
 
   // Both directions throw the same exception type on out-of-domain input. Their domains differ:
   // `ut1_to_jd` accepts years 1-400 that sit below `jd_to_ut1`'s bound, so round-trips only
   // close from 401-01-01 onwards.
-  ASSERT_THROW(jd_to_ut1(-5.0), std::runtime_error); // Negative finite values throw, not abort.
-  ASSERT_THROW(jd_to_ut1(1.0), std::runtime_error);
-  ASSERT_THROW(jd_to_ut1(1867522.4999), std::runtime_error); // 400-12-31, just below the bound.
+  ASSERT_THROW(std::ignore = jd_to_ut1(-5.0), std::runtime_error); // Negative finite values throw, not abort.
+  ASSERT_THROW(std::ignore = jd_to_ut1(1.0), std::runtime_error);
+  ASSERT_THROW(std::ignore = jd_to_ut1(1867522.4999), std::runtime_error); // 400-12-31, just below the bound.
 
   // Non-finite JDs bypass ordinary range checks (NaN comparisons are false) — rejected first.
-  ASSERT_THROW(jd_to_ut1(std::numeric_limits<double>::quiet_NaN()), std::runtime_error);
-  ASSERT_THROW(jd_to_ut1(std::numeric_limits<double>::infinity()), std::runtime_error);
-  ASSERT_THROW(jd_to_ut1(-std::numeric_limits<double>::infinity()), std::runtime_error);
+  ASSERT_THROW(std::ignore = jd_to_ut1(std::numeric_limits<double>::quiet_NaN()), std::runtime_error);
+  ASSERT_THROW(std::ignore = jd_to_ut1(std::numeric_limits<double>::infinity()), std::runtime_error);
+  ASSERT_THROW(std::ignore = jd_to_ut1(-std::numeric_limits<double>::infinity()), std::runtime_error);
 
   // #67: above JD 13689325.5 (conceptually 32768-01-01) `std::chrono::year` overflows, and the
   // uint32 arithmetic wraps into valid-looking but wrong dates.
-  ASSERT_NO_THROW(jd_to_ut1(13689325.499999));
-  ASSERT_THROW(jd_to_ut1(13689325.5), std::runtime_error);
-  ASSERT_THROW(jd_to_ut1(4.0e9), std::runtime_error); // wrapped to 2403-12-05 before #67.
+  ASSERT_NO_THROW(std::ignore = jd_to_ut1(13689325.499999));
+  ASSERT_THROW(std::ignore = jd_to_ut1(13689325.5), std::runtime_error);
+  ASSERT_THROW(std::ignore = jd_to_ut1(4.0e9), std::runtime_error); // wrapped to 2403-12-05 before #67.
 
   // Smallest supported year converts correctly: JD of 1-01-01 00:00 (gregorian) is 1721425.5.
   ASSERT_NEAR(ut1_to_jd(Datetime { to_ymd(1, 1, 1), 0.0 }), 1721425.5, EPSILON);

--- a/src/test/astro/leap_second_test.cpp
+++ b/src/test/astro/leap_second_test.cpp
@@ -22,6 +22,8 @@
  */
 
 #include <gtest/gtest.h>
+
+#include <tuple>
 #include <chrono>
 #include <cstdlib>
 #include <random>
@@ -93,7 +95,7 @@ TEST(LeapSecond, TaiMinusUtcLookup) {
   // Past the last entry ΔAT is held (CGPM 2022 Res. 4: no more leap seconds by 2035).
   ASSERT_EQ(tai_minus_utc(to_ymd(5000,  1,  1)), 37.0);
 
-  ASSERT_THROW({ tai_minus_utc(to_ymd(1971, 12, 31)); }, std::invalid_argument);
+  ASSERT_THROW({ std::ignore = tai_minus_utc(to_ymd(1971, 12, 31)); }, std::invalid_argument);
 }
 
 

--- a/src/test/astro/solar_time_test.cpp
+++ b/src/test/astro/solar_time_test.cpp
@@ -23,6 +23,8 @@
 
 #include <gtest/gtest.h>
 
+#include <tuple>
+
 #include <array>
 #include <chrono>
 #include <cmath>
@@ -346,11 +348,11 @@ TEST(SolarTime, ApparentSolarTimeGolden) {
 
 TEST(SolarTime, ApparentRejectsBadLongitude) {
   const auto utc = calendar::Datetime { util::to_ymd(2024, 6, 1), 0.5 };
-  ASSERT_THROW({ apparent(utc, AngleDeg { 180.5 }); },  std::invalid_argument);
-  ASSERT_THROW({ apparent(utc, AngleDeg { -181.0 }); }, std::invalid_argument);
-  ASSERT_THROW({ apparent(utc, AngleDeg { std::numeric_limits<double>::quiet_NaN() }); }, std::invalid_argument);
-  ASSERT_NO_THROW({ apparent(utc, AngleDeg { 180.0 }); });
-  ASSERT_NO_THROW({ apparent(utc, AngleDeg { -180.0 }); });
+  ASSERT_THROW({ std::ignore = apparent(utc, AngleDeg { 180.5 }); },  std::invalid_argument);
+  ASSERT_THROW({ std::ignore = apparent(utc, AngleDeg { -181.0 }); }, std::invalid_argument);
+  ASSERT_THROW({ std::ignore = apparent(utc, AngleDeg { std::numeric_limits<double>::quiet_NaN() }); }, std::invalid_argument);
+  ASSERT_NO_THROW({ std::ignore = apparent(utc, AngleDeg { 180.0 }); });
+  ASSERT_NO_THROW({ std::ignore = apparent(utc, AngleDeg { -180.0 }); });
 }
 
 } // namespace astro::solar_time::test

--- a/src/test/astro/sunrise_sunset_test.cpp
+++ b/src/test/astro/sunrise_sunset_test.cpp
@@ -379,27 +379,27 @@ TEST(SunriseSunset, InvalidInputsThrow) {
   const auto ymd = util::to_ymd(2024, 6, 21);
   constexpr double NAN_D = std::numeric_limits<double>::quiet_NaN();
 
-  ASSERT_THROW((void) transit_jde(ymd, loc(90.5, 0.0)), std::invalid_argument);
-  ASSERT_THROW((void) transit_jde(ymd, loc(0.0, 180.5)), std::invalid_argument);
-  ASSERT_THROW((void) transit_jde(ymd, loc(NAN_D, 0.0)), std::invalid_argument);
-  ASSERT_THROW((void) transit_jde(ymd, loc(0.0, NAN_D)), std::invalid_argument);
+  ASSERT_THROW(std::ignore = transit_jde(ymd, loc(90.5, 0.0)), std::invalid_argument);
+  ASSERT_THROW(std::ignore = transit_jde(ymd, loc(0.0, 180.5)), std::invalid_argument);
+  ASSERT_THROW(std::ignore = transit_jde(ymd, loc(NAN_D, 0.0)), std::invalid_argument);
+  ASSERT_THROW(std::ignore = transit_jde(ymd, loc(0.0, NAN_D)), std::invalid_argument);
 
   // An invalid gregorian date is rejected by `Datetime`'s constructor.
-  ASSERT_THROW((void) transit_jde(util::to_ymd(2024, 2, 30), EQUATOR), std::invalid_argument);
+  ASSERT_THROW(std::ignore = transit_jde(util::to_ymd(2024, 2, 30), EQUATOR), std::invalid_argument);
 
   const double transit = transit_jde(ymd, EQUATOR);
-  ASSERT_THROW((void) rise_set_jde(NAN_D, true, EQUATOR), std::invalid_argument);
-  ASSERT_THROW((void) rise_set_jde(transit, true, EQUATOR, AngleDeg { NAN_D }), std::invalid_argument);
-  ASSERT_THROW((void) rise_set_jde(transit, true, EQUATOR, AngleDeg { 100.0 }), std::invalid_argument);
-  ASSERT_THROW((void) rise_set_jde(transit, true, loc(-91.0, 0.0)), std::invalid_argument);
+  ASSERT_THROW(std::ignore = rise_set_jde(NAN_D, true, EQUATOR), std::invalid_argument);
+  ASSERT_THROW(std::ignore = rise_set_jde(transit, true, EQUATOR, AngleDeg { NAN_D }), std::invalid_argument);
+  ASSERT_THROW(std::ignore = rise_set_jde(transit, true, EQUATOR, AngleDeg { 100.0 }), std::invalid_argument);
+  ASSERT_THROW(std::ignore = rise_set_jde(transit, true, loc(-91.0, 0.0)), std::invalid_argument);
 
   // hour_angle_at_altitude is public API too: out-of-domain angles alias through sin/cos into
   // physically meaningless H₀ values, so they are rejected rather than returned (per review).
-  ASSERT_THROW((void) hour_angle_at_altitude(AngleDeg { NAN_D }, AngleDeg { 0.0 }, AngleDeg { 0.0 }),
+  ASSERT_THROW(std::ignore = hour_angle_at_altitude(AngleDeg { NAN_D }, AngleDeg { 0.0 }, AngleDeg { 0.0 }),
                std::invalid_argument);
-  ASSERT_THROW((void) hour_angle_at_altitude(AngleDeg { 0.0 }, AngleDeg { 95.0 }, AngleDeg { 0.0 }),
+  ASSERT_THROW(std::ignore = hour_angle_at_altitude(AngleDeg { 0.0 }, AngleDeg { 95.0 }, AngleDeg { 0.0 }),
                std::invalid_argument);
-  ASSERT_THROW((void) hour_angle_at_altitude(AngleDeg { 0.0 }, AngleDeg { 0.0 }, AngleDeg { 100.0 }),
+  ASSERT_THROW(std::ignore = hour_angle_at_altitude(AngleDeg { 0.0 }, AngleDeg { 0.0 }, AngleDeg { 100.0 }),
                std::invalid_argument);
 }
 

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <limits>
 #include <numbers>
+#include <numeric>
 #include <stdexcept>
 #include <tuple>
 #include <type_traits>

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -26,6 +26,7 @@
 #include <limits>
 #include <numbers>
 #include <stdexcept>
+#include <tuple>
 #include <type_traits>
 #include "toolbox.hpp"
 #include "util.hpp"
@@ -177,11 +178,11 @@ TEST(AstroMath, NormalizeRejectsNonFinite) {
   constexpr double NAN_D = std::numeric_limits<double>::quiet_NaN();
 
   for (const double bad : { INF_D, -INF_D, NAN_D }) {
-    ASSERT_THROW((void) normalize_deg(bad), std::invalid_argument);
-    ASSERT_THROW((void) normalize_rad(bad), std::invalid_argument);
-    ASSERT_THROW((void) normalize_pm180(bad), std::invalid_argument);
-    ASSERT_THROW((void) Angle<AngleUnit::DEG> { bad }.normalize(), std::invalid_argument);
-    ASSERT_THROW((void) Angle<AngleUnit::RAD> { bad }.normalize(), std::invalid_argument);
+    ASSERT_THROW(std::ignore = normalize_deg(bad), std::invalid_argument);
+    ASSERT_THROW(std::ignore = normalize_rad(bad), std::invalid_argument);
+    ASSERT_THROW(std::ignore = normalize_pm180(bad), std::invalid_argument);
+    ASSERT_THROW(std::ignore = Angle<AngleUnit::DEG> { bad }.normalize(), std::invalid_argument);
+    ASSERT_THROW(std::ignore = Angle<AngleUnit::RAD> { bad }.normalize(), std::invalid_argument);
   }
 }
 
@@ -310,11 +311,11 @@ TEST(AstroMath, AngleDivisionByZeroThrows) {
 
   // The contract (#48): a zero divisor is a caller mistake, not a state to hand on as ±inf.
   const auto angle = 30.0_deg;
-  ASSERT_THROW((void) (angle / 0.0), std::runtime_error);
-  ASSERT_THROW((void) (angle / -0.0), std::runtime_error); // IEEE says -0.0 == 0.0; so does the guard.
+  ASSERT_THROW(std::ignore = (angle / 0.0), std::runtime_error);
+  ASSERT_THROW(std::ignore = (angle / -0.0), std::runtime_error); // IEEE says -0.0 == 0.0; so does the guard.
 
   // The guard tests for zero, not for smallness — a denormal divisor still divides.
-  ASSERT_NO_THROW((void) (angle / std::numeric_limits<double>::denorm_min()));
+  ASSERT_NO_THROW(std::ignore = (angle / std::numeric_limits<double>::denorm_min()));
 }
 
 

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -405,7 +405,7 @@ TEST(AstroMath, NewtonMethodKeepsBestIterate) {
   // on the root, iteration 1 leaves for the edge and stays: only a retained iterate can come back.
   constexpr double start_jde = 2451545.0;
   constexpr double end_jde   = 2451546.0;
-  constexpr double root      = (start_jde + end_jde) / 2.0; // the solver's own first iterate
+  constexpr double root      = std::midpoint(start_jde, end_jde); // the solver's own first iterate
 
   const auto visits_root_then_diverges = [](const double jde) -> double {
     if (std::fabs(jde - root) < 1e-6) {

--- a/src/test/datetime_test.cpp
+++ b/src/test/datetime_test.cpp
@@ -22,6 +22,8 @@
  */
 
 #include <gtest/gtest.h>
+
+#include <tuple>
 #include <print>
 #include <limits>
 #include <ranges>
@@ -451,14 +453,14 @@ TEST(Datetime, AddSeconds) {
   ASSERT_EQ(back, (Datetime { util::to_ymd(2024, 6, 15), 0.0 }));
 
   // Non-finite or day-carry-overflowing offsets must throw, not reach the float→int cast.
-  ASSERT_THROW({ add_seconds(noon, std::numeric_limits<double>::quiet_NaN()); }, std::invalid_argument);
-  ASSERT_THROW({ add_seconds(noon, 4e14); }, std::invalid_argument);
-  ASSERT_THROW({ add_seconds(noon, -4e14); }, std::invalid_argument);
+  ASSERT_THROW({ std::ignore = add_seconds(noon, std::numeric_limits<double>::quiet_NaN()); }, std::invalid_argument);
+  ASSERT_THROW({ std::ignore = add_seconds(noon, 4e14); }, std::invalid_argument);
+  ASSERT_THROW({ std::ignore = add_seconds(noon, -4e14); }, std::invalid_argument);
 
   // Offsets under the day-carry bound can still leave `chrono::year`'s ±32767 — beyond it the
   // stored year is unspecified and `ok()` cannot be trusted, so this must throw, not wrap.
-  ASSERT_THROW({ add_seconds(noon, 86400.0 * 2.0e7); }, std::invalid_argument);
-  ASSERT_THROW({ add_seconds(noon, -86400.0 * 2.0e7); }, std::invalid_argument);
+  ASSERT_THROW({ std::ignore = add_seconds(noon, 86400.0 * 2.0e7); }, std::invalid_argument);
+  ASSERT_THROW({ std::ignore = add_seconds(noon, -86400.0 * 2.0e7); }, std::invalid_argument);
 }
 
 } // namespace calendar::test

--- a/src/test/jieqi_golden_test.cpp
+++ b/src/test/jieqi_golden_test.cpp
@@ -91,9 +91,9 @@ struct HkoRow {
 
 /** @brief Inverse of `JIEQI_SOLAR_LONGITUDE` (24 entries, exact doubles). */
 auto jieqi_from_lon(const double lon_deg) -> Jieqi {
-  for (uint8_t idx = 0; idx < JIEQI_COUNT; ++idx) {
-    if (JIEQI_SOLAR_LONGITUDE.at(idx) == lon_deg) {
-      return from_index(idx);
+  for (const auto jq : JIEQI_LIST) {
+    if (longitude_of(jq) == lon_deg) {
+      return jq;
     }
   }
   throw std::invalid_argument { "no jieqi has solar longitude " + std::to_string(lon_deg) };

--- a/src/test/jieqi_golden_test.cpp
+++ b/src/test/jieqi_golden_test.cpp
@@ -91,9 +91,9 @@ struct HkoRow {
 
 /** @brief Inverse of `JIEQI_SOLAR_LONGITUDE` (24 entries, exact doubles). */
 auto jieqi_from_lon(const double lon_deg) -> Jieqi {
-  for (const auto& [jq, lon] : JIEQI_SOLAR_LONGITUDE) {
-    if (lon == lon_deg) {
-      return jq;
+  for (uint8_t idx = 0; idx < JIEQI_COUNT; ++idx) {
+    if (JIEQI_SOLAR_LONGITUDE.at(idx) == lon_deg) {
+      return from_index(idx);
     }
   }
   throw std::invalid_argument { "no jieqi has solar longitude " + std::to_string(lon_deg) };

--- a/src/test/jieqi_test.cpp
+++ b/src/test/jieqi_test.cpp
@@ -39,19 +39,19 @@ using namespace astro::sun::geocentric_coord::math;
 // minute-precision values, single continuous JD assertion) and DE441-derived crossings.
 
 TEST(JieQi, NameQuery) {
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::立春)), 315.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::雨水)), 330.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::惊蛰)), 345.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::春分)), 0.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::清明)), 15.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::秋分)), 180.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::小雪)), 240.0);
+  ASSERT_EQ(longitude_of(Jieqi::立春), 315.0);
+  ASSERT_EQ(longitude_of(Jieqi::雨水), 330.0);
+  ASSERT_EQ(longitude_of(Jieqi::惊蛰), 345.0);
+  ASSERT_EQ(longitude_of(Jieqi::春分), 0.0);
+  ASSERT_EQ(longitude_of(Jieqi::清明), 15.0);
+  ASSERT_EQ(longitude_of(Jieqi::秋分), 180.0);
+  ASSERT_EQ(longitude_of(Jieqi::小雪), 240.0);
 
   // Test couple English aliases as well.
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::LICHUN)),  315.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::CHUNFEN)), 0.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::XIAOHAN)), 285.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::DAHAN)),   300.0);
+  ASSERT_EQ(longitude_of(Jieqi::LICHUN),  315.0);
+  ASSERT_EQ(longitude_of(Jieqi::CHUNFEN), 0.0);
+  ASSERT_EQ(longitude_of(Jieqi::XIAOHAN), 285.0);
+  ASSERT_EQ(longitude_of(Jieqi::DAHAN),   300.0);
 }
 
 
@@ -84,7 +84,7 @@ TEST(JieQi, JDE) {
       const auto jde = jieqi_jde(year, jq); // Use Newton's method to find the root.
 
       const auto jde_lon = detail::solar_longitude(jde);
-      const auto expected_lon = JIEQI_SOLAR_LONGITUDE.at(to_index(jq));
+      const auto expected_lon = longitude_of(jq);
 
       const auto lon_diff = std::fabs(std::fmod(jde_lon - expected_lon, 360.0));
       ASSERT_TRUE((lon_diff < 1e-9) or (lon_diff > 360.0 - 1e-9));

--- a/src/test/jieqi_test.cpp
+++ b/src/test/jieqi_test.cpp
@@ -39,19 +39,19 @@ using namespace astro::sun::geocentric_coord::math;
 // minute-precision values, single continuous JD assertion) and DE441-derived crossings.
 
 TEST(JieQi, NameQuery) {
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(Jieqi::立春), 315.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(Jieqi::雨水), 330.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(Jieqi::惊蛰), 345.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(Jieqi::春分), 0.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(Jieqi::清明), 15.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(Jieqi::秋分), 180.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(Jieqi::小雪), 240.0);
+  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::立春)), 315.0);
+  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::雨水)), 330.0);
+  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::惊蛰)), 345.0);
+  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::春分)), 0.0);
+  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::清明)), 15.0);
+  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::秋分)), 180.0);
+  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::小雪)), 240.0);
 
   // Test couple English aliases as well.
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(Jieqi::LICHUN),  315.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(Jieqi::CHUNFEN), 0.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(Jieqi::XIAOHAN), 285.0);
-  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(Jieqi::DAHAN),   300.0);
+  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::LICHUN)),  315.0);
+  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::CHUNFEN)), 0.0);
+  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::XIAOHAN)), 285.0);
+  ASSERT_EQ(JIEQI_SOLAR_LONGITUDE.at(to_index(Jieqi::DAHAN)),   300.0);
 }
 
 
@@ -84,7 +84,7 @@ TEST(JieQi, JDE) {
       const auto jde = jieqi_jde(year, jq); // Use Newton's method to find the root.
 
       const auto jde_lon = detail::solar_longitude(jde);
-      const auto expected_lon = JIEQI_SOLAR_LONGITUDE.at(jq);
+      const auto expected_lon = JIEQI_SOLAR_LONGITUDE.at(to_index(jq));
 
       const auto lon_diff = std::fabs(std::fmod(jde_lon - expected_lon, 360.0));
       ASSERT_TRUE((lon_diff < 1e-9) or (lon_diff > 360.0 - 1e-9));

--- a/src/test/lunar/algo1_test.cpp
+++ b/src/test/lunar/algo1_test.cpp
@@ -22,6 +22,8 @@
  */
 
 #include <gtest/gtest.h>
+
+#include <tuple>
 #include <vector>
 #include "random.hpp"
 #include "lunar/algo1.hpp"
@@ -37,8 +39,8 @@ TEST(LunarAlgo1, ArraySize) {
 }
 
 TEST(LunarAlgo1, LunarYear) {
-  ASSERT_THROW(calc_lunar_year(START_YEAR - 1), std::out_of_range);
-  ASSERT_THROW(calc_lunar_year(END_YEAR + 1), std::out_of_range);
+  ASSERT_THROW(std::ignore = calc_lunar_year(START_YEAR - 1), std::out_of_range);
+  ASSERT_THROW(std::ignore = calc_lunar_year(END_YEAR + 1), std::out_of_range);
 
   const auto check_month_lengths = [](const auto& l1, const auto& l2) -> bool {
     if (l1.size() != l2.size()) {

--- a/src/test/lunar/algo2_test.cpp
+++ b/src/test/lunar/algo2_test.cpp
@@ -22,6 +22,8 @@
  */
 
 #include <gtest/gtest.h>
+
+#include <tuple>
 #include <algorithm>
 #include "lunar/algo2.hpp"
 
@@ -310,8 +312,8 @@ TEST(LunarAlgo2, GetLunarInfo) {
 
 
 TEST(LunarAlgo2, YearOutOfRange) {
-  ASSERT_THROW(calc_lunar_year(START_YEAR - 1), std::out_of_range);
-  ASSERT_THROW(calc_lunar_year(END_YEAR + 1), std::out_of_range);
+  ASSERT_THROW(std::ignore = calc_lunar_year(START_YEAR - 1), std::out_of_range);
+  ASSERT_THROW(std::ignore = calc_lunar_year(END_YEAR + 1), std::out_of_range);
 
   // The C ABI reaches algo2 only through the cached wrapper, so the guard has to survive it.
   ASSERT_THROW(get_info_for_year(START_YEAR - 1), std::out_of_range);

--- a/src/test/lunar/algo2_test.cpp
+++ b/src/test/lunar/algo2_test.cpp
@@ -154,7 +154,7 @@ TEST(LunarAlgo2, LeapMonth) {
 
     const auto is_leap = [](const LunarMonth& month) {
       const auto& jq_pairs = month.contained_jieqis;
-      return not std::any_of(cbegin(jq_pairs), cend(jq_pairs), [](const auto& jq_pair) {
+      return not std::ranges::any_of(jq_pairs, [](const auto& jq_pair) {
         return is_qi(jq_pair.jieqi);
       });
     };

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -412,11 +412,8 @@ TEST(Util, MakeCachedThreadSafe) {
 }
 
 
-// #81 item 18 moved seed parsing from `strtoull` + `errno` to `std::from_chars`.
-//
-// These assertions pin the contract, not a defect: they pass on the old implementation too,
-// and that is exactly the acceptance criterion -- every input keeps the fate it already had.
-// The one intended difference is that `errno`, a process-global, is no longer touched.
+// Seed-override contract: only a fully-consumed non-negative decimal numeral is honored.
+// A leading sign or space, trailing junk, and overflow all fall back to the default.
 TEST(Random, ParseSeedAcceptsPlainNumerals) {
   using util::detail::parse_seed;
   ASSERT_EQ(parse_seed("0"), 0U);
@@ -431,7 +428,7 @@ TEST(Random, ParseSeedRejectsEverythingElse) {
   ASSERT_FALSE(parse_seed("").has_value());               // Empty
   ASSERT_FALSE(parse_seed(" 42").has_value());            // Leading space
   ASSERT_FALSE(parse_seed("+42").has_value());            // Explicit plus
-  ASSERT_FALSE(parse_seed("-1").has_value());             // Minus -- `strtoull` wrapped this to ULLONG_MAX
+  ASSERT_FALSE(parse_seed("-1").has_value());             // Leading minus
   ASSERT_FALSE(parse_seed("42abc").has_value());          // Trailing garbage
   ASSERT_FALSE(parse_seed("0x10").has_value());           // Hex prefix: the `x` after `0` is left unconsumed
   ASSERT_FALSE(parse_seed("1e3").has_value());            // Scientific notation

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -22,6 +22,8 @@
  */
 
 #include <gtest/gtest.h>
+
+#include <limits>
 #include <print>
 #include <atomic>
 #include <cmath>
@@ -407,6 +409,35 @@ TEST(Util, MakeCachedThreadSafe) {
   // Every key computed at least once; concurrent misses on a key may compute a few extras.
   ASSERT_GE(call_count, KEY_COUNT);
   ASSERT_LE(call_count, THREAD_COUNT * KEY_COUNT);
+}
+
+
+// #81 第 18 项:种子解析从 `strtoull` + `errno` 换到 `std::from_chars`。
+//
+// 这批断言钉的是**契约**,不是缺陷 —— 它们在旧实现上同样全绿,而那正是验收要的:
+// 证明换实现没有改变任何一种输入的归宿。唯一有意的差别是不再触碰 `errno`,
+// 那是个进程全局副作用,没有调用方依赖它。
+// 对拍见 `.review/style-arch/probe_pdelta_c5_seed_equiv.cpp`。
+TEST(Random, ParseSeedAcceptsPlainNumerals) {
+  using util::detail::parse_seed;
+  ASSERT_EQ(parse_seed("0"), 0U);
+  ASSERT_EQ(parse_seed("42"), 42U);
+  ASSERT_EQ(parse_seed("0042"), 42U);
+  ASSERT_EQ(parse_seed("18446744073709551615"), std::numeric_limits<uint64_t>::max());
+}
+
+TEST(Random, ParseSeedRejectsEverythingElse) {
+  using util::detail::parse_seed;
+  ASSERT_FALSE(parse_seed(nullptr).has_value());          // 未设置
+  ASSERT_FALSE(parse_seed("").has_value());               // 空串
+  ASSERT_FALSE(parse_seed(" 42").has_value());            // 前导空白
+  ASSERT_FALSE(parse_seed("+42").has_value());            // 显式正号
+  ASSERT_FALSE(parse_seed("-1").has_value());             // 负号 —— strtoull 会把它回绕成 ULLONG_MAX
+  ASSERT_FALSE(parse_seed("42abc").has_value());          // 尾随垃圾
+  ASSERT_FALSE(parse_seed("0x10").has_value());           // 十六进制前缀:`0` 之后 `x` 没被消费
+  ASSERT_FALSE(parse_seed("1e3").has_value());            // 科学计数法
+  ASSERT_FALSE(parse_seed("abc").has_value());            // 完全不是数
+  ASSERT_FALSE(parse_seed("18446744073709551616").has_value());  // 溢出 uint64
 }
 
 } // namespace util::test

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -412,12 +412,11 @@ TEST(Util, MakeCachedThreadSafe) {
 }
 
 
-// #81 第 18 项:种子解析从 `strtoull` + `errno` 换到 `std::from_chars`。
+// #81 item 18 moved seed parsing from `strtoull` + `errno` to `std::from_chars`.
 //
-// 这批断言钉的是**契约**,不是缺陷 —— 它们在旧实现上同样全绿,而那正是验收要的:
-// 证明换实现没有改变任何一种输入的归宿。唯一有意的差别是不再触碰 `errno`,
-// 那是个进程全局副作用,没有调用方依赖它。
-// 对拍见 `.review/style-arch/probe_pdelta_c5_seed_equiv.cpp`。
+// These assertions pin the contract, not a defect: they pass on the old implementation too,
+// and that is exactly the acceptance criterion -- every input keeps the fate it already had.
+// The one intended difference is that `errno`, a process-global, is no longer touched.
 TEST(Random, ParseSeedAcceptsPlainNumerals) {
   using util::detail::parse_seed;
   ASSERT_EQ(parse_seed("0"), 0U);
@@ -428,16 +427,16 @@ TEST(Random, ParseSeedAcceptsPlainNumerals) {
 
 TEST(Random, ParseSeedRejectsEverythingElse) {
   using util::detail::parse_seed;
-  ASSERT_FALSE(parse_seed(nullptr).has_value());          // 未设置
-  ASSERT_FALSE(parse_seed("").has_value());               // 空串
-  ASSERT_FALSE(parse_seed(" 42").has_value());            // 前导空白
-  ASSERT_FALSE(parse_seed("+42").has_value());            // 显式正号
-  ASSERT_FALSE(parse_seed("-1").has_value());             // 负号 —— strtoull 会把它回绕成 ULLONG_MAX
-  ASSERT_FALSE(parse_seed("42abc").has_value());          // 尾随垃圾
-  ASSERT_FALSE(parse_seed("0x10").has_value());           // 十六进制前缀:`0` 之后 `x` 没被消费
-  ASSERT_FALSE(parse_seed("1e3").has_value());            // 科学计数法
-  ASSERT_FALSE(parse_seed("abc").has_value());            // 完全不是数
-  ASSERT_FALSE(parse_seed("18446744073709551616").has_value());  // 溢出 uint64
+  ASSERT_FALSE(parse_seed(nullptr).has_value());          // Unset
+  ASSERT_FALSE(parse_seed("").has_value());               // Empty
+  ASSERT_FALSE(parse_seed(" 42").has_value());            // Leading space
+  ASSERT_FALSE(parse_seed("+42").has_value());            // Explicit plus
+  ASSERT_FALSE(parse_seed("-1").has_value());             // Minus -- `strtoull` wrapped this to ULLONG_MAX
+  ASSERT_FALSE(parse_seed("42abc").has_value());          // Trailing garbage
+  ASSERT_FALSE(parse_seed("0x10").has_value());           // Hex prefix: the `x` after `0` is left unconsumed
+  ASSERT_FALSE(parse_seed("1e3").has_value());            // Scientific notation
+  ASSERT_FALSE(parse_seed("abc").has_value());            // Not a number at all
+  ASSERT_FALSE(parse_seed("18446744073709551616").has_value());  // Overflows uint64
 }
 
 } // namespace util::test

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -413,7 +413,7 @@ TEST(Util, MakeCachedThreadSafe) {
 
 
 // Seed-override contract: only a fully-consumed non-negative decimal numeral is honored.
-// A leading sign or space, trailing junk, and overflow all fall back to the default.
+// These pass on the pre-#81 `strtoull` implementation too -- a no-regression pin, not a fix.
 TEST(Random, ParseSeedAcceptsPlainNumerals) {
   using util::detail::parse_seed;
   ASSERT_EQ(parse_seed("0"), 0U);

--- a/src/util/cache.hpp
+++ b/src/util/cache.hpp
@@ -46,7 +46,7 @@ using util::hash::TupleHash;
  * @return The cached function. Thread-safe; copies share one cache (#78).
  */
 template <typename RetType, typename... Args>
-inline auto make_cached(const std::function<RetType(Args...)>& func) -> std::function<RetType(Args...)> {
+[[nodiscard]] inline auto make_cached(const std::function<RetType(Args...)>& func) -> std::function<RetType(Args...)> {
   // Cache and mutex live behind a `shared_ptr`, so copying the returned
   // `std::function` shares one cache instead of forking divergent replicas (#78).
   struct State {
@@ -89,7 +89,7 @@ concept FunctionConvertible = requires(T t) {
  * @param func The function to cache.
  * @return The cached function.
  */
-inline auto cache_func(const FunctionConvertible auto& func) {
+[[nodiscard]] inline auto cache_func(const FunctionConvertible auto& func) {
   return make_cached(std::function(func));
 }
 

--- a/src/util/hash.hpp
+++ b/src/util/hash.hpp
@@ -32,7 +32,7 @@
 namespace util::hash {
 
 template <typename T>
-inline auto hash_combine(std::size_t seed, T&& v) -> std::size_t {
+[[nodiscard]] inline auto hash_combine(std::size_t seed, T&& v) -> std::size_t {
   // NOLINTBEGIN(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
   // Don't lint this code, because clang-tidy complains about calculating hash for `std::string`.
   auto v_hash = std::hash<std::decay_t<T>>{}(std::forward<T>(v));
@@ -46,12 +46,12 @@ inline auto hash_combine(std::size_t seed, T&& v) -> std::size_t {
 }
 
 template <typename T>
-inline auto hash(T&& v) -> std::size_t {
+[[nodiscard]] inline auto hash(T&& v) -> std::size_t {
   return std::hash<std::decay_t<T>>{}(std::forward<T>(v));
 }
 
 template <typename T, typename... Rest>
-inline auto hash(T&& v, Rest&&... rest) -> std::size_t {
+[[nodiscard]] inline auto hash(T&& v, Rest&&... rest) -> std::size_t {
   std::size_t seed = hash(std::forward<T>(v));
   (..., (seed = hash_combine(seed, std::forward<Rest>(rest))));
   return seed;
@@ -64,14 +64,14 @@ concept IsTuple = requires {
 };
 
 template <IsTuple T>
-inline auto hash(T&& t) -> std::size_t {
+[[nodiscard]] inline auto hash(T&& t) -> std::size_t {
   return std::apply([](auto&&... args) { return hash(std::forward<decltype(args)>(args)...); }, std::forward<T>(t));
 }
 
 
 template <typename... Args>
 struct TupleHash {
-  auto operator()(const std::tuple<Args...>& t) const -> std::size_t {
+  [[nodiscard]] auto operator()(const std::tuple<Args...>& t) const -> std::size_t {
     return std::apply([](const auto&... elems) {
       return hash(elems...);
     }, t);

--- a/src/util/hash.hpp
+++ b/src/util/hash.hpp
@@ -59,6 +59,7 @@ template <typename T, typename... Rest>
 
 /** @brief A concept which ensures the type is tuple-like. */
 template <typename T>
+// TODO: Use `std::tuple_like` once every CI leg has it (./linter.py --features). (#81)
 concept IsTuple = requires {
   typename std::tuple_size<T>::type;
 };

--- a/src/util/random.hpp
+++ b/src/util/random.hpp
@@ -63,9 +63,8 @@ inline constexpr uint64_t DEFAULT_SEED = 42;
   uint64_t parsed = 0;
   const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), parsed);
 
-  // Not consumed in full, or overflowed -- both fall back, exactly as the `strtoull` version did.
-  // The difference is that `from_chars` reports them through its own result instead of `errno`,
-  // so parsing an env var no longer writes a process-global as a side effect.
+  // Partial consume or overflow -- both fall back. `from_chars` reports them through its own
+  // result, so parsing an env var no longer writes `errno`, a process-global, as a side effect.
   if (ec != std::errc {} or ptr != sv.data() + sv.size()) {
     return std::nullopt;
   }

--- a/src/util/random.hpp
+++ b/src/util/random.hpp
@@ -44,7 +44,7 @@ namespace util::detail {
 
 inline constexpr uint64_t DEFAULT_SEED = 42;
 
-inline auto random_seed() -> uint64_t {
+[[nodiscard]] inline auto random_seed() -> uint64_t {
   // Only a fully-consumed, non-negative decimal numeral is honored (yes, 0 is a valid
   // seed); anything else — unset, leading whitespace/sign, trailing junk, overflow —
   // falls back to the default.
@@ -78,7 +78,7 @@ inline void print_random_seed_once() {
 
 // One engine per thread, all sharing the same seed — per-thread sequences are deterministic
 // and identical, which keeps multi-threaded tests reproducible without locking.
-inline auto engine() -> std::mt19937_64& {
+[[nodiscard]] inline auto engine() -> std::mt19937_64& {
   static thread_local auto eng = [] {
     print_random_seed_once();
     // Two-step (not brace-init): clang-tidy's narrowing check misresolves the ctor's
@@ -104,7 +104,7 @@ namespace util {
  */
 template <typename T>
   requires std::integral<T> || std::floating_point<T>
-inline auto random() -> T {
+[[nodiscard]] inline auto random() -> T {
   auto& gen = detail::engine();
 
   if constexpr (std::integral<T>) {
@@ -127,7 +127,7 @@ inline auto random() -> T {
  */
 template <typename T>
   requires std::integral<T> || std::floating_point<T>
-inline auto random(const T& min, const T& max) -> T {
+[[nodiscard]] inline auto random(const T& min, const T& max) -> T {
   assert(min < max);
   auto& gen = detail::engine();
 
@@ -145,14 +145,14 @@ inline auto random(const T& min, const T& max) -> T {
 // because this is not part of the C++ standard (for std::uniform_int_distribution).
 
 template <>
-inline auto random() -> uint8_t {
+[[nodiscard]] inline auto random() -> uint8_t {
   auto& gen = detail::engine();
   std::uniform_int_distribution<uint32_t> dist { 0, 255 };
   return static_cast<uint8_t>(dist(gen));
 }
 
 template <>
-inline auto random(const uint8_t& min, const uint8_t& max) -> uint8_t {
+[[nodiscard]] inline auto random(const uint8_t& min, const uint8_t& max) -> uint8_t {
   assert(min < max);
   auto& gen = detail::engine();
   std::uniform_int_distribution<uint32_t> dist { min, max };

--- a/src/util/random.hpp
+++ b/src/util/random.hpp
@@ -25,15 +25,18 @@
 
 
 #include <cassert>
-#include <cerrno>
+#include <charconv>
 #include <concepts>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <limits>
 #include <mutex>
+#include <optional>
 #include <print>
 #include <random>
+#include <string_view>
+#include <system_error>
 
 // #69: test draws come from one shared thread_local engine, so every run is reproducible.
 // The seed defaults to 42 and can be overridden via the CELESTIAL_TEST_SEED env var; the
@@ -44,10 +47,34 @@ namespace util::detail {
 
 inline constexpr uint64_t DEFAULT_SEED = 42;
 
+/**
+ * @brief Parse a `CELESTIAL_TEST_SEED` override.
+ * @param text The raw env-var text, or `nullptr` when it is unset.
+ * @return The seed, or `std::nullopt` when `text` is not a decimal numeral that is consumed in
+ *         full and fits in `uint64_t`. A leading sign, leading space, `0x` prefix and trailing
+ *         junk are all rejected -- only a plain non-negative numeral is honored (0 included).
+ */
+[[nodiscard]] inline auto parse_seed(const char* const text) -> std::optional<uint64_t> {
+  if (text == nullptr or *text < '0' or *text > '9') {
+    return std::nullopt;
+  }
+
+  const std::string_view sv { text };
+  uint64_t parsed = 0;
+  const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), parsed);
+
+  // Not consumed in full, or overflowed -- both fall back, exactly as the `strtoull` version did.
+  // The difference is that `from_chars` reports them through its own result instead of `errno`,
+  // so parsing an env var no longer writes a process-global as a side effect.
+  if (ec != std::errc {} or ptr != sv.data() + sv.size()) {
+    return std::nullopt;
+  }
+  return parsed;
+}
+
+
 [[nodiscard]] inline auto random_seed() -> uint64_t {
-  // Only a fully-consumed, non-negative decimal numeral is honored (yes, 0 is a valid
-  // seed); anything else — unset, leading whitespace/sign, trailing junk, overflow —
-  // falls back to the default.
+  // What counts as a valid override lives in `parse_seed`, not here.
 #ifdef _WIN32
   // MSVC/clang-cl deprecate plain getenv as "unsafe"; getenv_s is the blessed form.
   char env_buf[64] = {};
@@ -57,16 +84,7 @@ inline constexpr uint64_t DEFAULT_SEED = 42;
 #else
   const char* const env = std::getenv("CELESTIAL_TEST_SEED");
 #endif
-  if (env == nullptr or *env < '0' or *env > '9') {
-    return DEFAULT_SEED;
-  }
-  errno = 0;
-  char* end = nullptr;
-  const auto parsed = std::strtoull(env, &end, 10);
-  if (*end != '\0' or errno == ERANGE) {
-    return DEFAULT_SEED;
-  }
-  return parsed;
+  return parse_seed(env).value_or(DEFAULT_SEED);
 }
 
 inline void print_random_seed_once() {

--- a/src/util/ymd.hpp
+++ b/src/util/ymd.hpp
@@ -49,7 +49,7 @@ concept DayConvertible = std::same_as<T, std::chrono::days> or requires (T t) {
 };
 
 /*! @brief Converts the input year, month, and date to a `std::chrono::year_month_day`. */
-constexpr auto to_ymd(
+[[nodiscard]] constexpr auto to_ymd(
   const YearConvertible auto year, 
   const MonthConvertible auto month, 
   const DayConvertible auto day
@@ -60,7 +60,7 @@ constexpr auto to_ymd(
 
 
 /*! @brief Converts the input `std::chrono::year_month_day` to a year, month, and date. */
-constexpr auto from_ymd(const std::chrono::year_month_day& ymd) -> std::tuple<int32_t, uint32_t, uint32_t> {
+[[nodiscard]] constexpr auto from_ymd(const std::chrono::year_month_day& ymd) -> std::tuple<int32_t, uint32_t, uint32_t> {
   const int32_t y = static_cast<int32_t>(ymd.year());
   const uint32_t m = static_cast<uint32_t>(ymd.month());
   const uint32_t d = static_cast<uint32_t>(ymd.day());
@@ -73,7 +73,7 @@ namespace util::ymd_operator {
 
 using util::DayConvertible;
 
-constexpr auto operator+(
+[[nodiscard]] constexpr auto operator+(
   const std::chrono::year_month_day& ymd, 
   const DayConvertible auto& days
 ) -> std::chrono::year_month_day {
@@ -82,7 +82,7 @@ constexpr auto operator+(
 }
 
 
-constexpr auto operator+(
+[[nodiscard]] constexpr auto operator+(
   const DayConvertible auto& days,
   const std::chrono::year_month_day& ymd
 ) -> std::chrono::year_month_day {
@@ -91,7 +91,7 @@ constexpr auto operator+(
 }
 
 
-constexpr auto operator-(
+[[nodiscard]] constexpr auto operator-(
   const std::chrono::year_month_day& ymd, 
   const DayConvertible auto& days
 ) -> std::chrono::year_month_day {
@@ -100,7 +100,7 @@ constexpr auto operator-(
 }
 
 
-constexpr auto operator-(
+[[nodiscard]] constexpr auto operator-(
   const std::chrono::year_month_day& ymd1, 
   const std::chrono::year_month_day& ymd2
 ) -> int32_t {


### PR DESCRIPTION
风格架构批的 Pδ:清掉 #81 剩下的现代 C++ 小件。**`#81` 不在本 PR 关账** —— 第 5 项(ELP2000
合并 lon+rad 求和)是个性能项,已摘出为 P10 排在本 PR 之后,`#81` 在那里关。

## 内容

施工九个提交按关注面切,后两个是本地审阅轮的修复批:

| 提交 | 面 |
|---|---|
| `1300761` | JIEQI 两表 `unordered_map` → `constexpr std::array`(第 1、10 项) |
| `80bfd8a` | `Datetime` 比较算子 + 删死代码 `operator!=`(第 3、6、13 项) |
| `8d7356d` | 算法层小件 + 一处静默窄化(第 12、14、15、16 项) |
| `c4f2f3c` | `nodiscard` 全库补齐、两处 NOLINT 补真理由、`6378.14` 命名(第 4、17、19 项) |
| `dd7a1b9` | 种子解析换 `from_chars` 并提成具名契约;`tuple_like` 只立探针(第 18、20 项) |
| `a72c96c` | 三处函数尾多余分号 + JDE docstring 四处失真(第 9 项 + 吹毛求疵两条) |
| `3f9b337` | 补 `std::tuple_like` 的三腿基线(修 `dd7a1b9` 漏登记导致的 CI 红) |
| `38ec70d` | 丢弃返回值统一到 `std::ignore`;`util_test.cpp` 注释改回英文 |
| `9fa9434` `5aac7e9` | **R1 修复批** |
| `cb3f73a` | **R2 修复批** |

## 四处偏离 issue,都是有依据的

**第 11 项(`std::unreachable` ×2)整条不做。** `earth.hpp:280` 的 `default: throw` 是公开面枚举
switch(`Model : uint8_t` 固定底层类型,`static_cast<Model>(7)` 良定义、库外传得进来),换
`unreachable` 等于把输入校验降成 UB,撞 AGENTS.md §8。`algo2.hpp` 那半看着像内部不变量,但守它的
`assert(size == 12 or 13)` 在 Release 是死代码,而真正的前提(13 个月里必有一月不含中气)代码里
一处没断言;`calc_lunar_month_chunks` 又是公开 inline,直调可绕过年份闸门。实测全窗口
`[410, 5000]` 共 9182 个 chunk,**落底路径可达 0 次** ⇒ 换 `unreachable` 是拿一条实测为空的冷路径
去换 UB,收益落在从不执行的分支上。

**第 1 项保留 `.at()`。** issue 把「免 `.at()` 抛异常」列为收益,这条没采纳:`Jieqi` 是固定底层
类型,`static_cast<Jieqi>(25)` 与 `Jieqi::COUNT`(它本身等于 24)都能从库外走到
`calc_jieqi_jde`,换下标访问会把确定的异常变成 UB。而 `std::array::at()` 抛的正是
`std::out_of_range`,与 `unordered_map::at()` 同一个类型 ⇒ 契约逐字保留,零新增代码。

**第 17 项范围大了一个量级。** issue 点六处带个「等」,按判据全库扫是 **153 处缺、23 处已有**。
只补 issue 点名的四个文件会留下 119 处不一致,正是 #53 警告过的 half-migrated 状态。补完
**当场编不过 32 处**,全是测试里 `ASSERT_THROW(f(x), Ex)` 这类有意丢弃,逐处改成 `std::ignore =`。

判据本身在审阅中被改过一次,详见下方「审阅」。

**第 18 项的验收方向是反的。** `util/random.hpp` 的首字符闸门已把所有会分叉的输入(前导空白、
`+42`、`-1` —— `strtoull("-1")` 会回绕成 `ULLONG_MAX`)挡在解析之前,所以新增的负例断言
**在旧实现上同样全绿**。它们钉的是契约不是缺陷,证明的是「换实现没改变任何输入的归宿」。

## 审阅(本地两轮,共八席)

R1 五席:正确性三席(清单 grok · 盲审 kimi k3 · **盲审 grok**,同一份任务书换模型的对照实验)+
风格两席(措辞层 grok · 设计层 opus,镜头刻意错开)。R2 三席复验。**全程零 P1。**

改动了代码形状的两条:

**读表的键退成了裸 `uint8_t`,把它加回来。** 两表改成 `std::array` 之后,读表的键从 `Jieqi`
变成裸下标,而这个代码库里并存**两个含义不同的 `uint8_t` 索引空间** —— `to_index` 从立春数,
HKO 历书与 `GREGORIAN_YEAR_JIEQI_LIST` 从小寒数,差 22。喂错空间会静默拿到一个像模像样的错名字,
**而改之前那行编译不过**(审阅席取出 main 的头文件带对照实测:`JIEQI_NAME.at(uint8_t{7})` →
compile error,对照的 `.at(Jieqi::立春)` → compiles)。泄漏已经发生:`lib_jieqi.cpp` 两个相邻出口
一个走类型、一个走裸下标。

修法是 `name_of(Jieqi)` / `longitude_of(Jieqi)`,`.at()` 仍在读路径上,契约一字不动。全部调用点
迁移,`jieqi_from_lon` 的裸索引循环换成迭代 `JIEQI_LIST`。类型闸门实测有效(`name_of(uint8_t{7})`
→ compile error)。

**`peek()` 不再算完再退回去。** 它原本调 `next_month()` 算一个、再 `put_back_month()` 塞回槽,
现在直接填槽。`put_back_month` 随之删除,连同它那句 `assert` —— 审阅席核出那句**在任何构建下
都不可能触发**(唯一调用点紧跟在会清空槽的 `next_month()` 之后),它守的是当时的代码结构已经
保证的性质。**不是把断言改硬,是让不变量无从违反。** 另两个 put-back 保留:它们是月份构造算法
自身的前瞻-回退,与 `peek` 的缓存填充不是一回事。

**`[[nodiscard]]` 的判据换过一次,现在全库一致。** 原判据写的是「丢弃即调用方 bug 的纯函数」,
而三个有状态的 `next()` 被扫了进去 —— 盲审席指出这是实现偏离了 PR 自述的意图。改判据后仍不一致
(公开 `next()` 摘了、它包装的私有 helper 没摘,而 `next()` 的函数体就是 `return next_month();`),
两席各执一端、都说一致性比选哪条重要。**最终取「丢弃返回值可疑就加」并全库贯彻**:跳过一个元素
仍然可写,而且更显眼 —— `std::ignore = gen.next();`,正是本 PR 已铺了 52 处的写法。

**一句被证伪的注释,以及它牵出的 issue 依据错误。** R1 修复批新写的类注释声称
「`std::generator` 给不了 `peek`,所以那个单槽缓冲会活过 #99 的迁移」。**两席各写各的探针
独立证伪**:单遍指的是走过去回不来,不是看不了当前这个 —— input iterator 的 `*it` 就是一次
不推进的读,协程的挂起点本身就是那一个槽。归因也错了一层:两个 put-back 存在是因为**上游**
generator 只能取不能看,而 #99 迁的恰恰是那两个。**#99 正文「algo2 维持手搓」的理由与这句同源**,
勘误已留在该 issue,连同一个真会踩的坑(`std::generator<T>` 的 reference 是 `T&&`,`peek` 写成
`return *_it;` 会把值移出协程帧)。

未采纳一条并已交回原发现家裁决(`REJECTION: ACCEPTED`):名字表补齐 24 条 `static_assert`。
读表走访问器之后,「用错索引空间」这条高发面已经关掉;**likely 的编辑事故是整表移位,那三条钉
已经抓得住;residual 是两个内点对调,未钉但边际低。**

## 测试

新增 2 个 TEST(`Random.ParseSeedAcceptsPlainNumerals` / `ParseSeedRejectsEverythingElse`),
共 **211**。按仓里的验收口径核:直接跑 28 个测试二进制加总 = 211,与
`grep -c "^TEST(" src/test/**/*.cpp` 相等(不看 `ctest` 的登记数)。

## 验证

- **逐比特零改变**:`git archive e44a31e` 独立解基线树编译对拍,21 个年份 × 24 节气 = 504 行
  hexfloat 全同,两批修复之后复验仍全同。探针先过突变检出 —— 把清明黄经挪 1e-9 度,504 行里
  21 行当场变化(每年一行)。
- **越界契约实证**:`Jieqi::COUNT` / 25 / 200 改前改后都抛 `std::out_of_range`;审阅席另做
  14/14 的契约探针覆盖两个新访问器。
- **新加的 `static_assert` 过检出率**:黄经表交换两项、整体移位、名字表移位各挂 1 条;
  名字表中间两项互换 0 条 —— 注释里已写明它抓不到这一种。
- **种子解析等价对拍**:24 组边界输入喂给旧 `strtoull` 实现与新 `parse_seed`,归宿 24/24 相同;
  两个审阅席分别独立复做 35 组与 34 组,结论一致。
- **`std::midpoint` 与 `(a+b)/2.0`**:JDE 区间随机 2000 万对位级零差异(libstdc++ 实测)。
  更一般地,[numeric.ops.midpoint] 要求浮点重载至多一次不精确运算,而正确舍入的半和是唯一的
  ⇒ 任何合规实现都给同样的比特,不依赖具体标准库。
- 自包含闸门 31/31;特性探针 8 项 EXIT 0;冷构建(`rm -rf build && --all`)从零复验通过。
- clang-tidy 交给 CI 判:本机 21.1.8、CI 钉 18.1.8,大版本对不上,本机结果不作数。

## 范围说明

`#81` **不关**,合并时须留范围注记,写明三条:①第 5 项 → P10;②第 11 项两半都判不做,
理由见上,**此为终态不留尾巴**;③第 20 项本轮只落探针 —— `std::tuple_like` 在本机四个组合
与 CI 三条腿全部为 False,代码落地等标准库跟进,`hash.hpp` 已留带 token 的 TODO,
探针的前读闸门会在三腿转绿时主动说话。

审阅中另立两条,均不在本 PR:**#144**(仓级安全加固:两个 workflow 里未使用的
`id-token: write`、AI workflow 的 prompt 注入面)· **#99 的依据勘误**(见上)。
