### PR TITLE
ci: 删掉 claude workflows 未使用的 id-token: write(#144 第 1 条)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,7 +11,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,6 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
     steps:
       - uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
#144 安全审的第 1 条(四条中最小的一条,本 PR 只做这条,**不关 #144**)。

**改了什么**:`claude.yml` 与 `claude-review.yml` 各删一行 `id-token: write`,零行为改动。

**为什么**:两个 workflow 都用明文 `ANTHROPIC_API_KEY` 直连认证,没有走 OIDC——这个权限是白给的铸币能力:被 prompt injection 影响的 agent 可以铸造任意 audience 的 OIDC token(GitHub 签名的身份断言),危险程度取决于将来谁去信它。最小权限,删了没有任何东西会坏(#144 审计原文,本 PR 顺带验证这句话)。

**判据(本 PR 自测)**:`claude-review.yml` 在 PR 上运行的是**分支版本**——若 claude[bot] 的评审正常到达本 PR,即证明 OIDC 交换确实未被使用;若 bot 报 token 交换类错误,则 #144 第 1 条被证伪,本 PR 撤回并把证据记回 issue。

批内登记:进度 SSOT「不占 PR 名额的四件小事」之一,「纯减法,随时可发」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dwtbe9E8bUnUeStizKNLHz