### PR TITLE
fix(util): 让 concept 镜像它守护的表达式,而不是转述它 (#83)

### DIFF
--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -157,11 +157,11 @@ TEST(Util, DaysConvertibleContract) {
   static_assert(YmdShiftable<int>);
 
   // #83: a count of days, not a calendar field -- `days { day { 1 } }` has no viable constructor.
-  enum class Season : uint8_t { Spring = 1 };
   static_assert(not DaysConvertible<day>);
   static_assert(not DaysConvertible<month>);
   static_assert(not DaysConvertible<double>);
   static_assert(not DaysConvertible<hours>);   // pairs with `weeks` above: exact conversions only
+  enum class Season : uint8_t { Spring = 1 };
   static_assert(not DaysConvertible<Season>);
   static_assert(not YmdShiftable<day>);
 }

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -56,23 +56,15 @@ TEST(Util, ToYmd) {
 template <typename Y, typename M, typename D>
 concept ToYmdCallable = requires (Y y, M m, D d) { to_ymd(y, m, d); };
 
-/*! @brief Whether `ymd + t` is a viable shift. */
-template <typename T>
-concept YmdShiftable = requires (std::chrono::year_month_day ymd, T t) {
-  util::ymd_operator::operator+(ymd, t);
-};
 
 TEST(Util, ToYmdInputTypes) {
   using namespace std::chrono;
 
-  // #83: month and day are counts. They used to sit behind a constraint that paraphrased the
-  // body -- `days { static_cast<uint32_t>(t) }` -- and so admitted calendar fields and durations
-  // the body cannot use, moving the error from the call site into `to_ymd`.
+  // #83: month and day are counts, so calendar fields and durations must not reach the body.
   static_assert(not ToYmdCallable<int, int, days>);
   static_assert(not ToYmdCallable<int, int, day>);
   static_assert(not ToYmdCallable<int, month, int>);
 
-  // Every shape the tree actually calls with.
   static_assert(ToYmdCallable<int, int, int>);
   static_assert(ToYmdCallable<unsigned, unsigned, unsigned>);
   static_assert(ToYmdCallable<int, std::size_t, uint32_t>);
@@ -147,20 +139,29 @@ TEST(Util, OperatorSub) {
   ASSERT_EQ(ymd - (-365), 1902y / 1 / 1);
 }
 
+/*! @brief Whether `util::ymd_operator::operator+(ymd, t)` is viable. Qualified because ADL from
+           `year_month_day` reaches only `std::chrono`, and the file's `using namespace util;`
+           does not reach into the nested namespace. */
+template <typename T>
+concept YmdShiftable = requires (std::chrono::year_month_day ymd, T t) {
+  util::ymd_operator::operator+(ymd, t);
+};
+
 TEST(Util, DaysConvertibleContract) {
   using namespace std::chrono;
 
   static_assert(DaysConvertible<days>);
   static_assert(DaysConvertible<int>);
-  static_assert(DaysConvertible<uint32_t>);
+  static_assert(DaysConvertible<weeks>);   // exact in days; `hours` below is where the line is
   static_assert(YmdShiftable<days>);
   static_assert(YmdShiftable<int>);
 
-  // #83: a count of days, not a calendar field. `days { day { 1 } }` has no viable constructor,
-  // and the old paraphrasing constraint is what let that reach the body.
+  // #83: a count of days, not a calendar field -- `days { day { 1 } }` has no viable constructor.
   enum class Season : uint8_t { Spring = 1 };
   static_assert(not DaysConvertible<day>);
   static_assert(not DaysConvertible<month>);
+  static_assert(not DaysConvertible<double>);
+  static_assert(not DaysConvertible<hours>);
   static_assert(not DaysConvertible<Season>);
   static_assert(not YmdShiftable<day>);
 }
@@ -329,10 +330,7 @@ TEST(Util, MakeCachedConstraints) {
 
   static_assert(MakeCachedViable<double(int32_t, Key)>);
   static_assert(MakeCachedViable<Value(int32_t)>);
-  static_assert(MakeCachedViable<int(int, double)>);
 
-  // Saying what the `unordered_map` already requires is the whole point: misuse is rejected at
-  // the call instead of inside its instantiation.
   static_assert(not MakeCachedViable<void(int)>);
   static_assert(not MakeCachedViable<std::unique_ptr<int>(int)>);
   static_assert(not MakeCachedViable<int(Unhashable)>);

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -49,6 +49,35 @@ TEST(Util, ToYmd) {
   ASSERT_EQ(to_ymd(static_cast<int16_t>(2024), 3, 15), 2024y / 3 / 15);
 }
 
+/*! @brief Whether `to_ymd(y, m, d)` is a viable call. A concept rather than a bare
+           requires-expression: outside a template an ill-formed expression is a hard error,
+           not `false`. */
+template <typename Y, typename M, typename D>
+concept ToYmdCallable = requires (Y y, M m, D d) { to_ymd(y, m, d); };
+
+/*! @brief Whether `ymd + t` is a viable shift. */
+template <typename T>
+concept YmdShiftable = requires (std::chrono::year_month_day ymd, T t) {
+  util::ymd_operator::operator+(ymd, t);
+};
+
+TEST(Util, ToYmdInputTypes) {
+  using namespace std::chrono;
+
+  // #83: month and day are counts. They used to sit behind a constraint that paraphrased the
+  // body -- `days { static_cast<uint32_t>(t) }` -- and so admitted calendar fields and durations
+  // the body cannot use, moving the error from the call site into `to_ymd`.
+  static_assert(not ToYmdCallable<int, int, days>);
+  static_assert(not ToYmdCallable<int, int, day>);
+  static_assert(not ToYmdCallable<int, month, int>);
+
+  // Every shape the tree actually calls with.
+  static_assert(ToYmdCallable<int, int, int>);
+  static_assert(ToYmdCallable<unsigned, unsigned, unsigned>);
+  static_assert(ToYmdCallable<int, std::size_t, uint32_t>);
+  static_assert(ToYmdCallable<float, int, int>);
+}
+
 TEST(Util, FromYmd) {
   using namespace std::literals;
 
@@ -115,6 +144,24 @@ TEST(Util, OperatorSub) {
   ASSERT_EQ(ymd - 0, 1901y / 1 / 1);
   ASSERT_EQ(ymd - (-1), 1901y / 1 / 2);
   ASSERT_EQ(ymd - (-365), 1902y / 1 / 1);
+}
+
+TEST(Util, DaysConvertibleContract) {
+  using namespace std::chrono;
+
+  static_assert(DaysConvertible<days>);
+  static_assert(DaysConvertible<int>);
+  static_assert(DaysConvertible<uint32_t>);
+  static_assert(YmdShiftable<days>);
+  static_assert(YmdShiftable<int>);
+
+  // #83: a count of days, not a calendar field. `days { day { 1 } }` has no viable constructor,
+  // and the old paraphrasing constraint is what let that reach the body.
+  enum class Season : uint8_t { Spring = 1 };
+  static_assert(not DaysConvertible<day>);
+  static_assert(not DaysConvertible<month>);
+  static_assert(not DaysConvertible<Season>);
+  static_assert(not YmdShiftable<day>);
 }
 
 TEST(Util, GenRandomValue1) {

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -152,7 +152,7 @@ TEST(Util, DaysConvertibleContract) {
 
   static_assert(DaysConvertible<days>);
   static_assert(DaysConvertible<int>);
-  static_assert(DaysConvertible<weeks>);   // exact in days; `hours` below is where the line is
+  static_assert(DaysConvertible<weeks>);
   static_assert(YmdShiftable<days>);
   static_assert(YmdShiftable<int>);
 
@@ -161,7 +161,7 @@ TEST(Util, DaysConvertibleContract) {
   static_assert(not DaysConvertible<day>);
   static_assert(not DaysConvertible<month>);
   static_assert(not DaysConvertible<double>);
-  static_assert(not DaysConvertible<hours>);
+  static_assert(not DaysConvertible<hours>);   // pairs with `weeks` above: exact conversions only
   static_assert(not DaysConvertible<Season>);
   static_assert(not YmdShiftable<day>);
 }

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -27,6 +27,7 @@
 #include <print>
 #include <atomic>
 #include <cmath>
+#include <memory>
 #include <ranges>
 #include <thread>
 #include <unordered_set>
@@ -316,6 +317,26 @@ TEST(Util, HashCollision) {
   ASSERT_NEAR(tuples.size(), hash_values.size(), try_count * 0.00005);
 }
 
+
+/*! @brief Whether `make_cached` accepts a signature. `cache_func` funnels through it. */
+template <typename Sig>
+concept MakeCachedViable = requires (std::function<Sig> func) { util::cache::make_cached(func); };
+
+TEST(Util, MakeCachedConstraints) {
+  enum class Key : uint8_t { A };                      // stands in for `Jieqi` (jieqi.hpp)
+  struct Value { int32_t v; };                         // stands in for `LunarYear` (algo2.hpp)
+  struct Unhashable { auto operator==(const Unhashable&) const -> bool = default; };
+
+  static_assert(MakeCachedViable<double(int32_t, Key)>);
+  static_assert(MakeCachedViable<Value(int32_t)>);
+  static_assert(MakeCachedViable<int(int, double)>);
+
+  // Saying what the `unordered_map` already requires is the whole point: misuse is rejected at
+  // the call instead of inside its instantiation.
+  static_assert(not MakeCachedViable<void(int)>);
+  static_assert(not MakeCachedViable<std::unique_ptr<int>(int)>);
+  static_assert(not MakeCachedViable<int(Unhashable)>);
+}
 
 TEST(Util, MakeCached1) {
   std::atomic<int32_t> call_count { 0 };

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -163,6 +163,12 @@ TEST(Util, DaysConvertibleContract) {
   static_assert(not DaysConvertible<hours>);   // pairs with `weeks` above: exact conversions only
   enum class Season : uint8_t { Spring = 1 };
   static_assert(not DaysConvertible<Season>);
+
+  // The operators bind `const T&`, so the concept must check a const object too -- a conversion
+  // that is not const-qualified would otherwise pass here and fail in the body.
+  struct NonConstOnly { operator days() { return days { 3 }; } };   // NOLINT(google-explicit-constructor)
+  static_assert(not DaysConvertible<NonConstOnly>);
+  static_assert(not YmdShiftable<NonConstOnly>);
   static_assert(not YmdShiftable<day>);
 }
 

--- a/src/util/cache.hpp
+++ b/src/util/cache.hpp
@@ -43,11 +43,12 @@ using util::hash::TupleHash;
 // 1. Add a way to clear the cache (LRU, or something).
 
 /**
- * @brief What one component of a cache key must support. Element-wise, because `TupleHash` hashes
- *        the key that way — `std::hash<std::tuple<...>>` does not exist.
+ * @brief What one element of a cache key must support. Element-wise on purpose: `TupleHash`'s
+ *        `operator()` takes any tuple and fails inside its body, so constraining *it* would
+ *        constrain nothing.
  */
 template <typename T>
-concept CacheKey = std::equality_comparable<T> and requires (const T& value) {
+concept CacheKeyElement = std::equality_comparable<T> and requires (const T& value) {
   { std::hash<T> {}(value) } -> std::convertible_to<std::size_t>;
 };
 
@@ -57,12 +58,12 @@ concept CacheKey = std::equality_comparable<T> and requires (const T& value) {
  * @return The cached function. Thread-safe; copies share one cache (#78).
  * @note The constraints state what the `unordered_map` below already enforces, so misuse is
  *       rejected here instead of inside its instantiation. `copy_constructible` also rules out
- *       `void`, which has nothing to cache. Purity and a bounded key space are not expressible
- *       here — they stay the caller's contract.
+ *       `void`, which has nothing to cache. A bounded key space is not expressible here — the
+ *       cache never evicts, so that stays the caller's contract.
  */
 template <typename RetType, typename... Args>
 requires std::copy_constructible<RetType>
-     and (... and CacheKey<std::decay_t<Args>>)
+     and (... and CacheKeyElement<std::decay_t<Args>>)
 [[nodiscard]] inline auto make_cached(const std::function<RetType(Args...)>& func) -> std::function<RetType(Args...)> {
   // Cache and mutex live behind a `shared_ptr`, so copying the returned
   // `std::function` shares one cache instead of forking divergent replicas (#78).

--- a/src/util/cache.hpp
+++ b/src/util/cache.hpp
@@ -26,7 +26,9 @@
 #include <mutex>
 #include <tuple>
 #include <memory>
+#include <cstddef>
 #include <utility>
+#include <concepts>
 #include <functional>
 #include <type_traits>
 #include <unordered_map>
@@ -41,11 +43,26 @@ using util::hash::TupleHash;
 // 1. Add a way to clear the cache (LRU, or something).
 
 /**
+ * @brief What one component of a cache key must support. Element-wise, because `TupleHash` hashes
+ *        the key that way — `std::hash<std::tuple<...>>` does not exist.
+ */
+template <typename T>
+concept CacheKey = std::equality_comparable<T> and requires (const T& value) {
+  { std::hash<T> {}(value) } -> std::convertible_to<std::size_t>;
+};
+
+/**
  * @brief A wrapper that caches the result of a function.
  * @param func The function to cache. Must be pure — same arguments ⇒ same result.
  * @return The cached function. Thread-safe; copies share one cache (#78).
+ * @note The constraints state what the `unordered_map` below already enforces, so misuse is
+ *       rejected here instead of inside its instantiation. `copy_constructible` also rules out
+ *       `void`, which has nothing to cache. Purity and a bounded key space are not expressible
+ *       here — they stay the caller's contract.
  */
 template <typename RetType, typename... Args>
+requires std::copy_constructible<RetType>
+     and (... and CacheKey<std::decay_t<Args>>)
 [[nodiscard]] inline auto make_cached(const std::function<RetType(Args...)>& func) -> std::function<RetType(Args...)> {
   // Cache and mutex live behind a `shared_ptr`, so copying the returned
   // `std::function` shares one cache instead of forking divergent replicas (#78).

--- a/src/util/cache.hpp
+++ b/src/util/cache.hpp
@@ -47,10 +47,12 @@ using util::hash::TupleHash;
  *        `operator()` takes any tuple and fails inside its body, so constraining *it* would
  *        constrain nothing.
  */
+// Spelled as three library concepts rather than one `requires { std::hash<T> {}(v) }`: the latter
+// makes g++-14 ICE in `finish_compound_literal` when reached through a nested requires-expression.
 template <typename T>
-concept CacheKeyElement = std::equality_comparable<T> and requires (const T& value) {
-  { std::hash<T> {}(value) } -> std::convertible_to<std::size_t>;
-};
+concept CacheKeyElement = std::equality_comparable<T>
+                      and std::default_initializable<std::hash<T>>
+                      and std::invocable<std::hash<T>&, const T&>;
 
 /**
  * @brief A wrapper that caches the result of a function.

--- a/src/util/ymd.hpp
+++ b/src/util/ymd.hpp
@@ -46,8 +46,9 @@ concept DaysConvertible = requires (T t) {
 /*!
  * @brief Converts the input year, month, and date to a `std::chrono::year_month_day`.
  * @note Month and day are plain `uint32_t` while `year` keeps a concept — a deliberate asymmetry,
- *       not an oversight. `_year / month / day` feeds `operator/`, which takes an integer; the
- *       parameter type is already that contract, so a constraint there could only restate it (#83).
+ *       not an oversight. Both are counts that become `std::chrono::month` / `day`, whose
+ *       constructors take `unsigned`; the parameter type is that contract, so a constraint there
+ *       could only restate it (#83).
  */
 [[nodiscard]] constexpr auto to_ymd(
   const YearConvertible auto year,
@@ -55,7 +56,7 @@ concept DaysConvertible = requires (T t) {
   const uint32_t day
 ) -> std::chrono::year_month_day {
   const std::chrono::year _year { static_cast<int32_t>(year) };
-  return std::chrono::year_month_day { _year / month / day };
+  return std::chrono::year_month_day { _year / std::chrono::month { month } / std::chrono::day { day } };
 }
 
 

--- a/src/util/ymd.hpp
+++ b/src/util/ymd.hpp
@@ -38,8 +38,9 @@ concept YearConvertible = requires (T t) {
 
 /*! @brief A type `std::chrono::days` can be built from — what the operators below shift by. */
 template <typename T>
-concept DaysConvertible = requires (T t) {
-  // The check is the operators' own expression, not a paraphrase of it (#83).
+concept DaysConvertible = requires (const T& t) {
+  // The check is the operators' own expression, on the same const object they bind (#83): with a
+  // non-const `t` a conversion that is not const-qualified passes here and fails in the body.
   { std::chrono::days { t } } -> std::same_as<std::chrono::days>;
 };
 

--- a/src/util/ymd.hpp
+++ b/src/util/ymd.hpp
@@ -39,15 +39,15 @@ concept YearConvertible = requires (T t) {
 /*! @brief A type `std::chrono::days` can be built from — what the operators below shift by. */
 template <typename T>
 concept DaysConvertible = requires (T t) {
-  // The check is the operators' own expression, not a paraphrase of it. The paraphrase
-  // `days { static_cast<uint32_t>(t) }` admitted `std::chrono::day`, which the body cannot use (#83).
+  // The check is the operators' own expression, not a paraphrase of it (#83).
   { std::chrono::days { t } } -> std::same_as<std::chrono::days>;
 };
 
 /*!
  * @brief Converts the input year, month, and date to a `std::chrono::year_month_day`.
- * @note Month and day are plain `uint32_t`: every caller passes an integer, and the concrete type
- *       already rejects the rest at the call site — a constraint there could only paraphrase it (#83).
+ * @note Month and day are plain `uint32_t` while `year` keeps a concept — a deliberate asymmetry,
+ *       not an oversight. `_year / month / day` feeds `operator/`, which takes an integer; the
+ *       parameter type is already that contract, so a constraint there could only restate it (#83).
  */
 [[nodiscard]] constexpr auto to_ymd(
   const YearConvertible auto year,

--- a/src/util/ymd.hpp
+++ b/src/util/ymd.hpp
@@ -36,23 +36,23 @@ concept YearConvertible = requires (T t) {
   { std::chrono::year { static_cast<int32_t>(t) } } -> std::same_as<std::chrono::year>;
 };
 
-/*! @brief A type that can be converted to `std::chrono::month`. */
+/*! @brief A type `std::chrono::days` can be built from — what the operators below shift by. */
 template <typename T>
-concept MonthConvertible = std::same_as<T, std::chrono::month> or requires (T t) {
-  { std::chrono::month { static_cast<uint32_t>(t) } } -> std::same_as<std::chrono::month>;
+concept DaysConvertible = requires (T t) {
+  // The check is the operators' own expression, not a paraphrase of it. The paraphrase
+  // `days { static_cast<uint32_t>(t) }` admitted `std::chrono::day`, which the body cannot use (#83).
+  { std::chrono::days { t } } -> std::same_as<std::chrono::days>;
 };
 
-/*! @brief A type that can be converted to `std::chrono::days`. */
-template <typename T>
-concept DayConvertible = std::same_as<T, std::chrono::days> or requires (T t) {
-  { std::chrono::days { static_cast<uint32_t>(t) } } -> std::same_as<std::chrono::days>;
-};
-
-/*! @brief Converts the input year, month, and date to a `std::chrono::year_month_day`. */
+/*!
+ * @brief Converts the input year, month, and date to a `std::chrono::year_month_day`.
+ * @note Month and day are plain `uint32_t`: every caller passes an integer, and the concrete type
+ *       already rejects the rest at the call site — a constraint there could only paraphrase it (#83).
+ */
 [[nodiscard]] constexpr auto to_ymd(
-  const YearConvertible auto year, 
-  const MonthConvertible auto month, 
-  const DayConvertible auto day
+  const YearConvertible auto year,
+  const uint32_t month,
+  const uint32_t day
 ) -> std::chrono::year_month_day {
   const std::chrono::year _year { static_cast<int32_t>(year) };
   return std::chrono::year_month_day { _year / month / day };
@@ -71,11 +71,11 @@ concept DayConvertible = std::same_as<T, std::chrono::days> or requires (T t) {
 
 namespace util::ymd_operator {
 
-using util::DayConvertible;
+using util::DaysConvertible;
 
 [[nodiscard]] constexpr auto operator+(
   const std::chrono::year_month_day& ymd, 
-  const DayConvertible auto& days
+  const DaysConvertible auto& days
 ) -> std::chrono::year_month_day {
   const auto time_point = std::chrono::sys_days { ymd } + std::chrono::days { days };
   return std::chrono::year_month_day { time_point };
@@ -83,7 +83,7 @@ using util::DayConvertible;
 
 
 [[nodiscard]] constexpr auto operator+(
-  const DayConvertible auto& days,
+  const DaysConvertible auto& days,
   const std::chrono::year_month_day& ymd
 ) -> std::chrono::year_month_day {
   const auto time_point = std::chrono::sys_days { ymd } + std::chrono::days { days };
@@ -93,7 +93,7 @@ using util::DayConvertible;
 
 [[nodiscard]] constexpr auto operator-(
   const std::chrono::year_month_day& ymd, 
-  const DayConvertible auto& days
+  const DaysConvertible auto& days
 ) -> std::chrono::year_month_day {
   const auto time_point = std::chrono::sys_days { ymd } - std::chrono::days { days };
   return std::chrono::year_month_day { time_point };


### PR DESCRIPTION
`util/ymd.hpp` 的 `DayConvertible` 检查的表达式,和它守护的函数体执行的表达式,不是同一个。

```cpp
concept DayConvertible = ... { std::chrono::days { static_cast<uint32_t>(t) } } ...;
//                                                 ^^^^^^^^^^^^^^^^^^^^^^ 概念里有这个 cast

// 而 body 里没有:
const auto tp = std::chrono::sys_days { ymd } + std::chrono::days { days };
```

`std::chrono::day` 有 `explicit operator unsigned`,于是它过得了带 cast 的概念,却在函数体里
找不到可用的构造函数。两条实测:

```cpp
to_ymd(2024, 3, std::chrono::days { 15 });   // 过约束,炸在 body —— issue 记了这条
ymd + std::chrono::day { 15 };                // 过约束,炸在 body —— issue 没记这条
```

`MonthConvertible` 有一模一样的病:它收 `std::chrono::day` 与 scoped enum,而 body 的
`year / t` 两者都拒。

## 判据:concept 只做两件事

把错误从函数体挪到调用点、写下参数收什么。不做检查、不做转换、不影响生成的代码。

所以**只有当一个参数真的接受两族之间没有隐式转换的类型时,才需要 concept**;否则具体类型
自己就把这两件事做完了,而且类型本身还是文档。据此逐个量:

| 参数 | 真实接受面 | 结论 |
|---|---|---|
| `ymd_operator` 的位移量 | 裸整数 **与** `std::chrono::days`,两者之间无隐式转换(`duration` 的 rep 构造是 `explicit`) | **需要** concept |
| `to_ymd` 的 month / day | 只有整数一族(196 个调用点全传整数) | 不需要 —— 用 `uint32_t` |
| `to_ymd` 的 year | 多族(含 `float`) | 保留,且它**本来就是镜像的**,三个里唯一没病的 |

⇒ **修法是删,不是加**:删 `MonthConvertible`,`to_ymd` 从三个模板参数变一个;
`DayConvertible` 改名 `DaysConvertible` 并恢复镜像形,只服务那三个操作符。

用户可见的变化是错误落点:

```
旧  ymd.hpp:58: error: invalid operands to binary expression ('year_month' and 'const days')
新  调用点:     error: no matching function for call to 'to_ymd'
                note: candidate template ignored: constraints not satisfied [with day:auto = days]
```

## 这是恢复,不是发明

仓的第二个提交 `4be49b6` 里的 `DayCastable` 与本次恢复的形状**字节级相同**。
`72eeef3`(Refactor and add docs)一次做了三件事:把 `YearConvertible` 改成镜像形(改好了)、
新加转述形的 `MonthConvertible`(造病)、把 `DayConvertible` 从镜像改成转述(造病)。
同一个提交里两个方向都有 —— 当时没有判据,不是有人不懂。

## 顺带:同一判据的另一半 (`cache.hpp`)

`make_cached` 对键类型与返回类型零约束,`RetType = void` 或键不可哈希时错误落在
`unordered_map` 实例化深处。补上 `CacheKeyElement` 与 `std::copy_constructible<RetType>`,
**零接受面变化**(今天编得过的用法必然已满足这三条,map 实例化本就强制)。

这半边留下一条值得记的限定:

> **镜像 body 的表达式,只在那个表达式的失败对 SFINAE 可见时才成立。**

直接镜像 map 声明的整键写法看起来更字面,实测却**什么都不约束** ——
`TupleHash::operator()` 签名具体、调用表达式永远合法,失败沉在函数体里:

```cpp
concept WholeKey = requires (const std::tuple<Args...>& k) {
  { TupleHash<Args...> {}(k) } -> std::convertible_to<std::size_t>; ...
};
static_assert(WholeKey<int32_t, Unhashable>);   // 通过 —— 它拦不住任何东西
```

## 测试:拒绝面此前零覆盖

`#83` 的验收标准第二条点名的正是这个缺口。三个 `TEST` 把接受面与拒绝面钉成
`static_assert` 矩阵 —— 拒绝侧进仓之后,这两个缺陷从「一次性发现」变成每条 CI 腿上的闸门。

检出率:把概念退回旧的转述形,**6 条断言当场挂**(其中 `DaysConvertible<weeks>` 是矩阵里
唯一有区分力的正例 —— 旧形拒它、新形收它)。

一条语言细节写进了测试注释,因为它反直觉:**非模板上下文里,`requires` 体内的不合法表达式
是硬错不是 `false`**,所以否定断言必须包成 concept 走替换。

## 没做什么

| 项 | 为什么 |
|---|---|
| `to_ymd(2024, 2, 30)` 仍静默返回 `!ok()` | 要它干净,得先定「`year_month_day` 还要不要兼任阴历三元组的载体」—— 阴历月份合法取到 13,那时 `.ok()` 为 false **且正确**。这是 #130 的类型语义裁决,不是本 PR 能拍的 |
| `ymd.hpp:74` 的 namespace 级 using 未清 | 与 #51 的施工排期对齐;成本已量过(近乎零),注记已留在 #51 |
| `cache.hpp` 的 `TODO`(清空 / 淘汰)未动 | 属同批后续 PR |
| `not DaysConvertible<hours>` 没有闸门价值 | 明知它对新旧两式都为真,按**文档价值**保留:它与 `weeks` 配对才说出边界「只收能无损换算成天数的时长」 |

## 验证

- 全量:直接跑 `build/test/*` 二进制 **214 全过、0 失败**,与 `TEST(` 宏计数 **214** 对账相等
  (不取 ctest 的登记数)
- `--ruff` / `--self-contained`(32/32)/ `--features` 均 EXIT 0
- 零回归的依据是构造性的:本 PR **只动约束、函数体逐字不动** ⇒ 任何接受侧回归都是编译失败,
  三条腿(libc++ / libstdc++ / MSVC STL)必红,不存在「编过但行为漂移」的空间
- 四轮审阅(正确性清单 / 盲审 / 风格 / 减法)+ 一轮复核,**零 P1**;两条 P2 与十二条 P3 全部
  处置。其中一条是本 PR 自己在提交正文里写错的跨编译器断言(`-Wliteral-conversion` 为 clang
  专有,g++-14 腿上不成立),已在 `727cadb` 更正

Closes #83
