### PR TITLE
fix(util): hash_combine 收尾换 xorshift + 64 位黄金比,补雪崩测试与 mixer 基准

### DIFF
--- a/src/bench/bench_cache.cpp
+++ b/src/bench/bench_cache.cpp
@@ -12,7 +12,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This project is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
@@ -21,28 +21,29 @@
  * along with this project. If not, see <https://www.gnu.org/licenses/>.
  */
 
-// Every cache lookup pays one `hash_combine`, so the mixer's cost belongs to the cache's budget.
-// Its quality is a test (`Util.HashCombineAvalanche`); its cost is the pair below. Both mixers
-// live in the same binary and are timed interleaved, because the per-round paired ratio is the
-// figure that survives machine drift -- absolute nanoseconds do not (see harness.hpp).
+// The cache pays one `hash_combine` per lookup. The mixer's quality is a test
+// (`Util.HashCombineAvalanche`); its cost is the old/new pair below (see harness.hpp for why
+// the paired ratio is the figure to read).
 
 #include <array>
-#include <cstddef>
-#include <cstdint>
-#include <functional>
-#include <iostream>
-#include <type_traits>
-#include <utility>
 #include <vector>
+#include <cstdint>
+#include <cstddef>
+#include <utility>
+#include <iostream>
+#include <functional>
+#include <type_traits>
 
 #include "hash.hpp"
 #include "harness.hpp"
 
 namespace {
 
-using Key = std::pair<int32_t, uint8_t>; // stands in for (year, Jieqi), the jieqi cache key
+using Key = std::pair<int32_t, uint8_t>; // stands in for (year, Jieqi) -- Jieqi is an enum class
+                                         // over uint8_t, so its std::hash sees identical bits
 
-/** @brief The mixer as it was before the xorshift finalizer, frozen for the paired measurement. */
+/** @brief The mixer as it was before the xorshift finalizer, frozen for the paired measurement.
+ *         Never sync this with `hash_combine` -- the pair is meaningful only while they differ. */
 template <typename T>
 [[nodiscard]] auto old_hash_combine(std::size_t seed, T&& v) -> std::size_t {
   auto v_hash = std::hash<std::decay_t<T>>{}(std::forward<T>(v));
@@ -74,35 +75,49 @@ template <typename T>
 auto main() -> int {
   const auto keys = sample_keys();
 
-  // Volatile so neither the sums nor the hashing they come from can be optimized away.
+  // Volatile so the accumulated sums -- and the hashing they come from -- survive the optimizer.
+  // One read-modify-write per round, not per iteration: a volatile chain inside the loop would
+  // set a floor comparable to the hashing itself at ~3 ns a key.
   volatile std::size_t sink = 0;
 
+  // The two bodies differ by exactly one identifier (`old_`), so the pair audits at a glance.
   const bench::Case old_mixer {
-    // The old chain, spelled out: hash the first field, then combine the second with the
-    // frozen old mixer. Same work as the new case, which calls the public `hash` directly.
     .name = "cache key hash -- old mixer",
     .body = [&](const std::size_t iterations) {
+      std::size_t acc = 0;
+      std::size_t index = 0;
       for (std::size_t i = 0; i < iterations; ++i) {
-        const auto& [year, term] = keys.at(i % keys.size());
-        sink = sink + old_hash_combine(util::hash::hash(year), term);
+        const auto& [year, term] = keys[index];
+        acc += old_hash_combine(util::hash::hash(year), term);
+        if (++index == keys.size()) {
+          index = 0;
+        }
       }
+      sink = sink + acc;
     },
   };
 
   const bench::Case new_mixer {
     .name = "cache key hash -- new mixer",
     .body = [&](const std::size_t iterations) {
+      std::size_t acc = 0;
+      std::size_t index = 0;
       for (std::size_t i = 0; i < iterations; ++i) {
-        const auto& [year, term] = keys.at(i % keys.size());
-        sink = sink + util::hash::hash(year, term);
+        const auto& [year, term] = keys[index];
+        acc += util::hash::hash_combine(util::hash::hash(year), term);
+        if (++index == keys.size()) {
+          index = 0;
+        }
       }
+      sink = sink + acc;
     },
   };
 
-  // 24000 iterations per round, per bench_jieqi's calibration: long enough for a round's fixed
-  // cost to amortize away, which is what makes the ratio repeatable across runs.
+  // 240000 iterations: at ~3 ns a key a round is ~0.7 ms, long enough for a round's fixed cost
+  // to divide out. bench_jieqi's 24000 was calibrated on a ~20 ns cache hit; borrowed here it
+  // left the paired ratio under machine noise (p10..p90 crossing zero).
   const std::array mixer_pair { old_mixer, new_mixer };
-  const bench::Plan plan { .title = "Cache key hashing", .iterations = 24000 };
+  const bench::Plan plan { .title = "Cache key hashing", .iterations = 240000 };
   bench::run(plan, mixer_pair, std::cout);
 
   return 0;

--- a/src/bench/bench_cache.cpp
+++ b/src/bench/bench_cache.cpp
@@ -113,7 +113,7 @@ auto main() -> int {
     },
   };
 
-  // 240000 iterations: at ~3 ns a key a round is ~0.7 ms, long enough for a round's fixed cost
+  // 240000 iterations: at ~2 ns a key a round is ~0.5 ms, long enough for a round's fixed cost
   // to divide out. bench_jieqi's 24000 was calibrated on a ~20 ns cache hit; borrowed here it
   // left the paired ratio under machine noise (p10..p90 crossing zero).
   const std::array mixer_pair { old_mixer, new_mixer };

--- a/src/bench/bench_cache.cpp
+++ b/src/bench/bench_cache.cpp
@@ -1,0 +1,109 @@
+/*
+ * CelestialCalendar:
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ *
+ * Copyright (C) 2026 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Every cache lookup pays one `hash_combine`, so the mixer's cost belongs to the cache's budget.
+// Its quality is a test (`Util.HashCombineAvalanche`); its cost is the pair below. Both mixers
+// live in the same binary and are timed interleaved, because the per-round paired ratio is the
+// figure that survives machine drift -- absolute nanoseconds do not (see harness.hpp).
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "hash.hpp"
+#include "harness.hpp"
+
+namespace {
+
+using Key = std::pair<int32_t, uint8_t>; // stands in for (year, Jieqi), the jieqi cache key
+
+/** @brief The mixer as it was before the xorshift finalizer, frozen for the paired measurement. */
+template <typename T>
+[[nodiscard]] auto old_hash_combine(std::size_t seed, T&& v) -> std::size_t {
+  auto v_hash = std::hash<std::decay_t<T>>{}(std::forward<T>(v));
+  v_hash ^= seed * 0xc4ceb9fe1a85ec53;
+  v_hash ^= (v_hash >> 13) * 0xff51afd7ed558ccd;
+  v_hash *= 0x9e3779b9;
+  return v_hash;
+}
+
+/** @brief Ten years of solar terms, each key distinct -- the same shape bench_jieqi samples. */
+[[nodiscard]] auto sample_keys() -> std::vector<Key> {
+  constexpr int32_t FIRST_YEAR = 2000;
+  constexpr int32_t YEAR_COUNT = 10;
+  constexpr uint8_t TERMS_PER_YEAR = 24;
+
+  std::vector<Key> keys;
+  keys.reserve(static_cast<std::size_t>(YEAR_COUNT) * TERMS_PER_YEAR);
+  for (int32_t year = FIRST_YEAR; year < FIRST_YEAR + YEAR_COUNT; ++year) {
+    for (uint8_t term = 0; term < TERMS_PER_YEAR; ++term) {
+      keys.emplace_back(year, term);
+    }
+  }
+  return keys;
+}
+
+} // namespace
+
+
+auto main() -> int {
+  const auto keys = sample_keys();
+
+  // Volatile so neither the sums nor the hashing they come from can be optimized away.
+  volatile std::size_t sink = 0;
+
+  const bench::Case old_mixer {
+    // The old chain, spelled out: hash the first field, then combine the second with the
+    // frozen old mixer. Same work as the new case, which calls the public `hash` directly.
+    .name = "cache key hash -- old mixer",
+    .body = [&](const std::size_t iterations) {
+      for (std::size_t i = 0; i < iterations; ++i) {
+        const auto& [year, term] = keys.at(i % keys.size());
+        sink = sink + old_hash_combine(util::hash::hash(year), term);
+      }
+    },
+  };
+
+  const bench::Case new_mixer {
+    .name = "cache key hash -- new mixer",
+    .body = [&](const std::size_t iterations) {
+      for (std::size_t i = 0; i < iterations; ++i) {
+        const auto& [year, term] = keys.at(i % keys.size());
+        sink = sink + util::hash::hash(year, term);
+      }
+    },
+  };
+
+  // 24000 iterations per round, per bench_jieqi's calibration: long enough for a round's fixed
+  // cost to amortize away, which is what makes the ratio repeatable across runs.
+  const std::array mixer_pair { old_mixer, new_mixer };
+  const bench::Plan plan { .title = "Cache key hashing", .iterations = 24000 };
+  bench::run(plan, mixer_pair, std::cout);
+
+  return 0;
+}

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -26,6 +26,7 @@
 #include <limits>
 #include <print>
 #include <atomic>
+#include <bit>
 #include <cmath>
 #include <memory>
 #include <ranges>
@@ -322,6 +323,54 @@ TEST(Util, HashCollision) {
   std::println("{} collisions", tuples.size() - hash_values.size());
 
   ASSERT_NEAR(tuples.size(), hash_values.size(), try_count * 0.00005);
+}
+
+
+/*! @brief A hashable wrapper around an exact bit pattern, so the avalanche test controls the
+           mixer's input on every STL -- libc++ pre-mixes integer hashes with murmur, which
+           would mask a weak mixer. */
+struct Bits {
+  std::size_t value;
+};
+
+} // namespace util::test
+
+template <>
+struct std::hash<util::test::Bits> {
+  auto operator()(const util::test::Bits b) const noexcept -> std::size_t { return b.value; }
+};
+
+namespace util::test {
+
+TEST(Util, HashCombineAvalanche) {
+  static_assert(sizeof(std::size_t) == 8, "every CI leg is 64-bit; revisit if that changes");
+
+  constexpr std::size_t SAMPLES = 512;
+  // Mean flipped output bits per flipped input bit; ideal is 32 of 64. Calibration (probe at
+  // 512 samples/bit): the previous finalizer -- `v_hash *= 0x9e3779b9`, a 32-bit constant --
+  // scored as low as 7.7 on high input bits, the xorshift finalizer scores >= 27.8. The wide
+  // window keeps any CELESTIAL_TEST_SEED draw far from the edges.
+  constexpr double MIN_FLIPS = 26.0;
+  constexpr double MAX_FLIPS = 38.0;
+
+  for (std::size_t bit = 0; bit < 64; ++bit) {
+    const auto mask = std::size_t { 1 } << bit;
+    double value_flips = 0.0;
+    double seed_flips = 0.0;
+
+    for (std::size_t k = 0; k < SAMPLES; ++k) {
+      const auto seed = random<std::size_t>();
+      const Bits bits { random<std::size_t>() };
+      const auto base = hash::hash_combine(seed, bits);
+      value_flips += static_cast<double>(std::popcount(base ^ hash::hash_combine(seed, Bits { bits.value ^ mask })));
+      seed_flips += static_cast<double>(std::popcount(base ^ hash::hash_combine(seed ^ mask, bits)));
+    }
+
+    EXPECT_GE(value_flips / SAMPLES, MIN_FLIPS) << "input bit " << bit;
+    EXPECT_LE(value_flips / SAMPLES, MAX_FLIPS) << "input bit " << bit;
+    EXPECT_GE(seed_flips / SAMPLES, MIN_FLIPS) << "seed bit " << bit;
+    EXPECT_LE(seed_flips / SAMPLES, MAX_FLIPS) << "seed bit " << bit;
+  }
 }
 
 

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -336,10 +336,14 @@ struct Bits {
 
 } // namespace util::test
 
+namespace std {
+
 template <>
-struct std::hash<util::test::Bits> {
+struct hash<util::test::Bits> {
   [[nodiscard]] auto operator()(const util::test::Bits b) const noexcept -> std::size_t { return b.value; }
 };
+
+} // namespace std
 
 namespace util::test {
 

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -351,7 +351,8 @@ TEST(Util, HashCombineAvalanche) {
   // 512 samples/bit, outputs archived in the PR): the previous finalizer -- a 32-bit-constant
   // multiply -- scored as low as 7.7 on high input bits; the current one draws 27.4..33.4
   // across 100 seeds. The floor sits at input bit 7 and is structural, not noise: the
-  // retained prefix's `>> 13` drops the low 13 bits before mixing, and the window absorbs
+  // retained prefix's `>> 13` leaves the low 13 bits to the single golden-ratio multiply, and
+  // bit 7 is the worst-placed of those against the constant's bit pattern. The window absorbs
   // that floor rather than the ideal.
   constexpr double MIN_FLIPS = 26.0;
   constexpr double MAX_FLIPS = 38.0;

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -31,6 +31,7 @@
 #include <memory>
 #include <ranges>
 #include <thread>
+#include <functional>
 #include <unordered_set>
 #include "util.hpp"
 
@@ -327,8 +328,8 @@ TEST(Util, HashCollision) {
 
 
 /*! @brief A hashable wrapper around an exact bit pattern, so the avalanche test controls the
-           mixer's input on every STL -- libc++ pre-mixes integer hashes with murmur, which
-           would mask a weak mixer. */
+           mixer's input on every STL -- MSVC's integer `std::hash` is FNV-1a (verified:
+           `hash(1)` != 1), which would mask a weak mixer. */
 struct Bits {
   std::size_t value;
 };
@@ -337,39 +338,43 @@ struct Bits {
 
 template <>
 struct std::hash<util::test::Bits> {
-  auto operator()(const util::test::Bits b) const noexcept -> std::size_t { return b.value; }
+  [[nodiscard]] auto operator()(const util::test::Bits b) const noexcept -> std::size_t { return b.value; }
 };
 
 namespace util::test {
 
 TEST(Util, HashCombineAvalanche) {
-  static_assert(sizeof(std::size_t) == 8, "every CI leg is 64-bit; revisit if that changes");
+  static_assert(sizeof(std::size_t) == 8, "the 64 input bits below assume a 64-bit size_t");
 
   constexpr std::size_t SAMPLES = 512;
-  // Mean flipped output bits per flipped input bit; ideal is 32 of 64. Calibration (probe at
-  // 512 samples/bit): the previous finalizer -- `v_hash *= 0x9e3779b9`, a 32-bit constant --
-  // scored as low as 7.7 on high input bits, the xorshift finalizer scores >= 27.8. The wide
-  // window keeps any CELESTIAL_TEST_SEED draw far from the edges.
+  // Mean flipped output bits per flipped input bit; ideal is 32 of 64. Calibration (probes at
+  // 512 samples/bit, outputs archived in the PR): the previous finalizer -- a 32-bit-constant
+  // multiply -- scored as low as 7.7 on high input bits; the current one draws 27.4..33.4
+  // across 100 seeds. The floor sits at input bit 7 and is structural, not noise: the
+  // retained prefix's `>> 13` drops the low 13 bits before mixing, and the window absorbs
+  // that floor rather than the ideal.
   constexpr double MIN_FLIPS = 26.0;
   constexpr double MAX_FLIPS = 38.0;
 
   for (std::size_t bit = 0; bit < 64; ++bit) {
     const auto mask = std::size_t { 1 } << bit;
-    double value_flips = 0.0;
-    double seed_flips = 0.0;
+    int value_flips = 0;
+    int seed_flips = 0;
 
     for (std::size_t k = 0; k < SAMPLES; ++k) {
       const auto seed = random<std::size_t>();
       const Bits bits { random<std::size_t>() };
       const auto base = hash::hash_combine(seed, bits);
-      value_flips += static_cast<double>(std::popcount(base ^ hash::hash_combine(seed, Bits { bits.value ^ mask })));
-      seed_flips += static_cast<double>(std::popcount(base ^ hash::hash_combine(seed ^ mask, bits)));
+      value_flips += std::popcount(base ^ hash::hash_combine(seed, Bits { bits.value ^ mask }));
+      seed_flips += std::popcount(base ^ hash::hash_combine(seed ^ mask, bits));
     }
 
-    EXPECT_GE(value_flips / SAMPLES, MIN_FLIPS) << "input bit " << bit;
-    EXPECT_LE(value_flips / SAMPLES, MAX_FLIPS) << "input bit " << bit;
-    EXPECT_GE(seed_flips / SAMPLES, MIN_FLIPS) << "seed bit " << bit;
-    EXPECT_LE(seed_flips / SAMPLES, MAX_FLIPS) << "seed bit " << bit;
+    const auto value_mean = static_cast<double>(value_flips) / static_cast<double>(SAMPLES);
+    const auto seed_mean = static_cast<double>(seed_flips) / static_cast<double>(SAMPLES);
+    EXPECT_GE(value_mean, MIN_FLIPS) << "input bit " << bit;
+    EXPECT_LE(value_mean, MAX_FLIPS) << "input bit " << bit;
+    EXPECT_GE(seed_mean, MIN_FLIPS) << "seed bit " << bit;
+    EXPECT_LE(seed_mean, MAX_FLIPS) << "seed bit " << bit;
   }
 }
 

--- a/src/util/hash.hpp
+++ b/src/util/hash.hpp
@@ -25,6 +25,7 @@
 
 #include <tuple>
 #include <cstddef>
+#include <cstdint>
 #include <utility>
 #include <functional>
 #include <type_traits>
@@ -41,8 +42,13 @@ template <typename T>
   v_hash ^= seed * 0xc4ceb9fe1a85ec53;
   v_hash ^= (v_hash >> 13) * 0xff51afd7ed558ccd;
 
-  // Splitmix64-style finalizer: a multiply never moves high bits down (and `0x9e3779b9` is
-  // only 32 bits wide), so xorshifts bracket the 64-bit golden-ratio multiply.
+  // The finalizer assumes a 64-bit `size_t`: on a 32-bit one the shifts would be UB rather
+  // than merely weaker, so fail the compile instead.
+  static_assert(sizeof(std::size_t) == sizeof(std::uint64_t));
+
+  // A multiply only carries bits upward, so on its own the high half of the input never
+  // reaches the low bits -- the xorshifts either side of the golden-ratio multiply bring
+  // it down.
   v_hash ^= v_hash >> 32;
   v_hash *= 0x9e3779b97f4a7c15;
   v_hash ^= v_hash >> 32;

--- a/src/util/hash.hpp
+++ b/src/util/hash.hpp
@@ -40,7 +40,12 @@ template <typename T>
 
   v_hash ^= seed * 0xc4ceb9fe1a85ec53;
   v_hash ^= (v_hash >> 13) * 0xff51afd7ed558ccd;
-  v_hash *= 0x9e3779b9;
+
+  // Splitmix64-style finalizer: a multiply never moves high bits down (and `0x9e3779b9` is
+  // only 32 bits wide), so xorshifts bracket the 64-bit golden-ratio multiply.
+  v_hash ^= v_hash >> 32;
+  v_hash *= 0x9e3779b97f4a7c15;
+  v_hash ^= v_hash >> 32;
 
   return v_hash;
 }

--- a/src/util/hash.hpp
+++ b/src/util/hash.hpp
@@ -44,7 +44,8 @@ template <typename T>
 
   // The finalizer assumes a 64-bit `size_t`: on a 32-bit one the shifts would be UB rather
   // than merely weaker, so fail the compile instead.
-  static_assert(sizeof(std::size_t) == sizeof(std::uint64_t));
+  static_assert(sizeof(std::size_t) == sizeof(std::uint64_t),
+                "hash_combine's finalizer shifts by 32 and needs a 64-bit size_t");
 
   // A multiply only carries bits upward, so on its own the high half of the input never
   // reaches the low bits -- the xorshifts either side of the golden-ratio multiply bring


### PR DESCRIPTION
## 什么

`hash_combine` 的收尾混合修复(util 层契约批 PR-B,SSOT 施工表第 3 行):

- 旧收尾 `v_hash *= 0x9e3779b9`:乘法只把低位往高位传,高位输入永远影响不到低位输出;
  乘数还只有 32 位宽。探针实测(512 样本/输入位):翻输入 bit 63 平均只翻 7.7 个输出位
  (理想 32)。
- 新收尾:xorshift 夹住 64 位黄金比乘法(`^= >>32; *= 0x9e3779b97f4a7c15; ^= >>32`)。
  同探针 min 27.4..33.4(100 种子);只换常数不加 xorshift 无效(21.6),常数与位置一起改。
- 新增 `Util.HashCombineAvalanche`:自定义 `Bits` + 恒等 `std::hash<Bits>` 特化,绕开各 STL
  的整数 hash 差异(MSVC 是 FNV-1a 预混合,实测 `hash(1) != 1`),逐输入位断言输出翻转数
  落在 [26, 38]。
- 新增 `bench_cache.cpp`:新旧 mixer 同二进制同轮配对比值(验收①口径);旧实现就地冻结
  拷贝,永不与 `hash_combine` 同步。

## 检出率

新雪崩测试对旧 mixer 红:**78 条断言全挂,实测区间 7.65~25.58 < 26**(证据
`.review/pr-b/avalanche_red_old_mixer.log`)。旧 mixer 在 value bit 13-26 与 seed bit 0-26
上是通过的——没被守住的恰是高位。

## 测量

bench 修复后(opus 盲审 P1-1/P2-5:原 24000 迭代是抄 bench_jieqi 为 ~20 ns 命中定的标定,
对 ~2 ns 的纯哈希太短,比值沉在噪声里跨零;脚手架 `%`+`at`+volatile 链占比过半):
240000 迭代/轮,归档三跑 median **+8.0 / +8.9 / +7.0%**(.review/pr-b/bench_bench_cache_full.log),
即新 mixer 贵 ~0.2 ns/key(吞吐口径;延迟口径 ~0.7 ns,关键路径多约 4 cycle——opus R2),
相对 blade 本机实测 ~20 ns 的缓存命中(bench_bench_jieqi.log)可忽略。绝对值不跨机引用。

## 已知残余(如实记录)

雪崩最低值稳定在 input bit 7(27.4 量级,距理想 32 约 24σ,结构性非噪声):根因是保留的
前缀行 `(v_hash >> 13)` 在乘之前丢掉低 13 位,不在本批 mandate(收尾改 xorshift + 64 位
常数)内。窗口 [26,38] 容纳这个结构底部;继续强化(第二轮乘法)可独立立项。

## 门禁

- clang 18.1.8(MSVC STL)Release 构建 EXIT 0;28 个测试二进制全部 rc=0,215 跑过 =
  215 个 `TEST(` 宏对账相等(基线 214 + 新增 1)。
- 4 个 bench 二进制直接运行全 EXIT 0。注意:`project.py --bench` 在 Windows 当前必炸
  (automation/bench.py 把无扩展名的 build/bench/Makefile 当 benchmark 发现——
  `os.access(X_OK)` 在 Windows 近乎恒真——先 unlink 它再对它 CreateProcess,WinError 193)。
  风格线地界,本批不修,已记账。
- ruff / --self-contained(32/32)/ --features 全 EXIT 0。
- clang-tidy:本机全量运行未等到结束即开 PR(用户裁决)——权威门禁是 CI 的 Style Check 腿
  (clang-tidy 18.1.8,WarningsAsErrors:'*';bench_cache.cpp 在 compile_commands.json 内会被扫到)。
  本机跑到中段的输出里,error 全部落在 _deps/googletest-src(第三方,CI 不扫),本 PR 触碰的
  三个文件在中段日志中零告警——非完整证据,完整判定看 CI。

## 审阅史

R1 六席(T1 并行):正确性 kimi/grok 清单 + opus 盲审,风格 kimi/opus/grok。
无 P1 行为缺陷;opus 盲审 P1-1(bench 标定不可复现)与 P2-1(注释点错标准库,探针定案
为 MSVC FNV-1a)等已修复;三席收敛项(64 位假设落位)已进 `hash.hpp` 本体。
R2 三席原发现家复验(opus/kimi/grok):R1 发现全部 FIXES VERIFIED;opus 在修复 diff 上追加的
1 P2(提交消息引用未归档跑次 + 跨机引用 8 ns)+ 3 P3 已在尾修中处置(归档三跑完整报告、
正文改用归档数字、bit 7 机理句补全、bench 标定数字更新)。

探针与全部证据日志:`.review/pr-b/`(未跟踪目录;关键输出已归档:
avalanche_probe_output.log、avalanche_red_old_mixer.log、bench_bench_cache.log 等)。
