### PR TITLE
build/ci: 闸门真的在守,配置真的生效 —— #72 上半 + #50 + #133 两个基准点

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,13 +25,8 @@ Checks: |
   modernize-*,
   -modernize-use-std-numbers,
 
-# `readability-identifier-naming` stays off, and there are no CheckOptions to go with it any more.
-# The fourteen that used to sit below described a codebase this is not: enabled and measured, they
-# reported 182 sites, of which one was a real inconsistency. The rest were the maths -- `cos_λ`,
-# `argL`, `A1`, `θCoeffs` -- plus two options pointing the wrong way (`EnumCase: UPPER_CASE` wanted
-# `Algo` spelled `ALGO`; nothing described `const inline auto`). A check that fires 181 times to
-# find one thing does not get calibrated, it gets turned off, and the conventions get written for
-# people to read (AGENTS.md, "Naming"). #72
+# `readability-identifier-naming` is off on purpose: it cannot express domain notation (`cos_λ`,
+# `argL`, `θCoeffs`) or `const inline auto` callables. Conventions: AGENTS.md, "Naming". #72
 
 WarningsAsErrors: '*'
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,36 +25,14 @@ Checks: |
   modernize-*,
   -modernize-use-std-numbers,
 
+# `readability-identifier-naming` stays off, and there are no CheckOptions to go with it any more.
+# The fourteen that used to sit below described a codebase this is not: enabled and measured, they
+# reported 182 sites, of which one was a real inconsistency. The rest were the maths -- `cos_λ`,
+# `argL`, `A1`, `θCoeffs` -- plus two options pointing the wrong way (`EnumCase: UPPER_CASE` wanted
+# `Algo` spelled `ALGO`; nothing described `const inline auto`). A check that fires 181 times to
+# find one thing does not get calibrated, it gets turned off, and the conventions get written for
+# people to read (AGENTS.md, "Naming"). #72
+
 WarningsAsErrors: '*'
 
 UseColor: true
-
-CheckOptions:
-  - key: readability-identifier-naming.VariableCase
-    value: lower_case
-  - key: readability-identifier-naming.FunctionCase
-    value: lower_case
-  - key: readability-identifier-naming.ClassCase
-    value: CamelCase
-  - key: readability-identifier-naming.StructCase
-    value: CamelCase
-  - key: readability-identifier-naming.GlobalConstantCase
-    value: UPPER_CASE
-  - key: readability-identifier-naming.EnumCase
-    value: UPPER_CASE
-  - key: readability-identifier-naming.NamespaceCase
-    value: lower_case
-  - key: readability-identifier-naming.MemberCase
-    value: lower_case
-  - key: readability-identifier-naming.ParameterCase
-    value: lower_case
-  - key: readability-identifier-naming.LocalVariableCase
-    value: lower_case
-  - key: readability-identifier-naming.FieldCase
-    value: lower_case
-  - key: readability-identifier-naming.MethodCase
-    value: lower_case
-  - key: readability-identifier-naming.EnumConstantCase
-    value: UPPER_CASE
-  - key: readability-identifier-naming.MemberVariableCase
-    value: lower_case

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -154,9 +154,11 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
+    # A major, not `latest-stable`: an Xcode major carries an Apple Clang major, and `-Werror`
+    # makes any new diagnostic in it a red build on a day nobody touched the code (#72, #73).
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest-stable
+        xcode-version: '26'
     
     - name: Set up Python ${{ matrix.python-version }}  
       uses: actions/setup-python@v6 
@@ -245,7 +247,11 @@ jobs:
           python3 -m pip install --upgrade pip  
           if (Test-Path "Requirements.txt") { python3 -m pip install -r "Requirements.txt" }
 
-          choco install -y make llvm
+          # LLVM pinned (`make` is not): a new LLVM major starts flagging code that has not changed,
+          # under `-Werror`. 20.1.8 is what CI already resolved to -- note that is not the 18 the
+          # Linux legs and clang-tidy use, a pre-existing split this pin records rather than creates.
+          choco install -y make
+          choco install -y llvm --version=20.1.8
 
       - name: Build and Test
         env:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -114,6 +114,14 @@ jobs:
             fi
           done
 
+          # Guard on what was copied. The JSON files and the header below keep this directory
+          # non-empty whatever happens, so `if-no-files-found: error` on the upload cannot catch
+          # an artifact that ships with no library in it (#72).
+          if [ "$(find "$DEST_DIR" \( -name '*.so' -o -name '*.dylib' -o -name '*.dll' \) -type f | wc -l)" -eq 0 ]; then
+            echo "No shared library copied out of $OUTPUT_DIR/shared_lib"
+            exit 1
+          fi
+
           # Copy the build info JSON files to the destination directory
           cp "$OUTPUT_DIR/build_info.json" "$DEST_DIR/"
           cp "$OUTPUT_DIR/cpu_info.json" "$DEST_DIR/"
@@ -154,8 +162,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    # A major, not `latest-stable`: an Xcode major carries an Apple Clang major, and `-Werror`
-    # makes any new diagnostic in it a red build on a day nobody touched the code (#72, #73).
+    # Pinned; see AGENTS.md gotcha 9 (#72, #73).
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: '26'
@@ -190,16 +197,11 @@ jobs:
         # Find and copy real files (not symlinks)
         find ./build/shared_lib -name "*.dylib" -type f -exec cp {} ./macos_arm64 \;
 
-        # Guard on what was copied, not on what a glob matched. The old check was
-        # `[ ! -f ./build/shared_lib/*.dylib ]`, and CMake leaves two entries here -- the versioned
-        # file and an unversioned symlink -- so `[` got three operands, wrote `binary operator
-        # expected` to stderr and returned non-zero, which took the `if` to its false branch on
-        # every normal run. Worse, it asked the wrong question: with only symlinks and no real file
-        # the glob still matches, `-type f` still copies nothing, and the artifact still ships,
-        # because `celestial.h` and `build_info.json` keep the directory non-empty and
-        # `if-no-files-found: error` never fires (#72).
+        # Guard on what was copied, not on what a glob matched: with only symlinks and no real
+        # file, `-type f` copies nothing while `celestial.h` and `build_info.json` keep the
+        # directory non-empty, so `if-no-files-found: error` never fires (#72).
         if [ "$(find ./macos_arm64 -name '*.dylib' -type f | wc -l)" -eq 0 ]; then
-          echo "No shared lib found in ./build/shared_lib"
+          echo "No real .dylib copied out of ./build/shared_lib"
           exit 1
         fi
 
@@ -247,9 +249,7 @@ jobs:
           python3 -m pip install --upgrade pip  
           if (Test-Path "Requirements.txt") { python3 -m pip install -r "Requirements.txt" }
 
-          # LLVM pinned (`make` is not): a new LLVM major starts flagging code that has not changed,
-          # under `-Werror`. 20.1.8 is what CI already resolved to -- note that is not the 18 the
-          # Linux legs and clang-tidy use, a pre-existing split this pin records rather than creates.
+          # Pinned; see AGENTS.md gotcha 9 (#72, #73).
           choco install -y make
           choco install -y llvm --version=20.1.8
 
@@ -288,6 +288,14 @@ jobs:
           # Copy all .lib files to the destination directory
           foreach ($lib in $libFiles) {
             Copy-Item -Path $lib.FullName -Destination $destDir
+          }
+
+          # Guard on what was copied. The header and build_info.json below keep this directory
+          # non-empty whatever happens, so `if-no-files-found: error` on the upload cannot catch an
+          # artifact that ships with no library in it (#72).
+          if (@(Get-ChildItem -Path $destDir -File | Where-Object { $_.Extension -in '.dll', '.lib' }).Count -eq 0) {
+            Write-Error "No shared library copied out of $LIB_DIR"
+            exit 1
           }
 
           # Ship the published C-ABI header alongside the library

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -182,17 +182,24 @@ jobs:
         CXX: clang++
         CC:  clang
       run: |
-        # Check if any shared library is found
-        if [ ! -f ./build/shared_lib/*.dylib ]; then
-          echo "No shared lib found"
-          exit 1
-        fi
-
         # Create a folder "macos_arm64" at root dir and copy the new shared library to it
         mkdir -p ./macos_arm64
 
         # Find and copy real files (not symlinks)
         find ./build/shared_lib -name "*.dylib" -type f -exec cp {} ./macos_arm64 \;
+
+        # Guard on what was copied, not on what a glob matched. The old check was
+        # `[ ! -f ./build/shared_lib/*.dylib ]`, and CMake leaves two entries here -- the versioned
+        # file and an unversioned symlink -- so `[` got three operands, wrote `binary operator
+        # expected` to stderr and returned non-zero, which took the `if` to its false branch on
+        # every normal run. Worse, it asked the wrong question: with only symlinks and no real file
+        # the glob still matches, `-type f` still copies nothing, and the artifact still ships,
+        # because `celestial.h` and `build_info.json` keep the directory non-empty and
+        # `if-no-files-found: error` never fires (#72).
+        if [ "$(find ./macos_arm64 -name '*.dylib' -type f | wc -l)" -eq 0 ]; then
+          echo "No shared lib found in ./build/shared_lib"
+          exit 1
+        fi
 
         # Ship the published C-ABI header alongside the library
         cp ./src/shared_lib/celestial.h ./macos_arm64/

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -30,9 +30,7 @@ jobs:
           python3 -m pip install --upgrade pip  
           if [ -f Requirements.txt ]; then python3 -m pip install -r Requirements.txt; fi
 
-          # Both pinned, for the same reason: a linter that updates itself turns "the code changed"
-          # and "the tool changed" into the same red X. clang-tidy matches the clang-18 toolchain
-          # installed below; ruff is pinned at what CI was already resolving to (#72, #73).
+          # Both pinned; see AGENTS.md gotcha 9 (#72, #73).
           python3 -m pip install ruff==0.16.1 clang-tidy==18.1.8
 
       - name: Install LLVM and clang++
@@ -130,12 +128,10 @@ jobs:
           ./project.py --setup --clean --cmake --build --test -v 1
 
 
-  # macOS and Windows build+test are not here. They live in `build_and_test.yml`, which runs on
-  # pull requests and packages the artifacts, and running them in both places meant the same
-  # compile-and-test twice on every push to a branch with a PR open -- measured at ~305 runner
-  # seconds, and two places to read one failure. What a push still gets on those two platforms is
-  # the part that catches platform-specific rot early: `self-contained-headers` and
-  # `cxx-feature-probe` below are three-way matrices and both include them (#72).
+  # macOS and Windows build+test are not here: they live in `build_and_test.yml`, which runs on
+  # pull requests to main and packages the artifacts. A push still gets both platforms from
+  # `self-contained-headers` and `cxx-feature-probe` below -- three-way matrices that catch
+  # platform-specific rot early (#72).
 
   # ASan + UBSan on one Linux leg. It sits here rather than in `build_and_test.yml` because this
   # workflow's critical path is `linters-and-static-analysis`, which has room a parallel job can
@@ -193,10 +189,19 @@ jobs:
           for exe in build/test/*; do
             [ -f "$exe" ] && [ -x "$exe" ] || continue
             out=$("$exe" 2>&1) || { echo "$out"; echo "FAILED: $exe"; exit 1; }
-            n=$(echo "$out" | grep -oE "^\[==========\] [0-9]+ test" | grep -oE "[0-9]+" | head -1)
-            total=$((total + ${n:-0}))
+            # `sed`, not a `grep | grep` pipeline: this step runs under `-eo pipefail`, where a
+            # grep that matches nothing kills the job with no output at all. Say what happened.
+            n=$(printf '%s' "$out" | sed -nE 's/^\[==========\] ([0-9]+) test.*/\1/p' | head -1)
+            if [ -z "$n" ]; then
+              echo "$out"
+              echo "NO GTEST SUMMARY: $exe -- not a test binary, or it died before reporting"
+              exit 1
+            fi
+            total=$((total + n))
           done
-          declared=$(grep -rhoE '^[[:space:]]*TEST\(' src/test --include=*.cpp | wc -l)
+          # `TEST_F`/`TEST_P` too: the repo has none today, and a gate that starts miscounting the
+          # day someone adds a fixture would be worse than no gate at all.
+          declared=$(grep -rhoE '^[[:space:]]*TEST(_F|_P)?\(' src/test --include=*.cpp | wc -l)
           echo "ran $total, declared $declared"
           [ "$total" -eq "$declared" ] || { echo "count mismatch"; exit 1; }
 
@@ -247,9 +252,7 @@ jobs:
 
       - name: Install clang (Windows)
         if: runner.os == 'Windows'
-        # LLVM pinned (`make` is not): a new LLVM major starts flagging code that has not changed,
-        # under `-Werror`. 20.1.8 is what CI already resolved to -- note that is not the 18 the
-        # Linux legs and clang-tidy use, a pre-existing split this pin records rather than creates.
+        # Pinned; see AGENTS.md gotcha 9 (#72, #73).
         run: choco install -y llvm --version=20.1.8
 
       # The compiler comes from the matrix, not from $GITHUB_ENV: a step-level `env:`
@@ -294,8 +297,7 @@ jobs:
 
       # Same Xcode the macOS build leg pins. Without it this job reads the image default, and
       # the baseline would record a toolchain the project never actually compiles with.
-      # A major, not `latest-stable`: an Xcode major carries an Apple Clang major, and `-Werror`
-      # makes any new diagnostic in it a red build on a day nobody touched the code (#72, #73).
+      # Pinned; see AGENTS.md gotcha 9 (#72, #73).
       - uses: maxim-lobanov/setup-xcode@v1
         if: runner.os == 'macOS'
         with:
@@ -320,9 +322,7 @@ jobs:
 
       - name: Install clang (Windows)
         if: runner.os == 'Windows'
-        # LLVM pinned (`make` is not): a new LLVM major starts flagging code that has not changed,
-        # under `-Werror`. 20.1.8 is what CI already resolved to -- note that is not the 18 the
-        # Linux legs and clang-tidy use, a pre-existing split this pin records rather than creates.
+        # Pinned; see AGENTS.md gotcha 9 (#72, #73).
         run: choco install -y llvm --version=20.1.8
 
       - name: Probe awaited C++ features (${{ matrix.leg }})

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -129,7 +129,8 @@ jobs:
 
 
   # macOS and Windows build+test are not here: they live in `build_and_test.yml`, which runs on
-  # pull requests to main and packages the artifacts. A push still gets both platforms from
+  # pull requests to main and packages the artifacts -- running them here too repeated the same
+  # compile-and-test on every push to a branch with a PR open. A push still gets both platforms from
   # `self-contained-headers` and `cxx-feature-probe` below -- three-way matrices that catch
   # platform-specific rot early (#72).
 
@@ -199,9 +200,16 @@ jobs:
             fi
             total=$((total + n))
           done
-          # `TEST_F`/`TEST_P` too: the repo has none today, and a gate that starts miscounting the
-          # day someone adds a fixture would be worse than no gate at all.
-          declared=$(grep -rhoE '^[[:space:]]*TEST(_F|_P)?\(' src/test --include=*.cpp | wc -l)
+          # `TEST` and `TEST_F` only, because only those are one macro per test. `TEST_P` and
+          # `TYPED_TEST` expand to one per parameter or per type, so counting them would undercount
+          # and fail here for the wrong reason. Detect them instead: the day one appears, this
+          # reconciliation stops being valid and should be rewritten, not quietly widened.
+          if grep -rqE '^[[:space:]]*(TEST_P|TYPED_TEST)\(' src/test --include=*.cpp; then
+            echo "TEST_P/TYPED_TEST present: one macro no longer means one test, so the count below"
+            echo "cannot reconcile. Rewrite this check (count from --gtest_list_tests) before use."
+            exit 1
+          fi
+          declared=$(grep -rhoE '^[[:space:]]*TEST(_F)?\(' src/test --include=*.cpp | wc -l)
           echo "ran $total, declared $declared"
           [ "$total" -eq "$declared" ] || { echo "count mismatch"; exit 1; }
 

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -30,9 +30,10 @@ jobs:
           python3 -m pip install --upgrade pip  
           if [ -f Requirements.txt ]; then python3 -m pip install -r Requirements.txt; fi
 
-          # clang-tidy is pinned to match the clang-18 toolchain this job installs;
-          # newer clang-tidy ships new checks that flag pre-existing code.
-          python3 -m pip install ruff clang-tidy==18.1.8
+          # Both pinned, for the same reason: a linter that updates itself turns "the code changed"
+          # and "the tool changed" into the same red X. clang-tidy matches the clang-18 toolchain
+          # installed below; ruff is pinned at what CI was already resolving to (#72, #73).
+          python3 -m pip install ruff==0.16.1 clang-tidy==18.1.8
 
       - name: Install LLVM and clang++
         run: |
@@ -246,7 +247,10 @@ jobs:
 
       - name: Install clang (Windows)
         if: runner.os == 'Windows'
-        run: choco install -y llvm
+        # LLVM pinned (`make` is not): a new LLVM major starts flagging code that has not changed,
+        # under `-Werror`. 20.1.8 is what CI already resolved to -- note that is not the 18 the
+        # Linux legs and clang-tidy use, a pre-existing split this pin records rather than creates.
+        run: choco install -y llvm --version=20.1.8
 
       # The compiler comes from the matrix, not from $GITHUB_ENV: a step-level `env:`
       # outranks anything written to $GITHUB_ENV, so setting CXX in the install step
@@ -290,10 +294,12 @@ jobs:
 
       # Same Xcode the macOS build leg pins. Without it this job reads the image default, and
       # the baseline would record a toolchain the project never actually compiles with.
+      # A major, not `latest-stable`: an Xcode major carries an Apple Clang major, and `-Werror`
+      # makes any new diagnostic in it a red build on a day nobody touched the code (#72, #73).
       - uses: maxim-lobanov/setup-xcode@v1
         if: runner.os == 'macOS'
         with:
-          xcode-version: latest-stable
+          xcode-version: '26'
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -314,7 +320,10 @@ jobs:
 
       - name: Install clang (Windows)
         if: runner.os == 'Windows'
-        run: choco install -y llvm
+        # LLVM pinned (`make` is not): a new LLVM major starts flagging code that has not changed,
+        # under `-Werror`. 20.1.8 is what CI already resolved to -- note that is not the 18 the
+        # Linux legs and clang-tidy use, a pre-existing split this pin records rather than creates.
+        run: choco install -y llvm --version=20.1.8
 
       - name: Probe awaited C++ features (${{ matrix.leg }})
         env:

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -129,72 +129,75 @@ jobs:
           ./project.py --setup --clean --cmake --build --test -v 1
 
 
-  test-macos-apple-clang:  
-    runs-on: macos-latest
+  # macOS and Windows build+test are not here. They live in `build_and_test.yml`, which runs on
+  # pull requests and packages the artifacts, and running them in both places meant the same
+  # compile-and-test twice on every push to a branch with a PR open -- measured at ~305 runner
+  # seconds, and two places to read one failure. What a push still gets on those two platforms is
+  # the part that catches platform-specific rot early: `self-contained-headers` and
+  # `cxx-feature-probe` below are three-way matrices and both include them (#72).
+
+  # ASan + UBSan on one Linux leg. It sits here rather than in `build_and_test.yml` because this
+  # workflow's critical path is `linters-and-static-analysis`, which has room a parallel job can
+  # use; the other workflow's is the docker build, which has none. TSan is deliberately absent --
+  # it cannot share a binary with ASan, and the only concurrency to point it at today is one test
+  # in `util_test.cpp`. Worth revisiting when there is more (#72).
+  sanitizers:
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.12"]  
+        python-version: ["3.12"]
 
     steps:
-    - uses: actions/checkout@v7
-
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-    
-    - name: Set up Python ${{ matrix.python-version }}  
-      uses: actions/setup-python@v6 
-      with:
-        python-version: ${{ matrix.python-version }}
-    
-    - name: Install Python Dependencies
-      run: |  
-        python3 -m pip install --upgrade pip  
-        if [ -f Requirements.txt ]; then python3 -m pip install -r Requirements.txt; fi  
-
-    - name: Build and Test
-      env:
-        CXX: clang++
-        CC:  clang
-      run: |
-        chmod +x project.py
-        ./project.py --setup --clean --cmake --build --test -v 1
-
-
-  test-windows-clang:  
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: ["3.12"]  
-  
-    steps:  
       - uses: actions/checkout@v7
 
-      - name: Set up Visual Studio
-        uses: microsoft/setup-msbuild@v2
-        with:
-          vs-version: latest
-
-      - name: Set up Python ${{ matrix.python-version }}  
-        uses: actions/setup-python@v6 
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-  
-      - name: Install Dependencies
-        run: |  
-          python -m pip install --upgrade pip  
-          if (Test-Path "Requirements.txt") { python -m pip install -r "Requirements.txt" }
 
-          choco install -y make llvm
-
-      - name: Build and Test
-        env:
-          CXX: clang++
-          CC:  clang
+      - name: Install Python Dependencies
         run: |
-          chcp.com 65001
-          $env:PYTHONIOENCODING = "utf-8"
-          python3 ./project.py --setup --clean --cmake --build --test -v 1
+          python3 -m pip install --upgrade pip
+          if [ -f Requirements.txt ]; then python3 -m pip install -r Requirements.txt; fi
+
+      - name: Install LLVM and clang++
+        run: |
+          sudo add-apt-repository universe
+          sudo apt update
+          sudo apt install -y llvm-18 clang-18
+
+      - name: Build under ASan + UBSan
+        env:
+          CXX: clang++-18
+          CC:  clang-18
+          # CMake seeds `CMAKE_CXX_FLAGS` from `CXXFLAGS` on a fresh configure, and `--clean` makes
+          # every configure fresh -- so the sanitizers reach the build without `project.py` growing
+          # a flag that exists for one CI job.
+          # `-fno-sanitize-recover=all` is what makes UBSan fail rather than narrate: by default it
+          # prints and carries on, and the job would stay green while reporting undefined behaviour.
+          CXXFLAGS: "-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g"
+        run: |
+          chmod +x project.py
+          ./project.py --setup --clean --cmake --build --cores all -v 1
+
+      - name: Run every test binary
+        env:
+          UBSAN_OPTIONS: print_stacktrace=1
+        run: |
+          # Not `--test`: that goes through `ctest -R <name>`, and a filter that matches nothing
+          # makes gtest exit 0, which ctest records as a pass. A sanitizer gate that can silently
+          # skip a binary is no gate, so run them directly and reconcile the count against the
+          # `TEST(` macros -- proving the ones that ran are also the ones that exist.
+          total=0
+          for exe in build/test/*; do
+            [ -f "$exe" ] && [ -x "$exe" ] || continue
+            out=$("$exe" 2>&1) || { echo "$out"; echo "FAILED: $exe"; exit 1; }
+            n=$(echo "$out" | grep -oE "^\[==========\] [0-9]+ test" | grep -oE "[0-9]+" | head -1)
+            total=$((total + ${n:-0}))
+          done
+          declared=$(grep -rhoE '^[[:space:]]*TEST\(' src/test --include=*.cpp | wc -l)
+          echo "ran $total, declared $declared"
+          [ "$total" -eq "$declared" ] || { echo "count mismatch"; exit 1; }
 
 
   # Header self-containment (#71). Deliberately a matrix, not a single job: whether a

--- a/.github/workflows/random_soak.yml
+++ b/.github/workflows/random_soak.yml
@@ -62,8 +62,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    # A major, not `latest-stable`: an Xcode major carries an Apple Clang major, and `-Werror`
-    # makes any new diagnostic in it a red build on a day nobody touched the code (#72, #73).
+    # Pinned; see AGENTS.md gotcha 9 (#72, #73).
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: '26'
@@ -111,9 +110,7 @@ jobs:
           python -m pip install --upgrade pip
           if (Test-Path "Requirements.txt") { python -m pip install -r "Requirements.txt" }
 
-          # LLVM pinned (`make` is not): a new LLVM major starts flagging code that has not changed,
-          # under `-Werror`. 20.1.8 is what CI already resolved to -- note that is not the 18 the
-          # Linux legs and clang-tidy use, a pre-existing split this pin records rather than creates.
+          # Pinned; see AGENTS.md gotcha 9 (#72, #73).
           choco install -y make
           choco install -y llvm --version=20.1.8
 

--- a/.github/workflows/random_soak.yml
+++ b/.github/workflows/random_soak.yml
@@ -62,9 +62,11 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
+    # A major, not `latest-stable`: an Xcode major carries an Apple Clang major, and `-Werror`
+    # makes any new diagnostic in it a red build on a day nobody touched the code (#72, #73).
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest-stable
+        xcode-version: '26'
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -109,7 +111,11 @@ jobs:
           python -m pip install --upgrade pip
           if (Test-Path "Requirements.txt") { python -m pip install -r "Requirements.txt" }
 
-          choco install -y make llvm
+          # LLVM pinned (`make` is not): a new LLVM major starts flagging code that has not changed,
+          # under `-Werror`. 20.1.8 is what CI already resolved to -- note that is not the 18 the
+          # Linux legs and clang-tidy use, a pre-existing split this pin records rather than creates.
+          choco install -y make
+          choco install -y llvm --version=20.1.8
 
       - name: Build and Test
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,10 +157,20 @@ is tracked in #72.)
 
 分工：转录/脚手架/CI 可放手；API 形状、类型设计、数值核心、容差判断留给作者。
 
-### Naming (SSOT: `.clang-tidy` CheckOptions)
+### Naming
 
-`lower_case` — variables / functions / params / members / methods / namespaces.
-`CamelCase` — class / struct.  `UPPER_CASE` — global constants / enums / enum constants.
+Nothing checks this — `readability-identifier-naming` is off, and the CheckOptions that used to
+claim to be its SSOT described a codebase this is not (#72). Read it here instead:
+
+`lower_case` — variables, functions, parameters, members, methods, namespaces, and the
+`const inline auto` callables that `cache_func` returns (`jieqi_jde`, `get_info_for_year`): they
+are called, so they read as functions.
+`CamelCase` — classes, structs, **and enum types** (`Algo`, `AngleUnit`, `Jieqi`).
+`UPPER_CASE` — `inline constexpr` constants and enumerators.
+
+**Domain notation overrides all of it.** An identifier that stands for a symbol in the source keeps
+the source's spelling: `cos_λ`, `argL`, `A1`, `θCoeffs`, `gen_eval_θ`, and `Jieqi`'s 立春/冬至.
+Same discipline as the `@ref` rule above — the code should read next to the book.
 
 ### Header-only, and the code reads like the maths
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,9 +162,8 @@ is tracked in #72.)
 Nothing checks this — `readability-identifier-naming` is off, and the CheckOptions that used to
 claim to be its SSOT described a codebase this is not (#72). Read it here instead:
 
-`lower_case` — variables, functions, parameters, members, methods, namespaces, and the
-`const inline auto` callables that `cache_func` returns (`jieqi_jde`, `get_info_for_year`): they
-are called, so they read as functions.
+`lower_case` — variables, functions, parameters, members, methods, namespaces, and any
+`const inline auto` that is called rather than read: it is invoked, so it reads as a function.
 `CamelCase` — classes, structs, **and enum types** (`Algo`, `AngleUnit`, `Jieqi`).
 `UPPER_CASE` — `inline constexpr` constants and enumerators.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,14 +173,16 @@ Same discipline as the `@ref` rule above — the code should read next to the bo
 
 ### Comment language
 
-Narrative in English; domain terms keep their own spelling, glossed once in parentheses — `the
-Chinese Jieqi (节气)`, `a Jie (节)`, `Jieqi::冬至`. Translating an entity loses it, and the gloss is
-what lets a reader who has only the English follow. Full-Chinese runs are for named or quoted
-material, never for explanation.
+Narrative in English; domain terms keep their own spelling (`Jieqi::冬至`), glossed once in
+parentheses where a reader who has only the English needs a handle — `the Chinese Jieqi (节气)`,
+`a Jie (节)`. Translating an entity loses it. Outside the lunar subtree, keep new full-Chinese runs
+to named or quoted material rather than explanation; the stray restatement that predates this
+paragraph can stay where it is.
 
-The lunar subtree is the exception, and stays one: its Doxygen `@param` / `@return` lines carry a
-Chinese restatement after the English (`@param year The Lunar year. 阴历年份。`). Match the
-neighbours when editing there — do not spread it, do not strip it.
+The lunar subtree is where Chinese restatement is concentrated, and stays that way: its Doxygen
+carries a Chinese line after or under the English, on `@brief` / `@param` / `@return` / `@note`
+and member docs alike (`@param year The Lunar year. 阴历年份。`). Match the neighbours when
+editing there — do not spread the habit outward, do not strip it inside.
 
 Punctuation follows the language of the run it sits in: full-width inside a Chinese phrase,
 half-width everywhere else.
@@ -345,13 +347,16 @@ toolbox/        Helper scripts for artifacts, releases, build info
    validation must `throw` (fail-fast, independent of build type); `assert` is only
    for internal invariants, never as an input guard.
 
-9. **CI toolchains are pinned, all of them.** A tool that updates itself turns "the code changed"
-   and "the tool changed" into the same red X, on a day nobody touched the repository; a pin that
-   goes stale instead fails loudly with "no such version", which says what to do. Current pins:
-   clang-tidy and clang **18.1.8** (Linux, `core_tests.yml`), choco **LLVM 20.1.8** (Windows — not
-   the 18 the Linux legs use, a pre-existing split these pins record rather than create), Xcode
-   major **`'26'`** (a major carries an Apple Clang major, and `-Werror` makes any new diagnostic
-   in it a red build), ruff **0.16.1**. Bump deliberately, never incidentally (#72, #73).
+9. **CI toolchains are pinned — every one that can emit a diagnostic.** A tool that updates
+   itself turns "the code changed" and "the tool changed" into the same red X, on a day nobody
+   touched the repository; a pin that goes stale instead fails loudly with "no such version",
+   which says what to do. Pinned: clang-tidy and clang at **18** on the Linux legs, choco LLVM at
+   **20** on Windows (not the 18 the Linux legs use — a pre-existing split these pins record
+   rather than create), the Xcode **major** (a major carries an Apple Clang major, and `-Werror`
+   makes any new diagnostic in it a red build), and ruff. Exact versions live in the workflows,
+   not here — there is no gate reconciling two copies. Chocolatey's `make` is deliberately outside
+   this: it drives the build rather than diagnosing it, so a new version cannot turn `-Werror` red.
+   Bump deliberately, never incidentally (#72, #73).
 
 ## AI do / don't
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,9 +101,10 @@ taken to be a GoogleTest binary whose test count reconciles with the `TEST(` mac
 so a new file is picked up without a separate `--cmake`, and the runner finds the binary by
 directory. `--bench` clears stale binaries first, so a renamed or deleted benchmark stops running.
 
-A benchmark's absolute nanoseconds are not comparable across runs or machines — only the paired
-ratios inside one run are. `src/bench/harness.hpp` explains what it does about measurement bias
-and why (#81).
+A benchmark's absolute nanoseconds are never comparable across machines, and across runs only
+when a round is long enough for its fixed cost to amortize away — `bench_jieqi.cpp` runs the cache
+hit a second time at 24000 iterations for exactly that reason. Otherwise read the paired ratios
+inside one run. `src/bench/harness.hpp` explains what it does about measurement bias and why (#81).
 
 Windows PowerShell:
 
@@ -130,10 +131,9 @@ cmake --build build --parallel
 ctest --test-dir build/test
 ```
 
-`build/test`, not `build`: the tests register in the subdirectory, so
-`ctest --test-dir build` runs **zero** tests and still exits 0 — a green light
-that checked nothing. (The root cause, a missing top-level `enable_testing()`,
-is tracked in #72.)
+Either path works since #72 added the top-level `enable_testing()`. Without it only the
+subdirectory registered, so `ctest --test-dir build` ran **zero** tests and still exited 0 —
+a green light that checked nothing, which is why that call is load-bearing.
 
 ### Lint
 
@@ -159,11 +159,11 @@ is tracked in #72.)
 
 ### Naming
 
-Nothing checks this — `readability-identifier-naming` is off, and the CheckOptions that used to
-claim to be its SSOT described a codebase this is not (#72). Read it here instead:
+Nothing enforces this — `readability-identifier-naming` is deliberately off (#72). The convention
+lives here:
 
 `lower_case` — variables, functions, parameters, members, methods, namespaces, and any
-`const inline auto` that is called rather than read: it is invoked, so it reads as a function.
+`const inline auto` that is called rather than read.
 `CamelCase` — classes, structs, **and enum types** (`Algo`, `AngleUnit`, `Jieqi`).
 `UPPER_CASE` — `inline constexpr` constants and enumerators.
 
@@ -201,7 +201,7 @@ is intentional. Keep it. That buys a discipline:
   with designated initializers (`.λ = …`). Keep units in the type system.
 - `const`-correct; modern C++ (`<ranges>`, `<span>`, `std::array`).
 - 2-space indentation. Compiler flags: `-Wall -Wextra -Werror -Wpedantic -Wnull-dereference
-  -Wunreachable-code -O2`.
+  -Wunreachable-code`; the optimization level is `CMAKE_BUILD_TYPE`'s (Release = `-O3 -DNDEBUG`).
 - **Multi-line call layout**: when an argument is itself a call, or the call grows long, put
   each argument on its own line and the closing `);` on its own line at the call's
   indentation — matching the existing `upper_bound` / `Datetime`-construction sites:
@@ -330,6 +330,14 @@ toolbox/        Helper scripts for artifacts, releases, build info
    (target state; #77, #67 and #64 are closed, #70 is the last one open): public input
    validation must `throw` (fail-fast, independent of build type); `assert` is only
    for internal invariants, never as an input guard.
+
+9. **CI toolchains are pinned, all of them.** A tool that updates itself turns "the code changed"
+   and "the tool changed" into the same red X, on a day nobody touched the repository; a pin that
+   goes stale instead fails loudly with "no such version", which says what to do. Current pins:
+   clang-tidy and clang **18.1.8** (Linux, `core_tests.yml`), choco **LLVM 20.1.8** (Windows — not
+   the 18 the Linux legs use, a pre-existing split these pins record rather than create), Xcode
+   major **`'26'`** (a major carries an Apple Clang major, and `-Werror` makes any new diagnostic
+   in it a red build), ruff **0.16.1**. Bump deliberately, never incidentally (#72, #73).
 
 ## AI do / don't
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,20 @@ lives here:
 the source's spelling: `cos_λ`, `argL`, `A1`, `θCoeffs`, `gen_eval_θ`, and `Jieqi`'s 立春/冬至.
 Same discipline as the `@ref` rule above — the code should read next to the book.
 
+### Comment language
+
+Narrative in English; domain terms keep their own spelling, glossed once in parentheses — `the
+Chinese Jieqi (节气)`, `a Jie (节)`, `Jieqi::冬至`. Translating an entity loses it, and the gloss is
+what lets a reader who has only the English follow. Full-Chinese runs are for named or quoted
+material, never for explanation.
+
+The lunar subtree is the exception, and stays one: its Doxygen `@param` / `@return` lines carry a
+Chinese restatement after the English (`@param year The Lunar year. 阴历年份。`). Match the
+neighbours when editing there — do not spread it, do not strip it.
+
+Punctuation follows the language of the run it sits in: full-width inside a Chinese phrase,
+half-width everywhere else.
+
 ### Header-only, and the code reads like the maths
 
 Header-only is a **deliberate design choice** — the no-link, orthogonal, self-contained feel

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,17 +32,15 @@ RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Build and test the project
-# The whole suite, not only the integration tests. It used to be `-k integration` "since arm docker
-# env are slow on GitHub CI" — true of the eight-platform QEMU matrix, which was retired in 2026-07
-# for two native runners (#46). The reason outlived its premise by a year. Measured on the native
-# runners: all 211 tests cost arm64 275s against 248s for three of them, and arm64 running the whole
-# suite is still quicker than amd64 running three (#72).
 # Gate track of the #69 dual-track policy: pin the seed inside the image too — a docker
 # build layer does not inherit the GitHub Actions env context (default matches
 # DEFAULT_SEED in src/util/random.hpp).
 ARG CELESTIAL_TEST_SEED=42
 ENV CELESTIAL_TEST_SEED=${CELESTIAL_TEST_SEED}
 RUN if [ -f Requirements.txt ]; then /opt/venv/bin/pip install -r Requirements.txt; fi
+
+# The whole suite: `-k integration` was justified by the eight-platform QEMU matrix, retired in
+# 2026-07 for two native runners (#46), and these two legs are CI's only arm64 coverage (#72).
 RUN /opt/venv/bin/python ./project.py --clean --cores all --all -v 1
 
 # Save the build information

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN aptitude install -y python3 python3-pip python3-venv python3-full
 RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Build and test the project
 # Gate track of the #69 dual-track policy: pin the seed inside the image too — a docker
 # build layer does not inherit the GitHub Actions env context (default matches
 # DEFAULT_SEED in src/util/random.hpp).

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,14 +32,18 @@ RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Build and test the project
-# Only run the integration tests, since arm docker env are slow on GitHub CI
+# The whole suite, not only the integration tests. It used to be `-k integration` "since arm docker
+# env are slow on GitHub CI" — true of the eight-platform QEMU matrix, which was retired in 2026-07
+# for two native runners (#46). The reason outlived its premise by a year. Measured on the native
+# runners: all 211 tests cost arm64 275s against 248s for three of them, and arm64 running the whole
+# suite is still quicker than amd64 running three (#72).
 # Gate track of the #69 dual-track policy: pin the seed inside the image too — a docker
 # build layer does not inherit the GitHub Actions env context (default matches
 # DEFAULT_SEED in src/util/random.hpp).
 ARG CELESTIAL_TEST_SEED=42
 ENV CELESTIAL_TEST_SEED=${CELESTIAL_TEST_SEED}
 RUN if [ -f Requirements.txt ]; then /opt/venv/bin/pip install -r Requirements.txt; fi
-RUN /opt/venv/bin/python ./project.py --clean --cores all --all -k integration -v 1
+RUN /opt/venv/bin/python ./project.py --clean --cores all --all -v 1
 
 # Save the build information
 ARG DOCKER_PLATFORM=""

--- a/automation/build.py
+++ b/automation/build.py
@@ -39,7 +39,16 @@ def run_cmake(
 
   yellow_print("# Running cmake...")
 
-  cmds = ["cmake", str(SRC_DIR), "-G", "Unix Makefiles", f"-DCMAKE_BUILD_TYPE={build_type}"]
+  cmds = ["cmake", str(SRC_DIR), f"-DCMAKE_BUILD_TYPE={build_type}"]
+
+  # Pass `-G` only when the caller has not chosen: CMake reads `CMAKE_GENERATOR` from the
+  # environment, and a `-G` on the command line silently wins over it. The default is load-bearing,
+  # not a leftover -- the Windows leg installs `make` and builds with clang (`core_tests.yml`), and
+  # a generator that lays binaries out per configuration would put them somewhere the
+  # `build/test/*` acceptance run does not look (#72).
+  if "CMAKE_GENERATOR" not in os.environ:
+    cmds += ["-G", "Unix Makefiles"]
+
   if export_compile_commands:
     cmds.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
 

--- a/automation/build.py
+++ b/automation/build.py
@@ -43,9 +43,9 @@ def run_cmake(
 
   # Pass `-G` only when the caller has not chosen: CMake reads `CMAKE_GENERATOR` from the
   # environment, and a `-G` on the command line silently wins over it. The default is load-bearing,
-  # not a leftover -- the Windows leg installs `make` and builds with clang (`core_tests.yml`), and
-  # a generator that lays binaries out per configuration would put them somewhere the
-  # `build/test/*` acceptance run does not look (#72).
+  # not a leftover -- the Windows legs build with clang plus choco's `make` (`build_and_test.yml`,
+  # `random_soak.yml`), and a generator that lays binaries out per configuration would put them
+  # somewhere the `build/test/*` acceptance run does not look (#72).
   if "CMAKE_GENERATOR" not in os.environ:
     cmds += ["-G", "Unix Makefiles"]
 

--- a/automation/github.py
+++ b/automation/github.py
@@ -375,8 +375,6 @@ class GitHub:
       queue.put_nowait((asset.name, asset.browser_download_url))
 
     tag_name = selected_release.tag_name
-    # Named for what they contain: both entries used to point at the tarball, so the release
-    # shipped a gzipped tar called `src.zip` (#72).
     archive_url = f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/{tag_name}"
     queue.put_nowait(("src.zip", f"{archive_url}.zip"))
     queue.put_nowait(("src.tar.gz", f"{archive_url}.tar.gz"))

--- a/automation/github.py
+++ b/automation/github.py
@@ -23,6 +23,11 @@ from .utils import green_print, red_print, blue_print
 OWNER = "0xf3cd" # Yes, it's me.
 REPO  = "celestial-calendar"
 
+# `requests` has no default timeout, so a server that accepts the connection and then goes quiet
+# hangs the release tooling with no ceiling. The pair is (connect, read); the read half applies
+# between bytes received, not to a whole transfer, so it stays short without capping big artifacts.
+TIMEOUT = (10, 60)
+
 
 def gen_headers() -> Dict[str, str]:
   """
@@ -65,7 +70,7 @@ class GitHub:
       Dict[str, str]: A dictionary mapping workflow names to their IDs.
     """
     url = f"https://api.github.com/repos/{OWNER}/{REPO}/actions/workflows"
-    response = requests.get(url, headers=gen_headers())
+    response = requests.get(url, headers=gen_headers(), timeout=TIMEOUT)
     response.raise_for_status()
 
     json_resp = response.json()
@@ -105,7 +110,7 @@ class GitHub:
       List[str]: A list of run IDs.
     """
     url = f"https://api.github.com/repos/{OWNER}/{REPO}/actions/runs"
-    response = requests.get(url, headers=gen_headers())
+    response = requests.get(url, headers=gen_headers(), timeout=TIMEOUT)
     response.raise_for_status()
 
     json_resp = response.json()
@@ -137,7 +142,7 @@ class GitHub:
     """
     artifacts_url = f"https://api.github.com/repos/{OWNER}/{REPO}/actions/runs/{run_id}/artifacts"
     
-    response = requests.get(artifacts_url, headers=gen_headers())
+    response = requests.get(artifacts_url, headers=gen_headers(), timeout=TIMEOUT)
     response.raise_for_status()
     artifacts = response.json()
 
@@ -159,7 +164,7 @@ class GitHub:
     Returns:
       Path: The path to the downloaded artifact.
     """
-    with requests.get(download_url, headers=gen_headers(), stream=True) as response:
+    with requests.get(download_url, headers=gen_headers(), stream=True, timeout=TIMEOUT) as response:
       response.raise_for_status()
 
       download_dir.mkdir(parents=True, exist_ok=True)
@@ -277,7 +282,7 @@ class GitHub:
       List['GitHub.Release']: A list of GitHub releases.
     """
     url = f"https://api.github.com/repos/{OWNER}/{REPO}/releases"
-    response = requests.get(url, headers=gen_headers())
+    response = requests.get(url, headers=gen_headers(), timeout=TIMEOUT)
     response.raise_for_status()
 
     json_resp = response.json()
@@ -324,7 +329,7 @@ class GitHub:
     Returns:
       Path: The path to the downloaded asset.
     """
-    with requests.get(download_url, headers=gen_headers(), stream=True) as response:
+    with requests.get(download_url, headers=gen_headers(), stream=True, timeout=TIMEOUT) as response:
       response.raise_for_status()
 
       download_dir.mkdir(parents=True, exist_ok=True)
@@ -370,8 +375,11 @@ class GitHub:
       queue.put_nowait((asset.name, asset.browser_download_url))
 
     tag_name = selected_release.tag_name
-    queue.put_nowait(("src.zip", f"https://github.com/0xf3cd/celestial-calendar/archive/refs/tags/{tag_name}.tar.gz"))
-    queue.put_nowait(("src.tar.gz", f"https://github.com/0xf3cd/celestial-calendar/archive/refs/tags/{tag_name}.tar.gz"))
+    # Named for what they contain: both entries used to point at the tarball, so the release
+    # shipped a gzipped tar called `src.zip` (#72).
+    archive_url = f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/{tag_name}"
+    queue.put_nowait(("src.zip", f"{archive_url}.zip"))
+    queue.put_nowait(("src.tar.gz", f"{archive_url}.tar.gz"))
 
     paths: List[Path] = []
 

--- a/automation/self_contained.py
+++ b/automation/self_contained.py
@@ -35,10 +35,7 @@ def include_roots(src_dir: Path) -> List[Path]:
   hand-copied list drifts silently, so there is no second list to drift.
   """
   cmakelists = src_dir / "CMakeLists.txt"
-  roots = [src_dir / name.strip() for name in INCLUDE_DIR_RE.findall(cmakelists.read_text())]
-  # src/CMakeLists.txt still names `common`, which no longer exists (tracked in #72).
-  # Passing -I for a missing directory is harmless but pointless, so drop it.
-  return [r for r in roots if r.is_dir()]
+  return [src_dir / name.strip() for name in INCLUDE_DIR_RE.findall(cmakelists.read_text())]
 
 
 def check_self_contained() -> int:

--- a/automation/sysinfo.py
+++ b/automation/sysinfo.py
@@ -20,12 +20,18 @@ from .utils import run_cmd, ProcReturn
 
 def print_system_info() -> None:
   """Print system time and other system information."""
-  cmake_version: ProcReturn = run_cmd(["cmake", "--version"], print_cmd=False, print_stdout=False)
-  assert cmake_version.retcode == 0
+  # This function reports; `--setup` is what decides whether a missing tool should stop the run,
+  # and it says something worth reading. Reaching for cmake unguarded here took that away twice
+  # over: `run_cmd` raises `FileNotFoundError` when the binary is absent, and the `assert` that
+  # used to follow covered only the other case -- cmake present but `--version` failing (#72).
+  try:
+    cmake_version: ProcReturn = run_cmd(["cmake", "--version"], print_cmd=False, print_stdout=False)
+    cmake_version_str: str = " | ".join(
+      filter(lambda s: len(s.strip()) > 0, cmake_version.stdout.splitlines())
+    ) if cmake_version.retcode == 0 else "present, but `cmake --version` failed"
+  except FileNotFoundError:
+    cmake_version_str = "not found"
 
-  cmake_version_str: str = " | ".join(
-    filter(lambda s: len(s.strip()) > 0, cmake_version.stdout.splitlines())
-  )
   this_moment: datetime = datetime.now()
 
   print(60 * "#")

--- a/automation/sysinfo.py
+++ b/automation/sysinfo.py
@@ -20,15 +20,14 @@ from .utils import run_cmd, ProcReturn
 
 def print_system_info() -> None:
   """Print system time and other system information."""
-  # This function reports; `--setup` is what decides whether a missing tool should stop the run,
-  # and it says something worth reading. Reaching for cmake unguarded here took that away twice
-  # over: `run_cmd` raises `FileNotFoundError` when the binary is absent, and the `assert` that
-  # used to follow covered only the other case -- cmake present but `--version` failing (#72).
+  # This function only reports -- whether a missing tool stops the run is `--setup`'s call, and it
+  # says something readable. `run_cmd` raises `FileNotFoundError` when the binary is absent (#72).
   try:
     cmake_version: ProcReturn = run_cmd(["cmake", "--version"], print_cmd=False, print_stdout=False)
-    cmake_version_str: str = " | ".join(
-      filter(lambda s: len(s.strip()) > 0, cmake_version.stdout.splitlines())
-    ) if cmake_version.retcode == 0 else "present, but `cmake --version` failed"
+    if cmake_version.retcode == 0:
+      cmake_version_str = " | ".join(filter(lambda s: len(s.strip()) > 0, cmake_version.stdout.splitlines()))
+    else:
+      cmake_version_str = "present, but `cmake --version` failed"
   except FileNotFoundError:
     cmake_version_str = "not found"
 

--- a/linter.py
+++ b/linter.py
@@ -14,22 +14,6 @@
 # This software is distributed without any warranty.
 # See <https://www.gnu.org/licenses/> for more details.
 
-#!/usr/bin/env python3
-#
-# Automation script for building and testing the CelestialCalendar C++ project.
-#
-#########################################################################################
-# CelestialCalendar Automation:
-#   Python automation scripts for building and testing the CelestialCalendar C++ project.
-# 
-# Author : Ningqi Wang (0xf3cd)
-# Email  : nq.maigre@gmail.com
-# Repo   : https://github.com/0xf3cd/celestial-calendar
-# License: GNU General Public License v3.0
-# 
-# This software is distributed without any warranty.
-# See <https://www.gnu.org/licenses/> for more details.
-
 import sys
 import argparse
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,10 @@ include_directories(${PROJECT_SOURCE_DIR}/astro)
 include_directories(${PROJECT_SOURCE_DIR}/calendar)
 include_directories(${PROJECT_SOURCE_DIR}/util)
 
+# Here, not only in `test/`: without a top-level call CMake writes no `CTestTestfile.cmake` next to
+# this build tree's root, so `ctest --test-dir build` finds zero tests -- and reports success (#72).
+enable_testing()
+
 # Add subdirectories. The order is for readability only — CMake binds targets at generate
 # time, so `test` may reference `celestial_calendar` before its directory is processed (#67).
 add_subdirectory(shared_lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,11 +7,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Add compile options for different compilers
 add_compile_options(-Wall -Wextra -Werror -Wpedantic -Wnull-dereference -Wunreachable-code)
 
-# Optimization flag
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+# Optimization is `CMAKE_BUILD_TYPE`'s job: `CMAKE_CXX_FLAGS` lands before the build type's own
+# flags and silently loses to them. This file used to set `-O2`; Release compiled at `-O3` (#72).
 
 # Include directories
-include_directories(${PROJECT_SOURCE_DIR}/common)
 include_directories(${PROJECT_SOURCE_DIR}/astro)
 include_directories(${PROJECT_SOURCE_DIR}/calendar)
 include_directories(${PROJECT_SOURCE_DIR}/util)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,8 +7,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Add compile options for different compilers
 add_compile_options(-Wall -Wextra -Werror -Wpedantic -Wnull-dereference -Wunreachable-code)
 
-# Optimization is `CMAKE_BUILD_TYPE`'s job: `CMAKE_CXX_FLAGS` lands before the build type's own
-# flags and silently loses to them. This file used to set `-O2`; Release compiled at `-O3` (#72).
+# Optimization is `CMAKE_BUILD_TYPE`'s job: a flag set in `CMAKE_CXX_FLAGS` lands before the build
+# type's own and silently loses to it. Debug is therefore really `-O0`, so golden values computed
+# there can differ from a Release run by a ulp (#72).
 
 # Include directories
 include_directories(${PROJECT_SOURCE_DIR}/astro)

--- a/src/bench/bench_jieqi.cpp
+++ b/src/bench/bench_jieqi.cpp
@@ -1,0 +1,102 @@
+/*
+ * CelestialCalendar:
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ *
+ * Copyright (C) 2026 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// One solar-term moment costs a Newton search or a map lookup, depending only on whether the answer
+// is already in `jieqi_jde`'s cache. Both are timed here because the gap between them is what the
+// cache is for, and it is the number any proposal to change the caching has to move.
+
+#include <vector>
+#include <cstdint>
+#include <cstddef>
+#include <utility>
+#include <iostream>
+
+#include "cache.hpp"
+#include "jieqi.hpp"
+#include "harness.hpp"
+
+namespace {
+
+using Key = std::pair<int32_t, calendar::jieqi::Jieqi>;
+
+/** @brief Every solar term of ten consecutive years -- 240 distinct keys, none repeated. */
+[[nodiscard]] auto sample_keys() -> std::vector<Key> {
+  constexpr int32_t FIRST_YEAR = 2000;
+  constexpr int32_t YEAR_COUNT = 10;
+
+  std::vector<Key> keys;
+  keys.reserve(static_cast<std::size_t>(YEAR_COUNT) * calendar::jieqi::JIEQI_COUNT);
+
+  for (int32_t year = FIRST_YEAR; year < FIRST_YEAR + YEAR_COUNT; ++year) {
+    for (uint8_t index = 0; index < calendar::jieqi::JIEQI_COUNT; ++index) {
+      keys.emplace_back(year, calendar::jieqi::from_index(index));
+    }
+  }
+  return keys;
+}
+
+} // namespace
+
+
+auto main() -> int {
+  const auto keys = sample_keys();
+
+  // Volatile so neither the sums nor the calls they come from can be optimized away.
+  volatile double sink = 0.0;
+
+  const std::vector<bench::Case> cases {
+    {
+      // A cache that cannot be emptied -- `util/cache.hpp` still carries the TODO -- can only be
+      // made cold by being new, so this builds one per round rather than reusing the global.
+      // Per round, not per call: one wrapper construction amortized over `iterations` is
+      // invisible next to a Newton search, one per call would not be. Indexing `keys` directly
+      // rather than modulo is what keeps every call a miss: no key is asked for twice in a round.
+      .name = "jieqi_jde -- cold (every call a miss)",
+      .body = [&](const std::size_t iterations) {
+        const auto cold = util::cache::cache_func(calendar::jieqi::calc_jieqi_jde);
+        for (std::size_t i = 0; i < iterations; ++i) {
+          const auto [year, jq] = keys.at(i);
+          sink = sink + cold(year, jq);
+        }
+      },
+    },
+    {
+      // The global cache, whose keys the warm-up has already filled in.
+      .name = "jieqi_jde -- warm (every call a hit)",
+      .body = [&](const std::size_t iterations) {
+        for (std::size_t i = 0; i < iterations; ++i) {
+          const auto [year, jq] = keys.at(i);
+          sink = sink + calendar::jieqi::jieqi_jde(year, jq);
+        }
+      },
+    },
+  };
+
+  const bench::Plan plan {
+    .title = "Solar terms",
+    .iterations = keys.size(), // `keys.at(i)` above reads this many, so the two must agree.
+  };
+
+  bench::run(plan, cases, std::cout);
+  return 0;
+}

--- a/src/bench/bench_jieqi.cpp
+++ b/src/bench/bench_jieqi.cpp
@@ -25,6 +25,7 @@
 // is already in `jieqi_jde`'s cache. Both are timed here because the gap between them is what the
 // cache is for, and it is the number any proposal to change the caching has to move.
 
+#include <array>
 #include <vector>
 #include <cstdint>
 #include <cstddef>
@@ -39,7 +40,7 @@ namespace {
 
 using Key = std::pair<int32_t, calendar::jieqi::Jieqi>;
 
-/** @brief Every solar term of ten consecutive years -- 240 distinct keys, none repeated. */
+/** @brief Every solar term of ten consecutive years, each key distinct. */
 [[nodiscard]] auto sample_keys() -> std::vector<Key> {
   constexpr int32_t FIRST_YEAR = 2000;
   constexpr int32_t YEAR_COUNT = 10;
@@ -64,51 +65,45 @@ auto main() -> int {
   // Volatile so neither the sums nor the calls they come from can be optimized away.
   volatile double sink = 0.0;
 
-  const std::vector<bench::Case> cases {
-    {
-      // A cache that cannot be emptied -- `util/cache.hpp` still carries the TODO -- can only be
-      // made cold by being new, so this builds one per round rather than reusing the global.
-      // Per round, not per call: one wrapper construction amortized over `iterations` is
-      // invisible next to a Newton search, one per call would not be. Indexing `keys` directly
-      // rather than modulo is what keeps every call a miss: no key is asked for twice in a round.
-      .name = "jieqi_jde -- cold (every call a miss)",
-      .body = [&](const std::size_t iterations) {
-        const auto cold = util::cache::cache_func(calendar::jieqi::calc_jieqi_jde);
-        for (std::size_t i = 0; i < iterations; ++i) {
-          const auto [year, jq] = keys.at(i);
-          sink = sink + cold(year, jq);
-        }
-      },
-    },
-    {
-      // The global cache, whose keys the warm-up has already filled in. Modulo here where the cold
-      // case above indexes directly: a hit does not care how often a key repeats, and wrapping is
-      // what lets this same case be reused below with far more iterations than there are keys.
-      .name = "jieqi_jde -- warm (every call a hit)",
-      .body = [&](const std::size_t iterations) {
-        for (std::size_t i = 0; i < iterations; ++i) {
-          const auto [year, jq] = keys.at(i % keys.size());
-          sink = sink + calendar::jieqi::jieqi_jde(year, jq);
-        }
-      },
+  const bench::Case cold {
+    // A cache with no way to empty it -- `util/cache.hpp` still carries the TODO -- can only be
+    // made cold by being new, so this builds one per round. Per round, not per call: one wrapper
+    // construction amortized over `iterations` is invisible next to a Newton search. And `keys` is
+    // indexed directly rather than modulo, which is what keeps every call a miss.
+    .name = "jieqi_jde -- cold (every call a miss)",
+    .body = [&](const std::size_t iterations) {
+      const auto uncached = util::cache::cache_func(calendar::jieqi::calc_jieqi_jde);
+      for (std::size_t i = 0; i < iterations; ++i) {
+        const auto [year, jq] = keys.at(i);
+        sink = sink + uncached(year, jq);
+      }
     },
   };
 
-  // The pair answers what the cache buys, and 240 iterations is as many as it can answer it with:
-  // the cold case pays a Newton search each time, so a round already costs some 64 ms.
-  bench::run({ .title = "Solar terms", // `keys.at(i)` above reads `iterations` of them, so they agree.
-               .iterations = keys.size() },
-             cases, std::cout);
+  const bench::Case warm {
+    // The global cache, whose keys the warm-up has already filled in. Wrapping lets this case run
+    // for more iterations than there are keys, which the second round below needs.
+    .name = "jieqi_jde -- warm (every call a hit)",
+    .body = [&](const std::size_t iterations) {
+      for (std::size_t i = 0; i < iterations; ++i) {
+        const auto [year, jq] = keys.at(i % keys.size());
+        sink = sink + calendar::jieqi::jieqi_jde(year, jq);
+      }
+    },
+  };
 
-  // And then the hit on its own, with rounds long enough to measure it. At 240 iterations a round's
-  // fixed cost is around 600 ns, which lands as +30% on an 8 ns operation and a p10..p90 spanning
-  // nearly a factor of two -- fine for "four orders of magnitude", useless for tracking a 10%
-  // change to the hash or the lock. At 24000 the same figure repeats to within 1% across runs.
-  // Measured, on one machine: 10.6/10.1/10.6 ns and 8.3..15.8 at 240, against 8.1/8.1/8.0 ns and
-  // 8.0..9.0 at 24000. The two agree on `min`, which is what says the difference is per-round
-  // overhead amortized away rather than the machine wandering between runs.
-  const std::vector<bench::Case> hit_only { cases[1] };
-  bench::run({ .title = "Solar terms -- cache hit alone", .iterations = 24000 }, hit_only, std::cout);
+  // What the cache buys. `iterations` is bounded by `keys.size()` -- the cold case indexes `keys`
+  // directly -- and by the Newton search it pays each time, which already makes a round some 64 ms.
+  const std::array paired { cold, warm };
+  const bench::Plan paired_plan { .title = "Solar terms", .iterations = keys.size() };
+  bench::run(paired_plan, paired, std::cout);
+
+  // What a hit costs, with rounds long enough to say. At 240 iterations a round's fixed cost lands
+  // as some +30% on an 8 ns operation, with a p10..p90 spanning nearly a factor of two -- fine for
+  // "four orders of magnitude", useless for tracking a 10% change to the hash or the lock.
+  const std::array hit_only { warm };
+  const bench::Plan hit_plan { .title = "Solar terms -- cache hit alone", .iterations = 24000 };
+  bench::run(hit_plan, hit_only, std::cout);
 
   return 0;
 }

--- a/src/bench/bench_jieqi.cpp
+++ b/src/bench/bench_jieqi.cpp
@@ -92,8 +92,8 @@ auto main() -> int {
     },
   };
 
-  // What the cache buys. `iterations` is bounded by `keys.size()` -- the cold case indexes `keys`
-  // directly -- and by the Newton search it pays each time, which already makes a round some 64 ms.
+  // What the cache buys. `iterations` is bounded by `keys.size()`, because the cold case indexes
+  // `keys` directly.
   const std::array paired { cold, warm };
   const bench::Plan paired_plan { .title = "Solar terms", .iterations = keys.size() };
   bench::run(paired_plan, paired, std::cout);
@@ -101,6 +101,7 @@ auto main() -> int {
   // What a hit costs, with rounds long enough to say. At 240 iterations a round's fixed cost lands
   // as some +30% on an 8 ns operation, with a p10..p90 spanning nearly a factor of two -- fine for
   // "four orders of magnitude", useless for tracking a 10% change to the hash or the lock.
+  // 24000 is where that stops mattering: the figure repeats across runs to within a percent.
   const std::array hit_only { warm };
   const bench::Plan hit_plan { .title = "Solar terms -- cache hit alone", .iterations = 24000 };
   bench::run(hit_plan, hit_only, std::cout);

--- a/src/bench/bench_jieqi.cpp
+++ b/src/bench/bench_jieqi.cpp
@@ -81,22 +81,34 @@ auto main() -> int {
       },
     },
     {
-      // The global cache, whose keys the warm-up has already filled in.
+      // The global cache, whose keys the warm-up has already filled in. Modulo here where the cold
+      // case above indexes directly: a hit does not care how often a key repeats, and wrapping is
+      // what lets this same case be reused below with far more iterations than there are keys.
       .name = "jieqi_jde -- warm (every call a hit)",
       .body = [&](const std::size_t iterations) {
         for (std::size_t i = 0; i < iterations; ++i) {
-          const auto [year, jq] = keys.at(i);
+          const auto [year, jq] = keys.at(i % keys.size());
           sink = sink + calendar::jieqi::jieqi_jde(year, jq);
         }
       },
     },
   };
 
-  const bench::Plan plan {
-    .title = "Solar terms",
-    .iterations = keys.size(), // `keys.at(i)` above reads this many, so the two must agree.
-  };
+  // The pair answers what the cache buys, and 240 iterations is as many as it can answer it with:
+  // the cold case pays a Newton search each time, so a round already costs some 64 ms.
+  bench::run({ .title = "Solar terms", // `keys.at(i)` above reads `iterations` of them, so they agree.
+               .iterations = keys.size() },
+             cases, std::cout);
 
-  bench::run(plan, cases, std::cout);
+  // And then the hit on its own, with rounds long enough to measure it. At 240 iterations a round's
+  // fixed cost is around 600 ns, which lands as +30% on an 8 ns operation and a p10..p90 spanning
+  // nearly a factor of two -- fine for "four orders of magnitude", useless for tracking a 10%
+  // change to the hash or the lock. At 24000 the same figure repeats to within 1% across runs.
+  // Measured, on one machine: 10.6/10.1/10.6 ns and 8.3..15.8 at 240, against 8.1/8.1/8.0 ns and
+  // 8.0..9.0 at 24000. The two agree on `min`, which is what says the difference is per-round
+  // overhead amortized away rather than the machine wandering between runs.
+  const std::vector<bench::Case> hit_only { cases[1] };
+  bench::run({ .title = "Solar terms -- cache hit alone", .iterations = 24000 }, hit_only, std::cout);
+
   return 0;
 }

--- a/src/bench/bench_vsop87d.cpp
+++ b/src/bench/bench_vsop87d.cpp
@@ -1,0 +1,89 @@
+/*
+ * CelestialCalendar:
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ *
+ * Copyright (C) 2026 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Solar-term moments come out of a Newton search on the Sun's apparent longitude, and every step of
+// that search evaluates Earth's VSOP87D series -- which is most of what this binary times.
+// `evaluate` is reported next to the full chain so a change to one can be read against the other.
+
+#include <vector>
+#include <cstddef>
+#include <iostream>
+
+#include "sun.hpp"
+#include "harness.hpp"
+#include "julian_day.hpp"
+#include "vsop87d/vsop87d.hpp"
+#include "vsop87d/defines.hpp"
+
+namespace {
+
+/** @brief JDEs spanning roughly year 0 to year 4000. */
+[[nodiscard]] auto sample_jdes() -> std::vector<double> {
+  constexpr std::size_t COUNT = 4096;
+  std::vector<double> jdes;
+  jdes.reserve(COUNT);
+  for (std::size_t i = 0; i < COUNT; ++i) {
+    const double jc = -20.0 + (40.0 * static_cast<double>(i)) / static_cast<double>(COUNT);
+    jdes.push_back(astro::julian_day::jc_to_jde(jc));
+  }
+  return jdes;
+}
+
+} // namespace
+
+
+auto main() -> int {
+  const auto jdes = sample_jdes();
+
+  // Volatile so neither the sums nor the calls they come from can be optimized away.
+  volatile double sink = 0.0;
+
+  const std::vector<bench::Case> cases {
+    {
+      .name = "vsop87d::evaluate<EAR>",
+      .body = [&](const std::size_t iterations) {
+        for (std::size_t i = 0; i < iterations; ++i) {
+          const auto jm = astro::julian_day::jde_to_jm(jdes.at(i % jdes.size()));
+          const auto evaluated = astro::vsop87d::evaluate<astro::vsop87d::Planet::EAR>(jm);
+          sink = sink + evaluated.λ + evaluated.β + evaluated.r;
+        }
+      },
+    },
+    {
+      .name = "sun::geocentric_coord::apparent",
+      .body = [&](const std::size_t iterations) {
+        for (std::size_t i = 0; i < iterations; ++i) {
+          sink = sink + astro::sun::geocentric_coord::apparent(jdes.at(i % jdes.size())).λ.deg();
+        }
+      },
+    },
+  };
+
+  const bench::Plan plan {
+    .title = "VSOP87D",
+    .iterations = jdes.size(),
+  };
+
+  bench::run(plan, cases, std::cout);
+  return 0;
+}

--- a/src/bench/harness.hpp
+++ b/src/bench/harness.hpp
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <chrono>
 #include <format>
+#include <string>
 #include <vector>
 #include <cstddef>
 #include <ostream>
@@ -107,6 +108,19 @@ namespace detail {
 }
 
 
+/** @brief One paired ratio: a percentage within a factor of two, a factor past that -- `-99.994%`
+ *         rounds to `-100.0%`, which reads as free. */
+[[nodiscard]] inline auto format_ratio(const double ratio) -> std::string {
+  if (ratio >= 2.0) {
+    return std::format("{:.1f}x slower", ratio);
+  }
+  if (ratio > 0.0 and ratio <= 0.5) { // `> 0` keeps a degenerate zero out of the reciprocal.
+    return std::format("{:.0f}x faster", 1.0 / ratio);
+  }
+  return std::format("{:+.1f}%", 100.0 * (ratio - 1.0));
+}
+
+
 /** @brief Run `body` once for `iterations` and return the nanoseconds each iteration took. */
 [[nodiscard]] inline auto time_once(const Case& bench_case, const std::size_t iterations) -> double {
   const auto started = std::chrono::steady_clock::now();
@@ -167,11 +181,11 @@ inline void run(const Plan& plan, const std::span<const Case> cases, std::ostrea
     out << std::format("\n  vs {} (per-round paired ratio):\n", cases[0].name);
     for (std::size_t index = 1; index < cases.size(); ++index) {
       const auto stats = detail::summarize(ratios.at(index));
-      out << std::format("  {:<34} median {:+6.1f}%   p10..p90 {:+.1f}%..{:+.1f}%\n",
+      out << std::format("  {:<34} median {:>13}   p10..p90 {}..{}\n",
                          cases[index].name,
-                         100.0 * (stats.median - 1.0),
-                         100.0 * (stats.p10 - 1.0),
-                         100.0 * (stats.p90 - 1.0));
+                         detail::format_ratio(stats.median),
+                         detail::format_ratio(stats.p10),
+                         detail::format_ratio(stats.p90));
     }
   }
 

--- a/src/bench/harness.hpp
+++ b/src/bench/harness.hpp
@@ -108,8 +108,9 @@ namespace detail {
 }
 
 
-/** @brief One paired ratio: a percentage within a factor of two, a factor past that -- `-99.994%`
- *         rounds to `-100.0%`, which reads as free. */
+/** @brief One paired ratio: a percentage while the two are within a factor of two, a factor past
+ *         that -- on the fast side because percentages bottom out (`-99.994%` rounds to `-100.0%`,
+ *         which reads as free), on the slow side so a pair reads alike whichever way it went. */
 [[nodiscard]] inline auto format_ratio(const double ratio) -> std::string {
   if (ratio >= 2.0) {
     return std::format("{:.1f}x slower", ratio);
@@ -175,8 +176,12 @@ inline void run(const Plan& plan, const std::span<const Case> cases, std::ostrea
                        cases[index].name, stats.median, stats.min, stats.p10, stats.p90);
   }
 
-  // Ratios are paired inside a round, so machine drift cancels; the absolute figures above do not
-  // have that property and should not be compared across runs, let alone across machines.
+  // Ratios are paired inside a round, so machine drift cancels. The absolute figures above hold
+  // across runs only when a round is long enough for its fixed cost to amortize away, and never
+  // across machines.
+  // `p10..p90` reads high-to-low in the factor form, because a factor is the reciprocal of the
+  // ratio the quantiles were taken on. The labels say which is which; reordering them would make
+  // the labels lie.
   if (cases.size() > 1) {
     out << std::format("\n  vs {} (per-round paired ratio):\n", cases[0].name);
     for (std::size_t index = 1; index < cases.size(); ++index) {

--- a/src/calendar/lunar/algo1.hpp
+++ b/src/calendar/lunar/algo1.hpp
@@ -4,7 +4,7 @@
  *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
  * 
  * Copyright (C) 2024 Ningqi Wang (0xf3cd)
- * Email: nq.maigre* @gmail.com
+ * Email: nq.maigre@gmail.com
  * Repo : https://github.com/0xf3cd/celestial-calendar
  *  
  * This project is free software: you can redistribute it and/or modify

--- a/src/calendar/lunar/algo3.hpp
+++ b/src/calendar/lunar/algo3.hpp
@@ -4,7 +4,7 @@
  *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
  * 
  * Copyright (C) 2024 Ningqi Wang (0xf3cd)
- * Email: nq.maigre* @gmail.com
+ * Email: nq.maigre@gmail.com
  * Repo : https://github.com/0xf3cd/celestial-calendar
  *  
  * This project is free software: you can redistribute it and/or modify

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -18,9 +18,13 @@ else()
 endif()
 
 include(FetchContent)
+# The release asset, not `archive/refs/tags/...`: GitHub generates archive tarballs on request and
+# has changed their compression before, which moves the hash for an unchanged tag. An uploaded
+# asset is a fixed file, so the hash below stays true (#72).
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/archive/refs/tags/v1.15.2.tar.gz
+  URL      https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz
+  URL_HASH SHA256=65fab701d9829d38cb77c14acdc431d2108bfdbf8979e40eb8ae567edf10b27c
 )
 
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -36,6 +36,9 @@ target_compile_options(gtest_main PRIVATE -w)
 target_compile_options(gmock PRIVATE -w)
 target_compile_options(gmock_main PRIVATE -w)
 
+# Kept alongside the top-level call (#72): this directory declares its own `project()`, and
+# configuring it on its own still succeeds -- only configuring, since the `celestial_calendar`
+# target it links against lives one level up.
 enable_testing()
 include(GoogleTest)
 

--- a/src/test/datetime_test.cpp
+++ b/src/test/datetime_test.cpp
@@ -69,9 +69,10 @@ TEST(Datetime, FromTimepoint) {
   }
 
   { // Test with random nanoseconds.
-    // Bounded by construction, because no assertion below can catch it going wrong: `Datetime`
-    // normalizes whatever wrapped value it is handed. `now` sits some 1.8e18 ns past the epoch, so
-    // an offset from the whole `int64_t` range overflows this addition for roughly its top 40%.
+    // The offset is bounded by construction: signed overflow here is undefined, and no assertion
+    // below can see it -- `Datetime` normalizes whatever the wrap produced, so the test passes
+    // either way. `now` sits some 1.8e18 ns past the epoch, so an offset drawn from the whole
+    // `int64_t` range overflows this addition for roughly its top 40%.
     // `system_clock::duration` is not nanoseconds everywhere (libc++ counts microseconds, MSVC
     // 100ns ticks), so the headroom is computed after converting, not from `count()` (#72).
     const auto now_ns = duration_cast<nanoseconds>(now.time_since_epoch()).count();

--- a/src/test/datetime_test.cpp
+++ b/src/test/datetime_test.cpp
@@ -69,13 +69,11 @@ TEST(Datetime, FromTimepoint) {
   }
 
   { // Test with random nanoseconds.
-    // The offset is bounded, and not by taste. `now` sits some 1.8e18 ns past the epoch, so an
-    // offset drawn from the whole `int64_t` range overflows this addition for roughly its top 40%
-    // -- signed overflow, on hundreds of the thousand iterations below. None of the assertions can
-    // see it: `Datetime` normalizes whatever wrapped value it is handed, so they held and the test
-    // passed while the addition was undefined. UBSan reported it on its first run (#72).
+    // Bounded by construction, because no assertion below can catch it going wrong: `Datetime`
+    // normalizes whatever wrapped value it is handed. `now` sits some 1.8e18 ns past the epoch, so
+    // an offset from the whole `int64_t` range overflows this addition for roughly its top 40%.
     // `system_clock::duration` is not nanoseconds everywhere (libc++ counts microseconds, MSVC
-    // 100ns ticks), so the headroom is computed after converting, not from `count()` directly.
+    // 100ns ticks), so the headroom is computed after converting, not from `count()` (#72).
     const auto now_ns = duration_cast<nanoseconds>(now.time_since_epoch()).count();
     const auto headroom = std::numeric_limits<int64_t>::max() - now_ns;
 
@@ -261,10 +259,8 @@ TEST(Datetime, Consistency) {
 
   const auto random_tp_views = std::views::iota(0, 10000) | std::views::transform([&](auto) {
     const auto signed_ns = static_cast<int64_t>(ns_per_year);
-    // `nanoseconds`, matching what `ns_per_year` counts. It used to be `microseconds`, which asked
-    // for twenty *thousand* years rather than twenty, and converting that to the nanoseconds this
-    // addition promotes to overflowed `int64_t` -- undefined, and invisible to every assertion
-    // below, which only ever saw the wrapped result. UBSan reported it (#72).
+    // `nanoseconds`, matching what `ns_per_year` counts: +-20 years keeps this addition inside
+    // `int64_t`, and nothing below would notice if it did not (#72).
     return now + nanoseconds { util::random<int64_t>(-20 * signed_ns, 20 * signed_ns) };
   });
 

--- a/src/test/datetime_test.cpp
+++ b/src/test/datetime_test.cpp
@@ -69,8 +69,18 @@ TEST(Datetime, FromTimepoint) {
   }
 
   { // Test with random nanoseconds.
+    // The offset is bounded, and not by taste. `now` sits some 1.8e18 ns past the epoch, so an
+    // offset drawn from the whole `int64_t` range overflows this addition for roughly its top 40%
+    // -- signed overflow, on hundreds of the thousand iterations below. None of the assertions can
+    // see it: `Datetime` normalizes whatever wrapped value it is handed, so they held and the test
+    // passed while the addition was undefined. UBSan reported it on its first run (#72).
+    // `system_clock::duration` is not nanoseconds everywhere (libc++ counts microseconds, MSVC
+    // 100ns ticks), so the headroom is computed after converting, not from `count()` directly.
+    const auto now_ns = duration_cast<nanoseconds>(now.time_since_epoch()).count();
+    const auto headroom = std::numeric_limits<int64_t>::max() - now_ns;
+
     for (auto i = 0; i < 1000; i++) {
-      const auto tp = now + nanoseconds { util::random<int64_t>() };
+      const auto tp = now + nanoseconds { util::random<int64_t>(-headroom, headroom) };
       const Datetime dt { tp };
 
       const auto time_of_day = dt.time_of_day;
@@ -251,9 +261,11 @@ TEST(Datetime, Consistency) {
 
   const auto random_tp_views = std::views::iota(0, 10000) | std::views::transform([&](auto) {
     const auto signed_ns = static_cast<int64_t>(ns_per_year);
-    return now + microseconds { 
-      util::random<int64_t>(-20 * signed_ns, 20 * signed_ns) 
-    };
+    // `nanoseconds`, matching what `ns_per_year` counts. It used to be `microseconds`, which asked
+    // for twenty *thousand* years rather than twenty, and converting that to the nanoseconds this
+    // addition promotes to overflowed `int64_t` -- undefined, and invisible to every assertion
+    // below, which only ever saw the wrapped result. UBSan reported it (#72).
+    return now + nanoseconds { util::random<int64_t>(-20 * signed_ns, 20 * signed_ns) };
   });
 
   for (auto tp : random_tp_views) {


### PR DESCRIPTION
构建/CI 卫生批。主题是**修那些「看着在守、其实没在守」和「配了但没生效」的东西** ——
以及把两个基准点挂到 P10 立好的 harness 上。

**十五个提交 · 19 文件 · +457/−164 · 不动任何天文/历法逻辑。**

Closes #50
Closes #133

`#72` **不在本 PR 关账**:它的下半(导出面 visibility/SOVERSION/install、shared_lib 的日志名与
线程契约、发布链路的 `conclusion`/`head_sha` 过滤)归 P7b。切分判据是可机器化的 ——
**本 PR 的 diff 不含 `src/shared_lib/` 任何文件**(已自检,零命中)。

---

## 闸门其实没在守

**三条产 artifact 的腿,只有一条有守卫,而那一条问错了问题。**

macOS 那道写的是 `[ ! -f ./build/shared_lib/*.dylib ]`。CMake 在那里留下两个条目(版本化实体 +
无版本软链),`[` 因此收到三个操作数、报错返回非零、`if` 走假分支。四场景实测:

| `build/shared_lib/` 内容 | 旧 | 新 |
|---|---|---|
| 0 个 `.dylib` | exit 1(正确) | exit 1 |
| 1 个真文件 | 0 | 0 |
| 版本化实体 + 无版本软链(**每次真实运行**) | 0(+ stderr 噪音) | 0 |
| **只有软链、没有真文件** | **0 ← 放行** | **1 ← 拦住** |

所以准确的说法不是「它空转」,而是**它问错了问题**:问「glob 匹配到东西了吗」,而这一步真正
依赖的是「有真库被拷进产物目录了吗」。拷贝用 `-type f`,只有软链时一个都拷不走;而
`celestial.h` 与 `build_info.json` 照样进目录,目录非空,`if-no-files-found: error` 也兜不住 ⇒
**artifact 正常发布,里面没有库**。

**而 linux-docker 与 windows 连坏闸门都没有。** 这一条是 R1 的闸门区分力轮抓的 ——
半修比不修更坏,因为提交信息会宣称「闸门现在守的是这一步真正依赖的东西」,而它只对三分之一成立。
三条腿现在都对拷进产物目录的**真文件计数**。

**不过三条腿的边际价值不一样,别读成同一个洞**(claude[bot] 与 R2 闸门复验席独立指出的同一点):
linux-docker 的拷贝循环本来就用 `[ -f ]`,它跟随软链 —— 有效软链会被拷成真文件、悬空的被跳过。
所以那条腿新增守卫抓的是「**一个库都没有**」,不是「只有软链」;macOS 那条才是
`find -type f` 真正修掉了区分力。

**另外两道**:顶层缺 `enable_testing()`(`ctest --test-dir build` 报 **0 个测试并退出 0**,
现在 **211**)· FetchContent 拉 GoogleTest 无 `URL_HASH`。

## 新增一条 ASan + UBSan 腿

落在 `core_tests.yml`:该 workflow 的关键路径是 linter 的 474s,而这条腿 CI 实测 **209s**,
并行加进去不延长墙钟。TSan 刻意不上 —— 它与 ASan 不能共存,而今天全仓只有一处并发可指。

三处设计不是随手:

- **`CXXFLAGS` 送标志**,不给 `project.py` 加一个只为 CI 存在的开关
- **`-fno-sanitize-recover=all`** —— UBSan 默认只打印不失败;少了这行,job 会一边报告未定义行为
  一边保持绿色(R2 的闸门复验席做了对照实验:去掉后同一处 UB 让 step 返回 0、日志里什么都没有)
- **不走 `--test`** —— 它经 `ctest -R`,而 filter 匹配不到时 gtest 退 0、ctest 记 PASS。
  一个能静默跳过二进制的 sanitizer 闸门等于没有闸门,所以直接跑 `build/test/*` 并与
  `TEST(` / `TEST_F(` 宏计数对账

**这条腿一上线就抓到两个存量 UB**,都在 `datetime_test.cpp`,都因为断言只看 `Datetime` 归一化
之后的结果而静默通过多年:偏移量取整个 `int64_t` 范围(`now` 距纪元 1.8e18 ns ⇒ 上方约 40%
必溢出)· 常量叫 `ns_per_year` 却被包进 `microseconds{}`(意图 ±20 年,实际 ±20 千年)。

**对账口径本身也修过一次**:先加了 `TEST_P`,而 `TEST_P` 是一个宏对应 **N** 个测试
(实测:2 个宏 → 4 个测试),数进去会少报、误红。现在只数 1:1 的两个,
**检测到 `TEST_P`/`TYPED_TEST` 就明说这道对账的前提不成立、要求重写它**。

## CI 拓扑

- **去重**:macOS 与 Windows 的 build+test 在两个 workflow 里各跑一遍(同一次 push,实证两 run
  相隔 2 秒)。从 `core_tests.yml` 拿掉 —— 裸分支 push 仍从 `self-contained-headers` 与
  `cxx-feature-probe` 拿到这两个平台的覆盖(它们本来就是三平台矩阵),挪走的只是完整 build+test,
  而它在合并前由 `build_and_test.yml` 跑到。
- **arm64 改跑全量**:`Dockerfile` 一直只跑 3 个 integration,理由是 "arm docker env are slow"。
  那句话写于八平台 **QEMU** 时代,而 QEMU 已于 2026-07 换成原生 runner(#46)——**理由比它的
  前提多活了一年**,代价是两条 docker 腿少跑了 208 个测试。实测(两条腿日志都核过真跑了 211 个):
  arm64 **275s**(原 248s)· amd64 **298s**(原 291s);**arm64 跑 211 个仍比 amd64 跑 3 个快**。
- **工具链钉版**:ruff、Xcode 大版本、choco LLVM 各处。判据按**失败方式**选:钉住而过期 ⇒
  响亮地失败(「找不到该版本」);不钉 ⇒ 意外地失败(某天工具自己变了,代码一行没动却红)。
  choco 的 `make` 刻意不钉 —— 它驱动构建而不产生诊断,钉它只会在没人碰仓库的那天变红。

## `.clang-tidy` 的命名检查是死配置

`Checks` 里禁用着,下面却完整配着十四条 CheckOptions,而 AGENTS.md 据此声称「命名 SSOT」。

把它打开量了一遍(CI 同款 clang-tidy 18.1.8):**182 处唯一违规,其中只有 1 处是真的。**
其余分三类:**数学与领域记号**(`cos_α/β/δ/ε/λ/φ`、`argL/argB/argR`、`A1 A2 A3 D E F`、
`εCoeffs`、`gen_eval_θ`)· **配置指错方向**(`EnumCase: UPPER_CASE` 要求 `Algo` 写成 `ALGO`;
补 `LocalConstantCase` 后违规反涨到 1061,因为仓里 `const auto <lower_case>` 远多于
`constexpr <UPPER_CASE>`)· **分不清可调用对象与数据常量**(`jieqi_jde`、`get_info_for_year`
是 `cache_func` 的返回值,调用点写作 `jieqi_jde(year, jq)`)。

⇒ **它是死配置不是因为「忘了开」,是因为「开不了」。** 一道要误报 181 次才抓到 1 件事的闸门,
不该校准,该关掉,然后把约定写给人读 —— AGENTS.md 的「Naming」节因此重写,并修掉两处被坏配置
传染的错误:枚举**类型**是 CamelCase 不是 UPPER_CASE,枚举常量也不全是(`Jieqi` 的是中文节气名)。

唯一那 1 处真不一致(`au_km_scale`)**不在本 PR 修** —— #86 要连值一起改。

## #133 的两个基准点

`bench_vsop87d.cpp`(VSOP87 单次求值,与 `sun::geocentric_coord::apparent` 并列,形状照抄
`bench_elp2000.cpp`)· `bench_jieqi.cpp`(节气单次求根,冷/热两态)。

**冷态需要设计,因为缓存清不掉**(`util/cache.hpp` 的 TODO 还在,`jieqi_jde` 是进程级全局实例)。
所以冷态**每轮**新建一个 `cache_func` 包装器,让每次调用都是真 miss;循环直接索引而不取模,
这是「一轮之内不重复问同一个 key」的保证。核过:全仓只有两个全局缓存,`calc_jieqi_jde` 直奔
`sun::...::find_roots`,两个都不在它路径上 ⇒ **「冷」这个标签成立,不是近似**。

同一个二进制里跑两次 `bench::run()`:配对那轮(240 次迭代)回答「缓存买到了什么」,
另一轮**只有热态、24000 次迭代**回答「一次命中多少钱」。理由是 240 次的轮里 8 ns 的操作量不准 ——
每轮固定开销把中位数抬高约 30%,跨度接近两倍;24000 时同一个数复跑到 ±2%。

## 其它

`linter.py` 根文件的第二份文件头(从 `project.py` 抄的,连描述行都还写着 "building and testing")·
`src/CMakeLists.txt` 的 `-O2` 死配置(实际编译行 `-O2 -O3 -DNDEBUG`,删前后对拍 35 个 TU 的
`compile_commands.json`,**唯一差异就是少了它和一个指向不存在目录的 `-I`,零新增**)·
`build.py` 硬编码 generator(补逃生口:只在调用方没设 `CMAKE_GENERATOR` 时才传 `-G`)·
`sysinfo.py` 在 cmake 缺失时抛裸 traceback(实测炸的不是那个 `assert`,是 `run_cmd` 抛的
`FileNotFoundError`)· `github.py` 六个 request 无 timeout · 名为 `src.zip` 的产物装的是
gzip(魔数实测:`.zip` 是 `50 4b 03 04`,`.tar.gz` 是 `1f 8b`)· 两处写坏的 GPL 头邮箱 ·
googletest v1.15.2 → **1.17.0** 并钉 sha256(钉的是作者上传的 release 资产,不是 GitHub 现场
生成的 archive —— 后者的字节会随打包参数变)。

顺带加了 AGENTS.md 的「Comment language」节(另一条工作线交接来的,不单独开 PR)。
本仓实测 4211 行注释里 51 行含中文,两种形态:括注领域词,以及**集中在** lunar 子树的 Doxygen
中文重述。按「以邻近为准如实写,规范给未来定调不给历史翻案」写。

---

## 审阅

**R1:五席四个 remit**(正确性清单 · 正确性盲审 · 风格/设计 · 减法 · **闸门区分力**),T1 并行。
两个正确性席都 `P1=0`。发现几乎全落在一类上:**这个 PR 改了世界,却留下一批文字还在描述旧世界**
(五处,其中一处是本 PR 自己的提交在两个提交之后被自己证伪)。**采 24 驳 6**,驳回理由逐条写在
`305f00e` 的提交信息里。

**R2:四席**(闸门复验 · 新断言重审 · 剪枝复核 · 风格新眼睛)。闸门复验席给出
**`FIXES VERIFIED`,零条没修好**;新断言席逐条复核了 32 条断言并复议了那 6 条驳回,
结论是**全部接受、无驳错**。**采 12**,细节在 `d21fff1`。

R2 抓到的两条值得单独说:**剪枝时剪反了**(删掉了 `24000` 的取值依据、留下了纯成本旁白),
以及**钉版收敛时把一句刻意分歧的标记一起收敛掉了**(`LLVM pinned (make is not)`,
它的存在正是为了拦「顺手把 make 也钉上」)。

**三处提交信息里的数字不成立**(新断言席复核出的):平行翻译「23 处」没有一个可数口径得到、
全角标点「63 处」实为 65、破折号「88 对 19」是子集口径被写成了全仓。都只在提交信息里,
未进代码或文档。

## 验收

- `--clean --cmake --build` EXIT 0
- **直接跑 `build/test/*`:211 全过、0 个二进制失败**,与 `TEST(`/`TEST_F(` 宏计数 **211** 对账相等
  (不信 ctest 的数字 —— 它用 `--gtest_filter` 跑,过滤不到时 gtest 退 0、ctest 记 PASS)
- `ctest --test-dir build -N`:**0 → 211**
- `linter.py --all` EXIT 0(ruff + clang-tidy **18.1.8** + 自包含 **32/32** + feature probe)
- `--bench` EXIT 0,三个 benchmark
- 六个 workflow YAML 均可被 PyYAML 解析
- 逐提交 CI 全绿
- **闸门注入验证**:dylib 守卫四场景 · sanitizer 去掉 `-fno-sanitize-recover` 后静默放行 ·
  对账在注入 `TEST_P` 后报出前提不成立 · `URL_HASH` 改一位即 `Hash mismatch`

**本机验不了、由 CI 判的**:Windows 那道 PowerShell 守卫(本机无 pwsh)· 三处钉版能不能拿到 ·
docker 腿的端到端。
