### PR TITLE
feat(shared_lib,lunar): C ABI 导出 converter 双入口 + 演化政策 + 月份语义 —— #128 #129 #130

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -127,6 +127,13 @@ jobs:
           chmod +x project.py
           ./project.py --setup --clean --cmake --build --test -v 1
 
+      # The ctypes smoke gate needs the built shared library, and the linters leg
+      # configures without building -- so it lives on a build leg, one step after the
+      # library exists. One leg is enough: the wrappers and their goldens are
+      # toolchain-independent, and the C ABI itself is pinned on every leg.
+      - name: Smoke-test the ctypes bindings
+        run: python3 ./linter.py --ctypes-smoke
+
 
   # macOS and Windows build+test are not here: they live in `build_and_test.yml`, which runs on
   # pull requests to main and packages the artifacts -- running them here too repeated the same

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -51,7 +51,7 @@ jobs:
           ./project.py --clean --cmake
           
           chmod +x linter.py
-          ./linter.py --ruff --clang-tidy
+          ./linter.py --ruff --clang-tidy --abi-layout
 
           
   test-ubuntu-gcc14:  

--- a/automation/__init__.py
+++ b/automation/__init__.py
@@ -28,6 +28,7 @@ from .github import GitHub
 from .linter import run_ruff, run_clang_tidy
 from .self_contained import check_self_contained
 from .feature_probe import probe_features
+from .abi_layout import check_abi_layout
 from .bench import build_benchmarks, run_benchmarks, find_benchmarks
 
 __all__ = [
@@ -39,5 +40,6 @@ __all__ = [
   "run_cmd", "ProcReturn", "time_execution",
   "proj_root", "build_dir", "cpp_src_dir", "python_requirements", "cpp_test_dir",
   "GitHub", "run_ruff", "run_clang_tidy", "check_self_contained", "probe_features",
+  "check_abi_layout",
   "build_benchmarks", "run_benchmarks", "find_benchmarks"
 ]

--- a/automation/__init__.py
+++ b/automation/__init__.py
@@ -29,6 +29,7 @@ from .linter import run_ruff, run_clang_tidy
 from .self_contained import check_self_contained
 from .feature_probe import probe_features
 from .abi_layout import check_abi_layout
+from .ctypes_smoke import check_ctypes_smoke
 from .bench import build_benchmarks, run_benchmarks, find_benchmarks
 
 __all__ = [
@@ -40,6 +41,6 @@ __all__ = [
   "run_cmd", "ProcReturn", "time_execution",
   "proj_root", "build_dir", "cpp_src_dir", "python_requirements", "cpp_test_dir",
   "GitHub", "run_ruff", "run_clang_tidy", "check_self_contained", "probe_features",
-  "check_abi_layout",
+  "check_abi_layout", "check_ctypes_smoke",
   "build_benchmarks", "run_benchmarks", "find_benchmarks"
 ]

--- a/automation/abi_layout.py
+++ b/automation/abi_layout.py
@@ -80,8 +80,12 @@ def parse_py_structs(mirror: Path) -> Dict[str, Fields]:
       if not (isinstance(stmt, ast.Assign) and
               any(isinstance(t, ast.Name) and t.id == "_fields_" for t in stmt.targets)):
         continue
+      if not isinstance(stmt.value, (ast.List, ast.Tuple)):
+        raise RuntimeError(f"Unreadable _fields_ on Structure subclass {node.name}: not a literal list/tuple")
       fields = []
       for elt in stmt.value.elts:
+        if not isinstance(elt, ast.Tuple) or len(elt.elts) != 2:
+          raise RuntimeError(f"Unreadable _fields_ entry in {node.name}: not a (name, type) 2-tuple")
         fname_node, type_node = elt.elts
         if not isinstance(fname_node, ast.Constant) or not isinstance(fname_node.value, str):
           raise RuntimeError(f"Unreadable field name in {node.name}._fields_")

--- a/automation/abi_layout.py
+++ b/automation/abi_layout.py
@@ -1,0 +1,229 @@
+# CelestialCalendar Automation:
+#   Python automation scripts for building and testing the CelestialCalendar C++ project.
+#
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+# License: GNU General Public License v3.0
+#
+# This software is distributed without any warranty.
+# See <https://www.gnu.org/licenses/> for more details.
+
+import ast
+import ctypes
+import os
+import re
+import shutil
+import tempfile
+
+from pathlib import Path
+from typing import Dict, List, Final, Optional, Tuple
+
+from . import paths
+from .utils import run_cmd, green_print, red_print, yellow_print
+
+
+# The closed set of field types the gate understands, mapped to their ctypes mirror.
+# A field type outside it fails the gate loudly: extending the ABI with a new field
+# type is a deliberate act that must extend this table, not something to wave through.
+C_TO_CTYPES: Final[Dict[str, str]] = {
+  "bool":     "c_bool",
+  "uint8_t":  "c_uint8",
+  "uint16_t": "c_uint16",
+  "uint32_t": "c_uint32",
+  "int32_t":  "c_int32",
+  "double":   "c_double",
+}
+
+STRUCT_RE: Final[re.Pattern] = re.compile(r"typedef\s+struct\s+(\w+)\s*\{(.*?)\}\s*\1\s*;", re.DOTALL)
+FIELD_RE: Final[re.Pattern] = re.compile(r"^\s*(\w+)\s+(\w+)\s*;")
+
+# (field name, type name), in declaration order.
+Fields = List[Tuple[str, str]]
+
+
+def parse_c_structs(header: Path) -> Dict[str, Fields]:
+  """Parse every `typedef struct` in `celestial.h`: name -> fields in declaration order."""
+  structs: Dict[str, Fields] = {}
+  for name, body in STRUCT_RE.findall(header.read_text()):
+    fields = [(m.group(2), m.group(1)) for line in body.splitlines() if (m := FIELD_RE.match(line))]
+    if not fields:
+      raise RuntimeError(f"No fields parsed from struct {name} in {header}")
+    structs[name] = fields
+  if not structs:
+    raise RuntimeError(f"No typedef struct found in {header}")
+  return structs
+
+
+def parse_py_structs(mirror: Path) -> Dict[str, Fields]:
+  """Parse every ctypes `Structure` subclass in `common.py`, statically (no import, no .so).
+
+  Class names are normalized by stripping one leading underscore (`_JulianDay` mirrors
+  `JulianDay`; `DeltaT` carries no underscore). Anything the parser cannot read exactly —
+  a missing `_fields_`, a non-tuple entry, a non-simple type name — raises, because a
+  gate that guesses is no gate.
+  """
+  structs: Dict[str, Fields] = {}
+  for node in ast.parse(mirror.read_text()).body:
+    if not isinstance(node, ast.ClassDef):
+      continue
+    is_structure = any(
+      (isinstance(b, ast.Name) and b.id == "Structure") or
+      (isinstance(b, ast.Attribute) and b.attr == "Structure")
+      for b in node.bases
+    )
+    if not is_structure:
+      continue
+
+    fields: Optional[Fields] = None
+    for stmt in node.body:
+      if not (isinstance(stmt, ast.Assign) and
+              any(isinstance(t, ast.Name) and t.id == "_fields_" for t in stmt.targets)):
+        continue
+      fields = []
+      for elt in stmt.value.elts:
+        fname_node, type_node = elt.elts
+        if not isinstance(fname_node, ast.Constant) or not isinstance(fname_node.value, str):
+          raise RuntimeError(f"Unreadable field name in {node.name}._fields_")
+        if isinstance(type_node, ast.Name):
+          tname = type_node.id
+        elif isinstance(type_node, ast.Attribute):
+          tname = type_node.attr
+        else:
+          raise RuntimeError(f"Unreadable field type in {node.name}._fields_")
+        fields.append((fname_node.value, tname))
+
+    if not fields:
+      raise RuntimeError(f"No readable _fields_ on Structure subclass {node.name}")
+    structs[node.name[1:] if node.name.startswith("_") else node.name] = fields
+
+  if not structs:
+    raise RuntimeError(f"No Structure subclass found in {mirror}")
+  return structs
+
+
+def c_layout_probe(structs: Dict[str, Fields], header: Path, workdir: Path) -> Optional[Dict[str, int]]:
+  """Compile and run a tiny C program printing sizeof/offsetof for every struct and field.
+
+  This is the ground-truth side of the comparison: the values the C ABI actually has.
+  A missing or failing compiler must turn the gate red, never silently skip it.
+  """
+  cc = os.environ.get("CC", "cc")
+  if shutil.which(cc) is None:
+    red_print(f"C compiler not found: {cc} (set $CC)")
+    return None
+
+  lines = ['#include "celestial.h"', "#include <stdio.h>", "#include <stddef.h>", "int main(void) {"]
+  for name, fields in structs.items():
+    lines.append(f'  printf("{name} %zu\\n", sizeof({name}));')
+    for fname, _ in fields:
+      lines.append(f'  printf("{name}.{fname} %zu\\n", offsetof({name}, {fname}));')
+  lines += ["  return 0;", "}"]
+
+  src = workdir / "abi_layout_probe.c"
+  exe = workdir / "abi_layout_probe"
+  src.write_text("\n".join(lines) + "\n")
+
+  ret = run_cmd([cc, "-Wall", "-Werror", f"-I{header.parent}", str(src), "-o", str(exe)],
+                print_cmd=False, print_stdout=False, print_stderr=False)
+  if ret.retcode != 0:
+    red_print(f"Layout probe failed to compile with {cc}:")
+    for line in (ret.stderr or ret.stdout).splitlines()[:12]:
+      print(f"  {line}")
+    return None
+
+  ret = run_cmd([str(exe)], print_cmd=False, print_stdout=False, print_stderr=False)
+  if ret.retcode != 0:
+    red_print(f"Layout probe failed to run (exit {ret.retcode})")
+    return None
+
+  layout: Dict[str, int] = {}
+  for line in ret.stdout.splitlines():
+    key, _, value = line.rpartition(" ")
+    layout[key] = int(value)
+  return layout
+
+
+def py_layout(fields: Fields) -> Tuple[int, Dict[str, int]]:
+  """Build the mirrored struct with ctypes (stdlib only, no .so) and read its layout."""
+  ctype_fields = [(fname, getattr(ctypes, tname)) for fname, tname in fields]
+  cls = type("_Probe", (ctypes.Structure,), {"_fields_": ctype_fields})
+  return ctypes.sizeof(cls), {fname: getattr(cls, fname).offset for fname, _ in ctype_fields}
+
+
+def check_abi_layout() -> int:
+  """Hold the `statistics/common.py` ctypes mirror to the real layout in `celestial.h`.
+
+  common.py declares that every C-ABI export has a mirror here; a struct return read
+  through a drifted layout is garbage that no test prints (#85). Three layers, because
+  each sees what the others cannot: set equality catches a missing or extra mirror,
+  sizeof/offsetof catches layout drift, and the type-name map catches what raw layout
+  cannot — signedness and same-width swaps (c_int32 vs c_uint32, c_bool vs c_uint8).
+  """
+  print("#" * 60)
+  yellow_print("Checking that the ctypes mirror matches the real ABI layout...")
+
+  header = paths.proj_root() / "src" / "shared_lib" / "celestial.h"
+  mirror = paths.proj_root() / "statistics" / "common.py"
+
+  try:
+    c_structs = parse_c_structs(header)
+    py_structs = parse_py_structs(mirror)
+  except RuntimeError as e:
+    red_print(f"Parse failed: {e}")
+    return 1
+
+  failures: List[str] = []
+
+  # Layer 1: set equality, both directions.
+  for name in sorted(c_structs.keys() - py_structs.keys()):
+    failures.append(f"{name}: no ctypes mirror in common.py")
+  for name in sorted(py_structs.keys() - c_structs.keys()):
+    failures.append(f"{name}: ctypes mirror without a struct in celestial.h")
+
+  # Layer 2: compile and run the ground-truth probe once for every struct.
+  with tempfile.TemporaryDirectory(prefix="abi_layout_") as tmp:
+    ground_truth = c_layout_probe(c_structs, header, Path(tmp))
+  if ground_truth is None:
+    return 1
+
+  # Layers 2+3: per-struct layout and type-name comparison.
+  for name in sorted(c_structs.keys() & py_structs.keys()):
+    c_fields = c_structs[name]
+    py_fields = py_structs[name]
+    py_size, py_offsets = py_layout(py_fields)
+
+    if ground_truth[name] != py_size:
+      failures.append(f"{name}: sizeof {ground_truth[name]} (C) != {py_size} (ctypes)")
+
+    c_names = [f for f, _ in c_fields]
+    py_names = [f for f, _ in py_fields]
+    for fname in sorted(set(c_names) - set(py_names)):
+      failures.append(f"{name}.{fname}: field missing from the ctypes mirror")
+    for fname in sorted(set(py_names) - set(c_names)):
+      failures.append(f"{name}.{fname}: field without a counterpart in celestial.h")
+
+    py_type_of = dict(py_fields)
+    for fname, ctype in c_fields:
+      if ctype not in C_TO_CTYPES:
+        failures.append(f"{name}.{fname}: C type {ctype} is outside the gate's closed set — extend C_TO_CTYPES")
+        continue
+      if fname not in py_type_of:
+        continue  # already reported above
+      expected = C_TO_CTYPES[ctype]
+      if py_type_of[fname] != expected:
+        failures.append(f"{name}.{fname}: {ctype} mirrored as {py_type_of[fname]}, expected {expected}")
+      if py_offsets[fname] != ground_truth[f"{name}.{fname}"]:
+        failures.append(
+          f"{name}.{fname}: offset {ground_truth[f'{name}.{fname}']} (C) != {py_offsets[fname]} (ctypes)"
+        )
+
+  print("#" * 60)
+  if failures:
+    red_print(f"ABI layout gate failed ({len(failures)} finding(s)):")
+    for f in failures:
+      red_print(f"  - {f}")
+    return 1
+
+  green_print(f"ctypes mirror matches the ABI layout ({len(c_structs)} structs)")
+  return 0

--- a/automation/abi_layout.py
+++ b/automation/abi_layout.py
@@ -59,8 +59,8 @@ def parse_py_structs(mirror: Path) -> Dict[str, Fields]:
   """Parse every ctypes `Structure` subclass in `common.py`, statically (no import, no .so).
 
   Class names are normalized by stripping one leading underscore (`_JulianDay` mirrors
-  `JulianDay`; `DeltaT` carries no underscore). Anything the parser cannot read exactly —
-  a missing `_fields_`, a non-tuple entry, a non-simple type name — raises, because a
+  `JulianDay`; `DeltaT` carries no underscore). Anything the parser cannot read exactly --
+  a missing `_fields_`, a non-tuple entry, a non-simple type name -- raises, because a
   gate that guesses is no gate.
   """
   structs: Dict[str, Fields] = {}
@@ -102,7 +102,7 @@ def parse_py_structs(mirror: Path) -> Dict[str, Fields]:
   return structs
 
 
-def c_layout_probe(structs: Dict[str, Fields], header: Path, workdir: Path) -> Optional[Dict[str, int]]:
+def c_layout(structs: Dict[str, Fields], header: Path, workdir: Path) -> Optional[Dict[str, int]]:
   """Compile and run a tiny C program printing sizeof/offsetof for every struct and field.
 
   This is the ground-truth side of the comparison: the values the C ABI actually has.
@@ -154,11 +154,11 @@ def py_layout(fields: Fields) -> Tuple[int, Dict[str, int]]:
 def check_abi_layout() -> int:
   """Hold the `statistics/common.py` ctypes mirror to the real layout in `celestial.h`.
 
-  common.py declares that every C-ABI export has a mirror here; a struct return read
-  through a drifted layout is garbage that no test prints (#85). Three layers, because
+  Every struct in `celestial.h` has a ctypes mirror in `common.py`, and a struct read back
+  through a drifted mirror is garbage no test prints (#85). Three layers, because
   each sees what the others cannot: set equality catches a missing or extra mirror,
   sizeof/offsetof catches layout drift, and the type-name map catches what raw layout
-  cannot — signedness and same-width swaps (c_int32 vs c_uint32, c_bool vs c_uint8).
+  cannot -- signedness and same-width swaps (c_int32 vs c_uint32, c_bool vs c_uint8).
   """
   print("#" * 60)
   yellow_print("Checking that the ctypes mirror matches the real ABI layout...")
@@ -183,7 +183,7 @@ def check_abi_layout() -> int:
 
   # Layer 2: compile and run the ground-truth probe once for every struct.
   with tempfile.TemporaryDirectory(prefix="abi_layout_") as tmp:
-    ground_truth = c_layout_probe(c_structs, header, Path(tmp))
+    ground_truth = c_layout(c_structs, header, Path(tmp))
   if ground_truth is None:
     return 1
 
@@ -206,7 +206,7 @@ def check_abi_layout() -> int:
     py_type_of = dict(py_fields)
     for fname, ctype in c_fields:
       if ctype not in C_TO_CTYPES:
-        failures.append(f"{name}.{fname}: C type {ctype} is outside the gate's closed set — extend C_TO_CTYPES")
+        failures.append(f"{name}.{fname}: C type {ctype} is outside the gate's closed set -- extend C_TO_CTYPES")
         continue
       if fname not in py_type_of:
         continue  # already reported above

--- a/automation/ctypes_smoke.py
+++ b/automation/ctypes_smoke.py
@@ -1,0 +1,124 @@
+# CelestialCalendar Automation:
+#   Python automation scripts for building and testing the CelestialCalendar C++ project.
+#
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+# License: GNU General Public License v3.0
+#
+# This software is distributed without any warranty.
+# See <https://www.gnu.org/licenses/> for more details.
+
+import importlib.util
+
+from datetime import date
+from types import ModuleType
+from typing import Callable, List, Tuple
+
+from . import paths
+from .utils import green_print, red_print, yellow_print
+
+
+def load_common() -> ModuleType:
+  """Import `statistics/common.py`, which loads the real built library at module level.
+
+  Imported from a file location rather than via `sys.path`, so the generic module
+  name `common` cannot collide with anything else on the import path.
+  """
+  common_py = paths.proj_root() / "statistics" / "common.py"
+  spec = importlib.util.spec_from_file_location("common", common_py)
+  if spec is None or spec.loader is None:
+    raise RuntimeError(f"Cannot load module spec from {common_py}")
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+def check_ctypes_smoke() -> int:
+  """Run the `statistics/common.py` wrappers against the real built library.
+
+  The ABI layout gate parses `Structure._fields_` without executing anything, and the
+  C ABI tests stop at the C boundary -- so neither can see a wrapper body that fills a
+  dataclass field from the wrong struct member. The goldens below are the HKO-sourced
+  2023 leap-2nd-month pins from `cabi_smoke_test.cpp`, re-read through the Python
+  wrappers: if the values come back right end to end, the field plumbing is right.
+
+  Needs the built library (`./project.py --build`): a missing build turns the gate
+  red at import, never a silent skip.
+  """
+  print("#" * 60)
+  yellow_print("Smoke-testing the ctypes wrappers against the built library...")
+
+  try:
+    common = load_common()
+  except Exception as e:
+    red_print(f"Importing statistics/common.py failed (run ./project.py --build first): {e}")
+    return 1
+
+  algo1 = common.LunarAlgo.ALGO_1
+  algo3 = common.LunarAlgo.ALGO_3
+
+  # (label, call, expected return value).
+  value_cases: List[Tuple[str, Callable[[], object], object]] = [
+    ("gregorian_to_lunar(2023-03-22) -> leap 2nd month, day 1",
+     lambda: common.gregorian_to_lunar(algo1, 2023, 3, 22),
+     common.LunarDate(year=2023, month=2, is_leap=True, day=1)),
+    ("gregorian_to_lunar(2023-04-20) -> 3rd month, day 1",
+     lambda: common.gregorian_to_lunar(algo1, 2023, 4, 20),
+     common.LunarDate(year=2023, month=3, is_leap=False, day=1)),
+    ("gregorian_to_lunar(2023-03-22) via algo3 agrees",
+     lambda: common.gregorian_to_lunar(algo3, 2023, 3, 22),
+     common.LunarDate(year=2023, month=2, is_leap=True, day=1)),
+    ("lunar_to_gregorian(2023, leap 2nd, 1) -> 2023-03-22",
+     lambda: common.lunar_to_gregorian(algo1, 2023, 2, True, 1),
+     date(2023, 3, 22)),
+    ("lunar_to_gregorian(2023, 3rd, 1) -> 2023-04-20",
+     lambda: common.lunar_to_gregorian(algo1, 2023, 3, False, 1),
+     date(2023, 4, 20)),
+    ("algo3 supported range -> (1600, 2199)",
+     lambda: common.get_supported_lunar_year_range(algo3),
+     common.SupportedLunarYearRange(start=1600, end=2199)),
+  ]
+
+  # (label, call) -- invalid inputs must surface as ValueError, not a wrong date.
+  raising_cases: List[Tuple[str, Callable[[], object]]] = [
+    ("lunar_to_gregorian(2024, leap 2nd, 1): 2024 has no leap month",
+     lambda: common.lunar_to_gregorian(algo1, 2024, 2, True, 1)),
+    ("lunar_to_gregorian(2023, leap 5th, 1): 2023's leap month is the 2nd",
+     lambda: common.lunar_to_gregorian(algo1, 2023, 5, True, 1)),
+    ("lunar_to_gregorian(2023, leap 2nd, 30): the leap 2nd month has 29 days",
+     lambda: common.lunar_to_gregorian(algo1, 2023, 2, True, 30)),
+    ("gregorian_to_lunar(2023-13-01): month out of range",
+     lambda: common.gregorian_to_lunar(algo1, 2023, 13, 1)),
+  ]
+
+  failures: List[str] = []
+
+  for label, call, expected in value_cases:
+    try:
+      actual = call()
+    except Exception as e:
+      failures.append(f"{label}: raised {type(e).__name__}: {e}")
+      continue
+    if actual != expected:
+      failures.append(f"{label}: returned {actual!r}, expected {expected!r}")
+
+  for label, call in raising_cases:
+    try:
+      actual = call()
+    except ValueError:
+      continue
+    except Exception as e:
+      failures.append(f"{label}: raised {type(e).__name__}: {e}, expected ValueError")
+      continue
+    failures.append(f"{label}: returned {actual!r}, expected ValueError")
+
+  print("#" * 60)
+  if failures:
+    red_print(f"ctypes smoke gate failed ({len(failures)} finding(s)):")
+    for f in failures:
+      red_print(f"  - {f}")
+    return 1
+
+  green_print(f"ctypes wrappers agree with the built library ({len(value_cases) + len(raising_cases)} cases)")
+  return 0

--- a/linter.py
+++ b/linter.py
@@ -19,6 +19,7 @@ import argparse
 
 from automation import (
   run_ruff, run_clang_tidy, check_self_contained, probe_features, check_abi_layout,
+  check_ctypes_smoke,
 )
 
 
@@ -36,11 +37,14 @@ def parse_args() -> argparse.Namespace:
       "    ./linter.py --self-contained\n\n"
       "  To hold the ctypes mirror to the real ABI layout in celestial.h:\n"
       "    ./linter.py --abi-layout\n\n"
+      "  To run the ctypes wrappers against the built library (needs ./project.py --build first):\n"
+      "    ./linter.py --ctypes-smoke\n\n"
       "  To report which awaited C++ features this toolchain can compile:\n"
       "    ./linter.py --features\n\n"
       "  To hold a CI leg to the feature state this repo recorded for it:\n"
       "    ./linter.py --features libc++\n\n"
-      "  To run every check (ruff, clang-tidy, self-containment, ABI layout, feature report):\n"
+      "  To run every check (ruff, clang-tidy, self-containment, ABI layout, ctypes smoke,\n"
+      "  feature report):\n"
       "    ./linter.py -a/--all\n\n"
     ),
     formatter_class=argparse.RawTextHelpFormatter
@@ -53,6 +57,8 @@ def parse_args() -> argparse.Namespace:
                       help="Compile every header alone to prove it is self-contained")
   parser.add_argument("--abi-layout", action="store_true",
                       help="Hold the ctypes mirror in statistics/common.py to the real ABI layout")
+  parser.add_argument("--ctypes-smoke", action="store_true",
+                      help="Run the ctypes wrappers against the built library (needs a build)")
   parser.add_argument("--features", nargs="?", const="", default=None, metavar="LEG",
                       help="Probe the awaited C++ features; with a CI leg name, hold it to the recorded state")
 
@@ -79,6 +85,11 @@ if __name__ == "__main__":
 
   if args.abi_layout or args.all:
     ret_code = check_abi_layout()
+    if ret_code != 0:
+      sys.exit(ret_code)
+
+  if args.ctypes_smoke or args.all:
+    ret_code = check_ctypes_smoke()
     if ret_code != 0:
       sys.exit(ret_code)
 

--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ import sys
 import argparse
 
 from automation import (
-  run_ruff, run_clang_tidy, check_self_contained, probe_features,
+  run_ruff, run_clang_tidy, check_self_contained, probe_features, check_abi_layout,
 )
 
 
@@ -34,11 +34,13 @@ def parse_args() -> argparse.Namespace:
       "    ./linter.py --clang-tidy\n\n"
       "  To check that every header is self-contained:\n"
       "    ./linter.py --self-contained\n\n"
+      "  To hold the ctypes mirror to the real ABI layout in celestial.h:\n"
+      "    ./linter.py --abi-layout\n\n"
       "  To report which awaited C++ features this toolchain can compile:\n"
       "    ./linter.py --features\n\n"
       "  To hold a CI leg to the feature state this repo recorded for it:\n"
       "    ./linter.py --features libc++\n\n"
-      "  To run every check (ruff, clang-tidy, self-containment, feature report):\n"
+      "  To run every check (ruff, clang-tidy, self-containment, ABI layout, feature report):\n"
       "    ./linter.py -a/--all\n\n"
     ),
     formatter_class=argparse.RawTextHelpFormatter
@@ -49,6 +51,8 @@ def parse_args() -> argparse.Namespace:
   parser.add_argument("--clang-tidy", action="store_true", help="Run clang-tidy")
   parser.add_argument("--self-contained", action="store_true",
                       help="Compile every header alone to prove it is self-contained")
+  parser.add_argument("--abi-layout", action="store_true",
+                      help="Hold the ctypes mirror in statistics/common.py to the real ABI layout")
   parser.add_argument("--features", nargs="?", const="", default=None, metavar="LEG",
                       help="Probe the awaited C++ features; with a CI leg name, hold it to the recorded state")
 
@@ -70,6 +74,11 @@ if __name__ == "__main__":
 
   if args.self_contained or args.all:
     ret_code = check_self_contained()
+    if ret_code != 0:
+      sys.exit(ret_code)
+
+  if args.abi_layout or args.all:
+    ret_code = check_abi_layout()
     if ret_code != 0:
       sys.exit(ret_code)
 

--- a/src/calendar/lunar/common.hpp
+++ b/src/calendar/lunar/common.hpp
@@ -133,7 +133,7 @@ struct TraditionalMonth {
     return std::nullopt;
   }
   if (is_leap) {
-    if (info.leap_month == 0 or month != info.leap_month) {
+    if (month != info.leap_month) {
       return std::nullopt;
     }
     return static_cast<uint8_t>(month + 1);

--- a/src/calendar/lunar/common.hpp
+++ b/src/calendar/lunar/common.hpp
@@ -29,6 +29,7 @@
 #include <numeric>
 #include <cstdint>
 #include <concepts>
+#include <optional>
 #include <functional>
 #include <type_traits>
 
@@ -96,6 +97,71 @@ struct LunarYear {
     .leap_month        = leap_month,
     .month_lengths     = month_lengths,
   };  
+}
+
+
+/**
+ * @brief A lunar month in traditional numbering: month number (1-12) plus a leap flag.
+ *        传统编号的阴历月：月份 (1-12) 加闰月标记。
+ * @note  `leap_month` and the positional indexing of `month_lengths` speak different month
+ *        languages — a leap month has no traditional number of its own (it takes its predecessor's
+ *        number with the leap flag), but occupies its own position. E.g. lunar 2023 (leap 2nd
+ *        month): position 3 is the leap 2nd month, and the traditional 3rd month is position 4.
+ *        `leap_month` 是传统编号，而 `month_lengths` 按位置序号索引——闰月没有自己的传统编号
+ *        （承前一个月的编号加闰标记），但独占一个位置。例：2023 年闰二月，位置 3 = 闰二月，
+ *        传统三月 = 位置 4。
+ */
+struct TraditionalMonth {
+  uint8_t month;
+  bool is_leap;
+
+  [[nodiscard]] auto operator==(const TraditionalMonth& other) const -> bool = default;
+};
+
+/**
+ * @brief Translate a traditionally-numbered lunar month to its 1-based position in
+ *        `info.month_lengths`. 把传统编号的阴历月翻译成 `info.month_lengths` 里的位置序号（从 1 起）。
+ * @param info The lunar year. 阴历年信息。
+ * @param month The traditional month number (1-12). 传统编号 (1-12)。
+ * @param is_leap Whether the month is the leap month. 是否闰月。
+ * @return The 1-based position; `std::nullopt` if `month` is out of range, or if `is_leap`
+ *         does not match the year's actual leap month (including leap-less years).
+ *         位置序号（从 1 起）；`month` 越界，或 `is_leap` 与该年实际闰月不符（含无闰月年）时返回 `std::nullopt`。
+ */
+[[nodiscard]] inline auto month_position(const LunarYear& info, const uint8_t month, const bool is_leap) -> std::optional<uint8_t> {
+  if (month < 1 or month > 12) {
+    return std::nullopt;
+  }
+  if (is_leap) {
+    if (info.leap_month == 0 or month != info.leap_month) {
+      return std::nullopt;
+    }
+    return static_cast<uint8_t>(month + 1);
+  }
+  const bool after_leap = (info.leap_month != 0 and month > info.leap_month);
+  return static_cast<uint8_t>(month + (after_leap ? 1 : 0));
+}
+
+/**
+ * @brief Translate a 1-based position in `info.month_lengths` back to traditional numbering.
+ *        把 `info.month_lengths` 里的位置序号（从 1 起）翻译回传统编号。
+ * @param info The lunar year. 阴历年信息。
+ * @param position The 1-based position. 位置序号（从 1 起）。
+ * @return The traditionally-numbered month; `std::nullopt` if `position` is out of range.
+ *         传统编号的月；`position` 越界时返回 `std::nullopt`。
+ */
+[[nodiscard]] inline auto month_at_position(const LunarYear& info, const uint8_t position) -> std::optional<TraditionalMonth> {
+  // `month_lengths.size()` is 12 or 13 by construction, so the cast cannot lose anything.
+  if (position < 1 or position > static_cast<uint8_t>(info.month_lengths.size())) {
+    return std::nullopt;
+  }
+  if (info.leap_month == 0 or position <= info.leap_month) {
+    return TraditionalMonth { .month = position, .is_leap = false };
+  }
+  if (position == info.leap_month + 1) {
+    return TraditionalMonth { .month = info.leap_month, .is_leap = true };
+  }
+  return TraditionalMonth { .month = static_cast<uint8_t>(position - 1), .is_leap = false };
 }
 
 

--- a/src/calendar/lunar/converter.hpp
+++ b/src/calendar/lunar/converter.hpp
@@ -44,6 +44,17 @@ using namespace calendar::lunar::common;
  * @brief  Converts between gregorian date and lunar date. 
  *         将公历日期和阴历日期进行转换。
  * @tparam algo The algorithm to use. 使用的算法。
+ * @note   Lunar months are **positional** in this interface: the month of a lunar
+ *         `year_month_day` is the 1-based index into the year's month sequence (12 or 13
+ *         entries), where a leap month takes its own position — not the traditional month
+ *         number, which this interface cannot express (there is no leap flag). E.g. lunar
+ *         2023 (leap 2nd month): month 3 is the leap 2nd month, and the traditional 3rd
+ *         month is month 4. Translate with `common::month_position` /
+ *         `common::month_at_position` (#130).
+ *         本接口的阴历月是位置序号：阴历 `year_month_day` 的「月」是该年 12/13 个月里
+ *         从 1 起的位置，闰月独占一位——不是传统编号（本接口没有闰月标记，表达不了）。
+ *         例：2023 年闰二月，月 3 = 闰二月，传统三月 = 月 4。与传统编号的互转见
+ *         `common::month_position` / `common::month_at_position`（#130）。
  */
 template <common::Algo algo>
 struct Converter {
@@ -72,6 +83,8 @@ struct Converter {
          检查输入的阴历日期是否有效，且在支持的范围内。 
    * @param lunar_date The lunar date. 阴历日期。
    * @return `true` if valid, otherwise `false`. 如果有效，返回 `true`，否则返回 `false`。
+   * @attention The month is the positional index (see `Converter`'s note): a leap month
+                takes its own position. 月份是位置序号（见 `Converter` 的注）：闰月独占一位。
    */
   [[nodiscard]] static auto is_valid_lunar(const year_month_day& lunar_date) -> bool {
     if (lunar_date < AlgoMetadata::bounds().first_lunar_date or 
@@ -97,7 +110,8 @@ struct Converter {
    * @fn gregorian_to_lunar 
    * @brief Converts gregorian date to lunar date. 将公历日期转换为阴历日期。 
    * @param gregorian_date The gregorian date. 公历日期。
-   * @return The optional lunar date. 阴历日期（optional）。
+   * @return The optional lunar date; its month is the positional index (see `Converter`'s note).
+              阴历日期（optional）；其「月」是位置序号（见 `Converter` 的注）。
    * @attention The input date should be in the supported range.
                 输入的日期需要在所支持的范围内。
   * @attention `std::nullopt` is returned if the input date is invalid. No exception is thrown.
@@ -156,7 +170,8 @@ struct Converter {
   /** 
    * @fn lunar_to_gregorian
    * @brief Converts lunar date to gregorian date. 将阴历日期转换为公历日期。 
-   * @param lunar_date The lunar date. 阴历日期。
+   * @param lunar_date The lunar date; its month is the positional index (see `Converter`'s note).
+              阴历日期；其「月」是位置序号（见 `Converter` 的注）。
    * @return The optional gregorian date. 公历日期（optional）。
    * @attention The input date should be in the supported range.
                 输入的日期需要在所支持的范围内。

--- a/src/calendar/lunar/converter.hpp
+++ b/src/calendar/lunar/converter.hpp
@@ -111,7 +111,7 @@ struct Converter {
    * @brief Converts gregorian date to lunar date. 将公历日期转换为阴历日期。 
    * @param gregorian_date The gregorian date. 公历日期。
    * @return The optional lunar date; its month is the positional index (see `Converter`'s note).
-              阴历日期（optional）；其「月」是位置序号（见 `Converter` 的注）。
+             阴历日期（optional）；其「月」是位置序号（见 `Converter` 的注）。
    * @attention The input date should be in the supported range.
                 输入的日期需要在所支持的范围内。
   * @attention `std::nullopt` is returned if the input date is invalid. No exception is thrown.
@@ -171,7 +171,7 @@ struct Converter {
    * @fn lunar_to_gregorian
    * @brief Converts lunar date to gregorian date. 将阴历日期转换为公历日期。 
    * @param lunar_date The lunar date; its month is the positional index (see `Converter`'s note).
-              阴历日期；其「月」是位置序号（见 `Converter` 的注）。
+                       阴历日期；其「月」是位置序号（见 `Converter` 的注）。
    * @return The optional gregorian date. 公历日期（optional）。
    * @attention The input date should be in the supported range.
                 输入的日期需要在所支持的范围内。

--- a/src/shared_lib/c_header_check.c
+++ b/src/shared_lib/c_header_check.c
@@ -69,3 +69,11 @@ _Static_assert(offsetof(ApparentSolarTime, year) == 4 && offsetof(ApparentSolarT
                offsetof(ApparentSolarTime, day) == 12 && offsetof(ApparentSolarTime, fraction) == 16 &&
                sizeof(ApparentSolarTime) == 24, "ApparentSolarTime layout drifted");
 
+_Static_assert(offsetof(LunarDate, year) == 4 && offsetof(LunarDate, month) == 8 &&
+               offsetof(LunarDate, is_leap) == 9 && offsetof(LunarDate, day) == 10 &&
+               sizeof(LunarDate) == 12, "LunarDate layout drifted");
+
+_Static_assert(offsetof(GregorianDate, year) == 4 && offsetof(GregorianDate, month) == 8 &&
+               offsetof(GregorianDate, day) == 9 && sizeof(GregorianDate) == 12,
+               "GregorianDate layout drifted");
+

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -35,6 +35,12 @@
  * version. And no dllexport/dllimport macros: `WINDOWS_EXPORT_ALL_SYMBOLS` exports
  * everything, and imports resolve implicitly against the import library.
  *
+ * ABI evolution policy (#129): struct layouts are frozen once shipped — sizes and
+ * offsets are pinned by `c_header_check.c` at compile time. Changing a field (type,
+ * order, or count) means a new major version, or a new function with a `_v2`-style
+ * name returning the new shape; existing layouts never move. New structs are born
+ * under this same freeze, and adding new functions never breaks the ABI.
+ *
  * Error contract: every function is `noexcept` at the boundary. Struct-returning
  * functions signal failure with `valid = false`; the rest return `0` / `false`.
  * On failure the Julian Day functions also record a thread-local message readable
@@ -297,8 +303,11 @@ typedef struct LunarYearInfo {
   int32_t  year;       /* Gregorian year of the first day of the lunar year. */
   uint8_t  month;      /* Gregorian month of the first day of the lunar year. */
   uint8_t  day;        /* Gregorian day of the first day of the lunar year. */
-  uint8_t  leap_month; /* The leap month (1-12), or 0 if there is none. */
-  uint16_t month_len;  /* Least 12/13 bits: 1 = 30-day month, 0 = 29-day month. */
+  uint8_t  leap_month; /* The leap month (1-12) in TRADITIONAL numbering, or 0 if none. */
+  uint16_t month_len;  /* Least 12/13 bits: 1 = 30-day month, 0 = 29-day month. Bits are
+                          indexed by the month's POSITION in the year — a leap month takes
+                          its own position — not by traditional numbering; the converter
+                          entries below speak traditional numbering + `is_leap`. */
 } LunarYearInfo;
 
 /**

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -35,11 +35,13 @@
  * version. And no dllexport/dllimport macros: `WINDOWS_EXPORT_ALL_SYMBOLS` exports
  * everything, and imports resolve implicitly against the import library.
  *
- * ABI evolution policy (#129): struct layouts are frozen once shipped — sizes and
- * offsets are pinned by `c_header_check.c` at compile time. Changing a field (type,
- * order, or count) means a new major version, or a new function with a `_v2`-style
- * name returning the new shape; existing layouts never move. New structs are born
- * under this same freeze, and adding new functions never breaks the ABI.
+ * ABI evolution policy (#129): within a major version, struct layouts never move —
+ * sizes and offsets are pinned by `c_header_check.c` at compile time, and a struct is
+ * frozen the moment it lands here. Changing a field (type, order, or count) or an
+ * existing function's signature means a new major version, or a `_v2`-named function
+ * returning a new, separately named struct. Adding a struct or a function never breaks
+ * the ABI; widening what an existing function accepts (as `algo` was widened to 3)
+ * does not either, narrowing does.
  *
  * Error contract: every function is `noexcept` at the boundary. Struct-returning
  * functions signal failure with `valid = false`; the rest return `0` / `false`.
@@ -303,11 +305,13 @@ typedef struct LunarYearInfo {
   int32_t  year;       /* Gregorian year of the first day of the lunar year. */
   uint8_t  month;      /* Gregorian month of the first day of the lunar year. */
   uint8_t  day;        /* Gregorian day of the first day of the lunar year. */
-  uint8_t  leap_month; /* The leap month (1-12) in TRADITIONAL numbering, or 0 if none. */
-  uint16_t month_len;  /* Least 12/13 bits: 1 = 30-day month, 0 = 29-day month. Bits are
-                          indexed by the month's POSITION in the year — a leap month takes
-                          its own position — not by traditional numbering; the converter
-                          entries below speak traditional numbering + `is_leap`. */
+  uint8_t  leap_month; /* The leap month (1-12) in **traditional** numbering, or 0 if none. */
+  uint16_t month_len;  /* Least 12/13 bits, one per month in calendar order (bit 0 = the first
+                          month): 1 = 30-day month, 0 = 29-day month. A leap month occupies a
+                          bit of its own, so with `leap_month = 2` the bits run 1, 2, leap 2,
+                          3, … `gregorian_to_lunar` / `lunar_to_gregorian` below instead speak
+                          traditional numbering + `is_leap`, where that leap month is
+                          `month = 2, is_leap = true`. */
 } LunarYearInfo;
 
 /**
@@ -340,8 +344,11 @@ typedef struct GregorianDate {
  * @param year The Gregorian year.
  * @param month The Gregorian month.
  * @param day The Gregorian day of the month.
- * @returns A `LunarDate` struct; `valid = false` when the date is invalid or outside the
- *          range `get_supported_lunar_year_range` reports for `algo`.
+ * @returns A `LunarDate` struct; `valid = false` when `algo` is unknown, the input is not a
+ *          real Gregorian date, or it falls outside the Gregorian span the algorithm covers —
+ *          that span runs from the first day of lunar year `start` to the last day of lunar
+ *          year `end` (`start`/`end` as `get_supported_lunar_year_range` reports them), so it
+ *          begins and ends mid-Gregorian-year at both ends.
  * @note The lunar month is in **traditional numbering** (1-12) plus the `is_leap` flag —
  *       a leap month carries its predecessor's number with `is_leap = true`: in lunar 2023
  *       (leap 2nd month), the leap 2nd month is `month = 2, is_leap = true`, and the
@@ -355,9 +362,9 @@ LunarDate gregorian_to_lunar(uint8_t algo, int32_t year, uint8_t month, uint8_t 
  * @param algo The algorithm. Expected to be 1, 2, or 3.
  * @param year The lunar year.
  * @param month The lunar month, in traditional numbering (1-12) — see `gregorian_to_lunar`.
- * @param is_leap Whether the month is the leap month; only the year's actual leap month may
- *                pass `true` (e.g. in lunar 2023 that is `month = 2`), and every `true` in a
- *                leap-less year fails.
+ * @param is_leap Whether the month is the leap month. `true` is accepted only on the year's
+ *                actual leap month — `month = 2` in lunar 2023, and no month at all in a year
+ *                that has none.
  * @param day The day of the lunar month.
  * @returns A `GregorianDate` struct; `valid = false` when the input does not name a real
  *          lunar date (bad `algo`, year out of range, no such leap month, day out of range).

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -41,8 +41,8 @@
  * existing function's signature means a new major version, or a `_v2`-named function
  * returning a new, separately named struct. Adding a struct or a function never breaks
  * the ABI; widening what an existing function accepts (as `algo` was widened to 3)
- * keeps both; narrowing it keeps the ABI but breaks the contract, and needs a new
- * major version just the same.
+ * breaks neither the ABI nor the contract; narrowing it keeps the ABI but breaks
+ * the contract, and needs a new major version just the same.
  *
  * Error contract: every function is `noexcept` at the boundary. Struct-returning
  * functions signal failure with `valid = false`; the rest return `0` / `false`.

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -310,6 +310,51 @@ typedef struct LunarYearInfo {
  */
 LunarYearInfo get_lunar_year_info(uint8_t algo, int32_t year);
 
+typedef struct LunarDate {
+  bool    valid;   /* Indicates if the result is valid. */
+  int32_t year;    /* The lunar year. */
+  uint8_t month;   /* The lunar month, in traditional numbering (1-12). */
+  bool    is_leap; /* Whether the month is the leap month. */
+  uint8_t day;     /* The day of the lunar month. */
+} LunarDate;
+
+typedef struct GregorianDate {
+  bool    valid; /* Indicates if the result is valid. */
+  int32_t year;  /* The year. */
+  uint8_t month; /* The month. */
+  uint8_t day;   /* The day. */
+} GregorianDate;
+
+/**
+ * @brief Convert a Gregorian date to a lunar date.
+ * @param algo The algorithm. Expected to be 1, 2, or 3.
+ * @param year The Gregorian year.
+ * @param month The Gregorian month.
+ * @param day The Gregorian day of the month.
+ * @returns A `LunarDate` struct; `valid = false` when the date is invalid or outside the
+ *          range `get_supported_lunar_year_range` reports for `algo`.
+ * @note The lunar month is in **traditional numbering** (1-12) plus the `is_leap` flag —
+ *       a leap month carries its predecessor's number with `is_leap = true`: in lunar 2023
+ *       (leap 2nd month), the leap 2nd month is `month = 2, is_leap = true`, and the
+ *       traditional 3rd month is `month = 3, is_leap = false`. This is NOT the positional
+ *       month index that `LunarYearInfo.month_len` is indexed by.
+ */
+LunarDate gregorian_to_lunar(uint8_t algo, int32_t year, uint8_t month, uint8_t day);
+
+/**
+ * @brief Convert a lunar date to a Gregorian date.
+ * @param algo The algorithm. Expected to be 1, 2, or 3.
+ * @param year The lunar year.
+ * @param month The lunar month, in traditional numbering (1-12) — see `gregorian_to_lunar`.
+ * @param is_leap Whether the month is the leap month; only the year's actual leap month may
+ *                pass `true` (e.g. in lunar 2023 that is `month = 2`), and every `true` in a
+ *                leap-less year fails.
+ * @param day The day of the lunar month.
+ * @returns A `GregorianDate` struct; `valid = false` when the input does not name a real
+ *          lunar date (bad `algo`, year out of range, no such leap month, day out of range).
+ */
+GregorianDate lunar_to_gregorian(uint8_t algo, int32_t year, uint8_t month, bool is_leap, uint8_t day);
+
 
 /* ---------- Delta T ---------- */
 

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -41,7 +41,8 @@
  * existing function's signature means a new major version, or a `_v2`-named function
  * returning a new, separately named struct. Adding a struct or a function never breaks
  * the ABI; widening what an existing function accepts (as `algo` was widened to 3)
- * does not either, narrowing does.
+ * keeps both; narrowing it keeps the ABI but breaks the contract, and needs a new
+ * major version just the same.
  *
  * Error contract: every function is `noexcept` at the boundary. Struct-returning
  * functions signal failure with `valid = false`; the rest return `0` / `false`.

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -287,7 +287,7 @@ typedef struct SupportedLunarYearRange {
 
 /**
  * @brief Get the supported lunar year range of the algorithm.
- * @param algo The algorithm. Expected to be 1 or 2.
+ * @param algo The algorithm. Expected to be 1, 2, or 3.
  * @returns A `SupportedLunarYearRange` struct.
  */
 SupportedLunarYearRange get_supported_lunar_year_range(uint8_t algo);
@@ -303,7 +303,7 @@ typedef struct LunarYearInfo {
 
 /**
  * @brief Get the lunar year information for the given year.
- * @param algo The algorithm. Expected to be 1 or 2.
+ * @param algo The algorithm. Expected to be 1, 2, or 3.
  * @param year The lunar year. Outside the range `get_supported_lunar_year_range` reports for
  *             `algo`, the result is `valid = false`.
  * @returns A `LunarYearInfo` struct.

--- a/src/shared_lib/lib_lunar.cpp
+++ b/src/shared_lib/lib_lunar.cpp
@@ -29,6 +29,63 @@
 #include "lunar/algo1.hpp"
 #include "lunar/algo2.hpp"
 #include "lunar/algo3.hpp"
+#include "lunar/converter.hpp"
+
+
+namespace {
+
+// #128: the C ABI speaks traditional month numbering + leap flag, while the converter core
+// speaks positional month indices (#130). The translation lives here, on the library side
+// of the boundary — the positional semantics stay out of the published ABI.
+
+template <calendar::lunar::common::Algo algo>
+auto convert_to_lunar(const int32_t year, const uint8_t month, const uint8_t day) -> std::optional<LunarDate> {
+  const auto converted = calendar::lunar::converter::Converter<algo>::gregorian_to_lunar(util::to_ymd(year, month, day));
+  if (not converted) {
+    return std::nullopt;
+  }
+
+  const auto [y, m, d] = util::from_ymd(*converted);
+  const auto& info = calendar::lunar::common::AlgoMetadata<algo>::get_info_for_year(y);
+  const auto traditional = calendar::lunar::common::month_at_position(info, static_cast<uint8_t>(m));
+  if (not traditional) {
+    return std::nullopt;
+  }
+
+  return LunarDate {
+    .valid   = true,
+    .year    = y,
+    .month   = traditional->month,
+    .is_leap = traditional->is_leap,
+    .day     = static_cast<uint8_t>(d),
+  };
+}
+
+template <calendar::lunar::common::Algo algo>
+auto convert_to_gregorian(const int32_t year, const uint8_t month, const bool is_leap, const uint8_t day) -> std::optional<GregorianDate> {
+  // An out-of-window year throws here; the export's catch turns that into `valid = false`.
+  const auto& info = calendar::lunar::common::AlgoMetadata<algo>::get_info_for_year(year);
+
+  const auto position = calendar::lunar::common::month_position(info, month, is_leap);
+  if (not position) {
+    return std::nullopt;
+  }
+
+  const auto converted = calendar::lunar::converter::Converter<algo>::lunar_to_gregorian(util::to_ymd(year, *position, day));
+  if (not converted) {
+    return std::nullopt;
+  }
+
+  const auto [y, m, d] = util::from_ymd(*converted);
+  return GregorianDate {
+    .valid = true,
+    .year  = y,
+    .month = static_cast<uint8_t>(m),
+    .day   = static_cast<uint8_t>(d),
+  };
+}
+
+} // namespace
 
 
 extern "C" {
@@ -105,6 +162,72 @@ auto get_lunar_year_info(const uint8_t algo, const int32_t year) -> LunarYearInf
   } catch (const std::exception& e) {
     // #67: `e.what()` is a message, not a format string — pass it as an argument.
     lib::info("Exception raised during execution of get_lunar_year_info, algo = {}, year = {}", algo, year);
+    lib::info("{}", e.what());
+    return {};
+  } catch (...) {
+    return {};
+  }
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- y/m/d is the natural date order, as in every neighbour.
+auto gregorian_to_lunar(const uint8_t algo, const int32_t year, const uint8_t month, const uint8_t day) -> LunarDate {
+  try {
+    if (algo != 1 and algo != 2 and algo != 3) {
+      throw std::runtime_error {
+        std::format("Unsupported algorithm: {}", algo)
+      };
+    }
+
+    const auto converted = std::invoke([=]() -> std::optional<LunarDate> {
+      if (algo == 1) {
+        return convert_to_lunar<calendar::lunar::common::Algo::ALGO_1>(year, month, day);
+      }
+      if (algo == 2) {
+        return convert_to_lunar<calendar::lunar::common::Algo::ALGO_2>(year, month, day);
+      }
+      return convert_to_lunar<calendar::lunar::common::Algo::ALGO_3>(year, month, day);
+    });
+
+    if (not converted) {
+      return {};
+    }
+    return *converted;
+
+  } catch (const std::exception& e) {
+    lib::info("Exception raised during execution of gregorian_to_lunar, algo = {}, year = {}, month = {}, day = {}", algo, year, month, day);
+    lib::info("{}", e.what());
+    return {};
+  } catch (...) {
+    return {};
+  }
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- y/m/d is the natural date order, as in every neighbour.
+auto lunar_to_gregorian(const uint8_t algo, const int32_t year, const uint8_t month, const bool is_leap, const uint8_t day) -> GregorianDate {
+  try {
+    if (algo != 1 and algo != 2 and algo != 3) {
+      throw std::runtime_error {
+        std::format("Unsupported algorithm: {}", algo)
+      };
+    }
+
+    const auto converted = std::invoke([=]() -> std::optional<GregorianDate> {
+      if (algo == 1) {
+        return convert_to_gregorian<calendar::lunar::common::Algo::ALGO_1>(year, month, is_leap, day);
+      }
+      if (algo == 2) {
+        return convert_to_gregorian<calendar::lunar::common::Algo::ALGO_2>(year, month, is_leap, day);
+      }
+      return convert_to_gregorian<calendar::lunar::common::Algo::ALGO_3>(year, month, is_leap, day);
+    });
+
+    if (not converted) {
+      return {};
+    }
+    return *converted;
+
+  } catch (const std::exception& e) {
+    lib::info("Exception raised during execution of lunar_to_gregorian, algo = {}, year = {}, month = {}, is_leap = {}, day = {}", algo, year, month, is_leap, day);
     lib::info("{}", e.what());
     return {};
   } catch (...) {

--- a/src/shared_lib/lib_lunar.cpp
+++ b/src/shared_lib/lib_lunar.cpp
@@ -62,6 +62,7 @@ auto convert_to_lunar(const int32_t year, const uint8_t month, const uint8_t day
 }
 
 template <calendar::lunar::common::Algo algo>
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- y/m/d(+leap) is the natural date order, as in every neighbour.
 auto convert_to_gregorian(const int32_t year, const uint8_t month, const bool is_leap, const uint8_t day) -> std::optional<GregorianDate> {
   // An out-of-window year throws here; the export's catch turns that into `valid = false`.
   const auto& info = calendar::lunar::common::AlgoMetadata<algo>::get_info_for_year(year);

--- a/src/shared_lib/lib_lunar.cpp
+++ b/src/shared_lib/lib_lunar.cpp
@@ -28,6 +28,7 @@
 
 #include "lunar/algo1.hpp"
 #include "lunar/algo2.hpp"
+#include "lunar/algo3.hpp"
 
 
 extern "C" {
@@ -51,6 +52,14 @@ auto get_supported_lunar_year_range(const uint8_t algo) -> SupportedLunarYearRan
     };
   }
 
+  if (algo == 3) {
+    return {
+      .valid = true,
+      .start = calendar::lunar::algo3::START_YEAR,
+      .end   = calendar::lunar::algo3::END_YEAR,
+    };
+  }
+
   return {};
 }
 
@@ -58,7 +67,7 @@ auto get_lunar_year_info(const uint8_t algo, const int32_t year) -> LunarYearInf
   using namespace std::views;
   
   try {
-    if (algo != 1 and algo != 2) {
+    if (algo != 1 and algo != 2 and algo != 3) {
       throw std::runtime_error {
         std::format("Unsupported algorithm: {}", algo)
       };
@@ -68,7 +77,10 @@ auto get_lunar_year_info(const uint8_t algo, const int32_t year) -> LunarYearInf
       if (algo == 1) {
         return calendar::lunar::algo1::calc_lunar_year(year);
       }
-      return calendar::lunar::algo2::get_info_for_year(year);
+      if (algo == 2) {
+        return calendar::lunar::algo2::get_info_for_year(year);
+      }
+      return calendar::lunar::algo3::calc_lunar_year(year);
     });
 
     const auto [y, m, d] = util::from_ymd(raw.date_of_first_day);

--- a/src/test/lunar/common_test.cpp
+++ b/src/test/lunar/common_test.cpp
@@ -86,6 +86,7 @@ TEST(LunarCommon, MonthTranslationRoundTrip) {
     for (uint32_t pos = 1; pos <= info.month_lengths.size(); ++pos) {
       const auto tm = month_at_position(info, static_cast<uint8_t>(pos));
       ASSERT_TRUE(tm.has_value());
+      // NOLINTNEXTLINE(bugprone-unchecked-optional-access) -- guarded by the ASSERT_TRUE above.
       EXPECT_EQ(month_position(info, tm->month, tm->is_leap), pos);
     }
   }

--- a/src/test/lunar/common_test.cpp
+++ b/src/test/lunar/common_test.cpp
@@ -29,8 +29,8 @@
 namespace calendar::lunar::common::test {
 
 // Provenance of the 2023 pins: lunar 2023 carries a leap 2nd month (闰二月) — HKO data
-// (https://www.hko.gov.hk/sc/gts/time/conversion.htm) baked into algo1's table, which covers
-// 1901-2100; algo3's baked entry for 2023 must agree.
+// (https://www.hko.gov.hk/sc/gts/time/conversion.htm, published for 1901-2100) baked into
+// algo1's table (1901-2099); algo3's baked entry for 2023 must agree.
 TEST(LunarCommon, Leap2023DataAgreement) {
   EXPECT_EQ(algo1::calc_lunar_year(2023).leap_month, 2);
   EXPECT_EQ(algo3::calc_lunar_year(2023).leap_month, 2);
@@ -43,8 +43,8 @@ TEST(LunarCommon, MonthPositionLeapYear) {
 
   EXPECT_EQ(month_position(info2023, 1, false), 1);
   EXPECT_EQ(month_position(info2023, 2, false), 2);
-  EXPECT_EQ(month_position(info2023, 2, true), 3);  // 闰二月 = 位置 3
-  EXPECT_EQ(month_position(info2023, 3, false), 4); // 传统三月 = 位置 4
+  EXPECT_EQ(month_position(info2023, 2, true), 3);  // leap 2nd month (闰二月) = position 3
+  EXPECT_EQ(month_position(info2023, 3, false), 4); // traditional 3rd month = position 4
   EXPECT_EQ(month_position(info2023, 12, false), 13);
 }
 

--- a/src/test/lunar/common_test.cpp
+++ b/src/test/lunar/common_test.cpp
@@ -1,0 +1,94 @@
+/*
+ * CelestialCalendar: 
+ *   A C++23-style library that performs astronomical calculations and date conversions among various calendars,
+ *   including Gregorian, Lunar, and Chinese Ganzhi calendars.
+ * 
+ * Copyright (C) 2026 Ningqi Wang (0xf3cd)
+ * Email: nq.maigre@gmail.com
+ * Repo : https://github.com/0xf3cd/celestial-calendar
+ *  
+ * This project is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This project is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this project. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+#include "lunar/algo1.hpp"
+#include "lunar/algo3.hpp"
+#include "lunar/common.hpp"
+
+namespace calendar::lunar::common::test {
+
+// Provenance of the 2023 pins: lunar 2023 carries a leap 2nd month (闰二月) — HKO data
+// (https://www.hko.gov.hk/sc/gts/time/conversion.htm) baked into algo1's table, which covers
+// 1901-2100; algo3's baked entry for 2023 must agree.
+TEST(LunarCommon, Leap2023DataAgreement) {
+  EXPECT_EQ(algo1::calc_lunar_year(2023).leap_month, 2);
+  EXPECT_EQ(algo3::calc_lunar_year(2023).leap_month, 2);
+}
+
+TEST(LunarCommon, MonthPositionLeapYear) {
+  const auto info2023 = algo1::calc_lunar_year(2023);
+  ASSERT_EQ(info2023.leap_month, 2);
+  ASSERT_EQ(info2023.month_lengths.size(), 13);
+
+  EXPECT_EQ(month_position(info2023, 1, false), 1);
+  EXPECT_EQ(month_position(info2023, 2, false), 2);
+  EXPECT_EQ(month_position(info2023, 2, true), 3);  // 闰二月 = 位置 3
+  EXPECT_EQ(month_position(info2023, 3, false), 4); // 传统三月 = 位置 4
+  EXPECT_EQ(month_position(info2023, 12, false), 13);
+}
+
+TEST(LunarCommon, MonthPositionRejectsBadInput) {
+  const auto info2023 = algo1::calc_lunar_year(2023);
+
+  const auto info2024 = algo1::calc_lunar_year(2024);
+  ASSERT_EQ(info2024.leap_month, 0); // 2024 has no leap month.
+  ASSERT_EQ(info2024.month_lengths.size(), 12);
+
+  EXPECT_EQ(month_position(info2023, 0, false), std::nullopt);
+  EXPECT_EQ(month_position(info2023, 13, false), std::nullopt);
+  EXPECT_EQ(month_position(info2023, 5, true), std::nullopt); // 2023's leap month is the 2nd, not the 5th.
+  EXPECT_EQ(month_position(info2024, 2, true), std::nullopt); // no leap month in 2024 at all.
+}
+
+TEST(LunarCommon, MonthAtPosition) {
+  const auto info2023 = algo1::calc_lunar_year(2023);
+
+  EXPECT_EQ(month_at_position(info2023, 1), (TraditionalMonth { 1, false }));
+  EXPECT_EQ(month_at_position(info2023, 2), (TraditionalMonth { 2, false }));
+  EXPECT_EQ(month_at_position(info2023, 3), (TraditionalMonth { 2, true }));
+  EXPECT_EQ(month_at_position(info2023, 4), (TraditionalMonth { 3, false }));
+  EXPECT_EQ(month_at_position(info2023, 13), (TraditionalMonth { 12, false }));
+
+  EXPECT_EQ(month_at_position(info2023, 0), std::nullopt);
+  EXPECT_EQ(month_at_position(info2023, 14), std::nullopt);
+
+  const auto info2024 = algo1::calc_lunar_year(2024);
+  EXPECT_EQ(month_at_position(info2024, 12), (TraditionalMonth { 12, false }));
+  EXPECT_EQ(month_at_position(info2024, 13), std::nullopt);
+}
+
+TEST(LunarCommon, MonthTranslationRoundTrip) {
+  // Conservation: position → traditional → position is the identity on every valid
+  // position of every year algo1 covers.
+  for (int32_t year = algo1::START_YEAR; year <= algo1::END_YEAR; ++year) {
+    const auto info = algo1::calc_lunar_year(year);
+    for (uint32_t pos = 1; pos <= info.month_lengths.size(); ++pos) {
+      const auto tm = month_at_position(info, static_cast<uint8_t>(pos));
+      ASSERT_TRUE(tm.has_value());
+      EXPECT_EQ(month_position(info, tm->month, tm->is_leap), pos);
+    }
+  }
+}
+
+} // namespace calendar::lunar::common::test

--- a/src/test/shared_lib/cabi_smoke_test.cpp
+++ b/src/test/shared_lib/cabi_smoke_test.cpp
@@ -330,11 +330,6 @@ TEST(CAbiSmoke, LunarConverter) {
   EXPECT_EQ(trad3.month, 3U);
   EXPECT_FALSE(trad3.is_leap);
 
-  // The accepted Gregorian window spills past the lunar-year range at both ends: it starts at
-  // lunar 1901's first day (1901-02-19) and ends at lunar 2099's last day (in 2100).
-  EXPECT_FALSE(gregorian_to_lunar(1, 1901, 1, 1).valid);
-  EXPECT_TRUE(gregorian_to_lunar(1, 2100, 1, 25).valid);
-
   const LunarDate via_algo3 = gregorian_to_lunar(3, 2023, 3, 22);
   ASSERT_TRUE(via_algo3.valid);
   EXPECT_EQ(via_algo3.month, 2U);
@@ -352,6 +347,10 @@ TEST(CAbiSmoke, LunarConverter) {
   EXPECT_EQ(back2.day, 20U);
 
   EXPECT_FALSE(gregorian_to_lunar(9, 2023, 3, 22).valid);
+  // The accepted Gregorian window is offset from the lunar-year range at both ends: it opens on
+  // lunar 1901's first day (1901-02-19) and closes on lunar 2099's last day (2100-02-08).
+  EXPECT_FALSE(gregorian_to_lunar(1, 1901, 1, 1).valid);
+  EXPECT_TRUE(gregorian_to_lunar(1, 2100, 1, 25).valid);
   EXPECT_FALSE(gregorian_to_lunar(1, 2101, 1, 1).valid);
   EXPECT_FALSE(gregorian_to_lunar(1, 2023, 13, 1).valid);
   EXPECT_FALSE(lunar_to_gregorian(9, 2023, 2, true, 1).valid);

--- a/src/test/shared_lib/cabi_smoke_test.cpp
+++ b/src/test/shared_lib/cabi_smoke_test.cpp
@@ -283,8 +283,14 @@ TEST(CAbiSmoke, Lunar) {
   ASSERT_TRUE(range2.valid);
   EXPECT_LT(range2.start, range2.end);
 
+  // #128: algo=3 is now exported (1600-2199); the pin that held it "unsupported" flips here.
+  const SupportedLunarYearRange range3 = get_supported_lunar_year_range(3);
+  ASSERT_TRUE(range3.valid);
+  EXPECT_EQ(range3.start, 1600);
+  EXPECT_EQ(range3.end, 2199);
+
   EXPECT_FALSE(get_supported_lunar_year_range(0).valid);
-  EXPECT_FALSE(get_supported_lunar_year_range(3).valid);
+  EXPECT_FALSE(get_supported_lunar_year_range(4).valid);
 
   EXPECT_TRUE(get_lunar_year_info(2, 2024).valid);
   EXPECT_FALSE(get_lunar_year_info(9, 2024).valid); // unsupported algorithm
@@ -300,6 +306,11 @@ TEST(CAbiSmoke, Lunar) {
   EXPECT_TRUE(get_lunar_year_info(2, range2.end).valid);
   EXPECT_FALSE(get_lunar_year_info(2, range2.start - 1).valid);
   EXPECT_FALSE(get_lunar_year_info(2, range2.end + 1).valid);
+
+  EXPECT_TRUE(get_lunar_year_info(3, range3.start).valid);
+  EXPECT_TRUE(get_lunar_year_info(3, range3.end).valid);
+  EXPECT_FALSE(get_lunar_year_info(3, range3.start - 1).valid);
+  EXPECT_FALSE(get_lunar_year_info(3, range3.end + 1).valid);
 }
 
 

--- a/src/test/shared_lib/cabi_smoke_test.cpp
+++ b/src/test/shared_lib/cabi_smoke_test.cpp
@@ -314,9 +314,9 @@ TEST(CAbiSmoke, Lunar) {
 }
 
 
-// #128: bidirectional conversion, traditional numbering + leap flag. Golden: lunar 2023 has a
-// leap 2nd month (闰二月), and 闰二月初一 = 2023-03-22 / 三月初一 = 2023-04-20 — HKO data,
-// algo1's and algo3's baked tables agree (pinned in `LunarCommon.Leap2023DataAgreement`).
+// Golden: lunar 2023 has a leap 2nd month (闰二月), and 闰二月初一 (its 1st day) = 2023-03-22 /
+// 三月初一 = 2023-04-20 — HKO data, algo1's and algo3's baked tables agree
+// (pinned in `LunarCommon.Leap2023DataAgreement`).
 TEST(CAbiSmoke, LunarConverter) {
   const LunarDate leap2 = gregorian_to_lunar(1, 2023, 3, 22);
   ASSERT_TRUE(leap2.valid);
@@ -330,7 +330,11 @@ TEST(CAbiSmoke, LunarConverter) {
   EXPECT_EQ(trad3.month, 3U);
   EXPECT_FALSE(trad3.is_leap);
 
-  // algo3's table agrees with algo1's for 2023, so the same date converts the same way.
+  // The accepted Gregorian window spills past the lunar-year range at both ends: it starts at
+  // lunar 1901's first day (1901-02-19) and ends at lunar 2099's last day (in 2100).
+  EXPECT_FALSE(gregorian_to_lunar(1, 1901, 1, 1).valid);
+  EXPECT_TRUE(gregorian_to_lunar(1, 2100, 1, 25).valid);
+
   const LunarDate via_algo3 = gregorian_to_lunar(3, 2023, 3, 22);
   ASSERT_TRUE(via_algo3.valid);
   EXPECT_EQ(via_algo3.month, 2U);
@@ -347,8 +351,6 @@ TEST(CAbiSmoke, LunarConverter) {
   EXPECT_EQ(back2.month, 4U);
   EXPECT_EQ(back2.day, 20U);
 
-  // Invalid matrix: bad algo / out-of-window year / leap forced on a leap-less year /
-  // leap flag on the wrong month / day past the month's length / bad Gregorian month.
   EXPECT_FALSE(gregorian_to_lunar(9, 2023, 3, 22).valid);
   EXPECT_FALSE(gregorian_to_lunar(1, 2101, 1, 1).valid);
   EXPECT_FALSE(gregorian_to_lunar(1, 2023, 13, 1).valid);

--- a/src/test/shared_lib/cabi_smoke_test.cpp
+++ b/src/test/shared_lib/cabi_smoke_test.cpp
@@ -347,10 +347,14 @@ TEST(CAbiSmoke, LunarConverter) {
   EXPECT_EQ(back2.day, 20U);
 
   EXPECT_FALSE(gregorian_to_lunar(9, 2023, 3, 22).valid);
-  // The accepted Gregorian window is offset from the lunar-year range at both ends: it opens on
+  // The accepted Gregorian window does not line up with Gregorian years 1901-2099: it opens on
   // lunar 1901's first day (1901-02-19) and closes on lunar 2099's last day (2100-02-08).
   EXPECT_FALSE(gregorian_to_lunar(1, 1901, 1, 1).valid);
+  EXPECT_FALSE(gregorian_to_lunar(1, 1901, 2, 18).valid);
+  EXPECT_TRUE(gregorian_to_lunar(1, 1901, 2, 19).valid);
   EXPECT_TRUE(gregorian_to_lunar(1, 2100, 1, 25).valid);
+  EXPECT_TRUE(gregorian_to_lunar(1, 2100, 2, 8).valid);
+  EXPECT_FALSE(gregorian_to_lunar(1, 2100, 2, 9).valid);
   EXPECT_FALSE(gregorian_to_lunar(1, 2101, 1, 1).valid);
   EXPECT_FALSE(gregorian_to_lunar(1, 2023, 13, 1).valid);
   EXPECT_FALSE(lunar_to_gregorian(9, 2023, 2, true, 1).valid);

--- a/src/test/shared_lib/cabi_smoke_test.cpp
+++ b/src/test/shared_lib/cabi_smoke_test.cpp
@@ -314,6 +314,52 @@ TEST(CAbiSmoke, Lunar) {
 }
 
 
+// #128: bidirectional conversion, traditional numbering + leap flag. Golden: lunar 2023 has a
+// leap 2nd month (闰二月), and 闰二月初一 = 2023-03-22 / 三月初一 = 2023-04-20 — HKO data,
+// algo1's and algo3's baked tables agree (pinned in `LunarCommon.Leap2023DataAgreement`).
+TEST(CAbiSmoke, LunarConverter) {
+  const LunarDate leap2 = gregorian_to_lunar(1, 2023, 3, 22);
+  ASSERT_TRUE(leap2.valid);
+  EXPECT_EQ(leap2.year, 2023);
+  EXPECT_EQ(leap2.month, 2U);
+  EXPECT_TRUE(leap2.is_leap);
+  EXPECT_EQ(leap2.day, 1U);
+
+  const LunarDate trad3 = gregorian_to_lunar(1, 2023, 4, 20);
+  ASSERT_TRUE(trad3.valid);
+  EXPECT_EQ(trad3.month, 3U);
+  EXPECT_FALSE(trad3.is_leap);
+
+  // algo3's table agrees with algo1's for 2023, so the same date converts the same way.
+  const LunarDate via_algo3 = gregorian_to_lunar(3, 2023, 3, 22);
+  ASSERT_TRUE(via_algo3.valid);
+  EXPECT_EQ(via_algo3.month, 2U);
+  EXPECT_TRUE(via_algo3.is_leap);
+
+  const GregorianDate back1 = lunar_to_gregorian(1, 2023, 2, true, 1);
+  ASSERT_TRUE(back1.valid);
+  EXPECT_EQ(back1.year, 2023);
+  EXPECT_EQ(back1.month, 3U);
+  EXPECT_EQ(back1.day, 22U);
+
+  const GregorianDate back2 = lunar_to_gregorian(1, 2023, 3, false, 1);
+  ASSERT_TRUE(back2.valid);
+  EXPECT_EQ(back2.month, 4U);
+  EXPECT_EQ(back2.day, 20U);
+
+  // Invalid matrix: bad algo / out-of-window year / leap forced on a leap-less year /
+  // leap flag on the wrong month / day past the month's length / bad Gregorian month.
+  EXPECT_FALSE(gregorian_to_lunar(9, 2023, 3, 22).valid);
+  EXPECT_FALSE(gregorian_to_lunar(1, 2101, 1, 1).valid);
+  EXPECT_FALSE(gregorian_to_lunar(1, 2023, 13, 1).valid);
+  EXPECT_FALSE(lunar_to_gregorian(9, 2023, 2, true, 1).valid);
+  EXPECT_FALSE(lunar_to_gregorian(1, 2100, 1, false, 1).valid);
+  EXPECT_FALSE(lunar_to_gregorian(1, 2024, 2, true, 1).valid); // 2024 has no leap month
+  EXPECT_FALSE(lunar_to_gregorian(1, 2023, 5, true, 1).valid); // 2023's leap month is the 2nd
+  EXPECT_FALSE(lunar_to_gregorian(1, 2023, 2, true, 30).valid); // 闰二月 has 29 days
+}
+
+
 // #67: `std::println` throws `std::system_error` on a failed stream — with stdout closed,
 // the log call inside a catch handler must not escape and terminate the host.
 TEST(CAbiSmoke, LoggingSurvivesClosedStdout) {

--- a/statistics/common.py
+++ b/statistics/common.py
@@ -505,6 +505,7 @@ def new_moons_in_year(year: int) -> NewMoons:
 class LunarAlgo(Enum):
   ALGO_1 = 1
   ALGO_2 = 2
+  ALGO_3 = 3
 
 class _SupportedLunarYearRange(Structure):
   _fields_ = [

--- a/statistics/common.py
+++ b/statistics/common.py
@@ -584,4 +584,77 @@ def get_lunar_year_info(algo: LunarAlgo, year: int) -> LunarYearInfo:
     month_lengths = month_lengths,
   )
 
+
+class _LunarDate(Structure):
+  _fields_ = [
+    ("valid", c_bool),
+    ("year", c_int32),
+    ("month", c_uint8),
+    ("is_leap", c_bool),
+    ("day", c_uint8),
+  ]
+
+class _GregorianDate(Structure):
+  _fields_ = [
+    ("valid", c_bool),
+    ("year", c_int32),
+    ("month", c_uint8),
+    ("day", c_uint8),
+  ]
+
+LIB.gregorian_to_lunar.argtypes = [c_uint8, c_int32, c_uint8, c_uint8]
+LIB.gregorian_to_lunar.restype = _LunarDate
+
+LIB.lunar_to_gregorian.argtypes = [c_uint8, c_int32, c_uint8, c_bool, c_uint8]
+LIB.lunar_to_gregorian.restype = _GregorianDate
+
+@dataclass
+class LunarDate:
+  year: int
+  month: int    # Traditional numbering (1-12). 传统编号。
+  is_leap: bool # Whether the month is the leap month.
+  day: int
+
+def gregorian_to_lunar(algo: LunarAlgo, year: int, month: int, day: int) -> LunarDate:
+  """
+  Convert a Gregorian date to a lunar date.
+
+  @param algo The algorithm to use.
+  @param year The Gregorian year.
+  @param month The Gregorian month.
+  @param day The Gregorian day of the month.
+  @returns A `LunarDate` instance; the month is in traditional numbering (1-12) plus
+           `is_leap` — e.g. 2023-03-22 is the leap 2nd month of lunar 2023
+           (month = 2, is_leap = True).
+  """
+  result = LIB.gregorian_to_lunar(algo.value, year, month, day)
+
+  if not result.valid:
+    raise ValueError("Error occurred in gregorian_to_lunar.")
+
+  return LunarDate(
+    year = result.year,
+    month = result.month,
+    is_leap = result.is_leap,
+    day = result.day,
+  )
+
+def lunar_to_gregorian(algo: LunarAlgo, year: int, month: int, is_leap: bool, day: int) -> date:
+  """
+  Convert a lunar date to a Gregorian date.
+
+  @param algo The algorithm to use.
+  @param year The lunar year.
+  @param month The lunar month, in traditional numbering (1-12).
+  @param is_leap Whether the month is the leap month.
+  @param day The day of the lunar month.
+  @returns A `date` instance representing the Gregorian date.
+  """
+  result = LIB.lunar_to_gregorian(algo.value, year, month, is_leap, day)
+
+  if not result.valid:
+    raise ValueError("Error occurred in lunar_to_gregorian.")
+
+  return date(result.year, result.month, result.day)
+
 #endregion

--- a/statistics/common.py
+++ b/statistics/common.py
@@ -594,24 +594,13 @@ class _LunarDate(Structure):
     ("day", c_uint8),
   ]
 
-class _GregorianDate(Structure):
-  _fields_ = [
-    ("valid", c_bool),
-    ("year", c_int32),
-    ("month", c_uint8),
-    ("day", c_uint8),
-  ]
-
 LIB.gregorian_to_lunar.argtypes = [c_uint8, c_int32, c_uint8, c_uint8]
 LIB.gregorian_to_lunar.restype = _LunarDate
-
-LIB.lunar_to_gregorian.argtypes = [c_uint8, c_int32, c_uint8, c_bool, c_uint8]
-LIB.lunar_to_gregorian.restype = _GregorianDate
 
 @dataclass
 class LunarDate:
   year: int
-  month: int    # Traditional numbering (1-12). 传统编号。
+  month: int    # Traditional numbering (1-12).
   is_leap: bool # Whether the month is the leap month.
   day: int
 
@@ -639,6 +628,18 @@ def gregorian_to_lunar(algo: LunarAlgo, year: int, month: int, day: int) -> Luna
     day = result.day,
   )
 
+
+class _GregorianDate(Structure):
+  _fields_ = [
+    ("valid", c_bool),
+    ("year", c_int32),
+    ("month", c_uint8),
+    ("day", c_uint8),
+  ]
+
+LIB.lunar_to_gregorian.argtypes = [c_uint8, c_int32, c_uint8, c_bool, c_uint8]
+LIB.lunar_to_gregorian.restype = _GregorianDate
+
 def lunar_to_gregorian(algo: LunarAlgo, year: int, month: int, is_leap: bool, day: int) -> date:
   """
   Convert a lunar date to a Gregorian date.
@@ -646,7 +647,8 @@ def lunar_to_gregorian(algo: LunarAlgo, year: int, month: int, is_leap: bool, da
   @param algo The algorithm to use.
   @param year The lunar year.
   @param month The lunar month, in traditional numbering (1-12).
-  @param is_leap Whether the month is the leap month.
+  @param is_leap Whether the month is the leap month; only the year's actual leap month
+                 may be flagged, and a leap-less year has none.
   @param day The day of the lunar month.
   @returns A `date` instance representing the Gregorian date.
   """


### PR DESCRIPTION
C ABI 导出与演化批。主题是**把 lunar converter 导出到 C ABI、给 ABI 立演化政策、把月份编号的两套语义在文档与类型上说破** —— 外加给 `statistics/common.py` 的 ctypes 镜像补上两道闸门(本批认领)。

**十个提交 · 13 文件 · +915/−12 · 测试 214 → 220。**

Closes #128
Closes #129
Closes #130

---

## #128:导出 converter,放开 algo3

新入口 +2、新结构体 +2,月口径 = **传统编号 + `is_leap`**;位置序号语义债不进 ABI,位置↔传统的翻译在 lib 层完成:

```c
typedef struct LunarDate     { bool valid; int32_t year; uint8_t month; bool is_leap; uint8_t day; } LunarDate;
typedef struct GregorianDate { bool valid; int32_t year; uint8_t month; uint8_t day; } GregorianDate;

LunarDate     gregorian_to_lunar(uint8_t algo, int32_t year, uint8_t month, uint8_t day);
GregorianDate lunar_to_gregorian(uint8_t algo, int32_t year, uint8_t month, bool is_leap, uint8_t day);
```

- 无 `is_valid_*` 入口;无效输入 → `valid = false`,与既有 23 个入口的 `return {};` 失败路径同款。
- API 注释写清口径指引,含 2023 闰二月的具体例子(2023-03-22 = 闰二月初一 → `month=2, is_leap=true`)。
- **algo 参数接受 1/2/3**:两处 "Expected to be 1 or 2" 注释改口径、`lib_lunar.cpp` 的年级别硬限放开并加 algo3 分支;`cabi_smoke_test.cpp` 那条「algo=3 无效」的钉翻面,端点 1600/2199 从 ABI 读回再钉。
- #128 正文「#70 落地后再导出 algo3」的先后建议已获显式豁免:Gate 1 已实证 baked 表与当前默认 ΔT 零差异,P5b 第 2 节交付的是 provenance 注记不是数据修正,表不会变。

## #129:ABI 演化政策

`celestial.h` 头注释块加「ABI 演化政策」段,与「无前缀符号策略」并列:**布局冻结;字段变更 = 新 major 或 `_v2` 新函数名;新增函数永不破坏;widening 不破坏、narrowing 破契约(以本 PR 的 algo 放开为例)**。零结构体改动、不加 reserved —— 新增的 `LunarDate`/`GregorianDate` 出生即受同一政策约束。

## #130:月份语义双侧写破 + 双向 helper

- **C++ 侧**:`converter.hpp` 四个 doc 块写破位置序号语义;新 helper `month_position` / `month_at_position`(住 `common.hpp`,返回 `std::optional` / `TraditionalMonth`,可失败而不静默映射)。
- **C 侧**:`celestial.h` 农历节写破三件事 —— `month_len` 位图**按位置序号索引**(bit 0 = 正月)、`LunarYearInfo.leap_month` 是**传统编号**、新入口说**传统编号 + is_leap**。
- `is_valid_lunar` 语义与既有钉版**不动**:#130 那句「校验路径用传统编号」按字面做是行为变更(钉版要翻面),超出文档/helper 范畴;语义债留待单独立项。
- 钉语义测试:2023 闰二月双向映射(位置 3 = 闰二月、传统三月 = 位置 4),HKO 金标。

## 两道新闸门(common.py 镜像,本批认领)

- **`./linter.py --abi-layout`(挂 linters 腿)**:ast 静态解析 `_fields_`(不 import common.py —— 它模块级 `CDLL`,linters 腿无构建产物),三层对拍:struct 集合相等(双向)→ `cc` 编译运行的真值 sizeof/offset → 类型名映射(堵纯布局看不见的同宽对调:`c_int32`↔`c_uint32`、`c_bool`↔`c_uint8`)。**上线前突变六针全红**(换序/改宽/改符号/同宽对调/删字段/删镜像类)。
- **`./linter.py --ctypes-smoke`(挂 test-ubuntu-clang 腿,构建后一步)**:R1 闸门区分力席登记的缺口 —— 布局闸门不执行包装函数,**包装体填错字段(布局绿 + C ABI 测试绿也看不见)此前没有自动化执行路径**。载真 .so 实跑,HKO 金标(与 `cabi_smoke_test.cpp` 同源)双向对拍 + algo3 range + 负例共 10 例。**突变两针全红**(包装体 month/day 对调、LIB 实参对调)。缺构建产物时红而不跳。
- `c_header_check.c` +2 组 `_Static_assert`(sizeof + offset),覆盖两个新结构体。

## 审阅

**R1 五席,T1 并行**(正确性清单 grok · 正确性盲审 fable · ABI/风格 opus · 减法 grok · 闸门区分力 grok)。清单席 **NO FINDINGS**(六攻击面执行式扫过);最高置信信号是 **fable 与 opus 独立撞同一处**:`gregorian_to_lunar` 的 @returns 把受理窗口写成了阴历年范围,而输入是公历 —— 两端接缝都反(2100-01-25 实可转、1901-01-01 实不可转,ctypes 打真 .so 实证)。**采 16 驳 4**,判据逐条记台账。

**R2 → R4 收敛轮**(双席 → 单席 → 单席,`FIXES VERIFIED`),修复批 ×3。R2 的新断言重审条款兑现:抓到的三条全是**修复批自己新说出口的话**(混 ABI 与契约的措辞、被下一行证伪的接缝注释、落位劈开金标簇的钉)。R3 顺手把受理窗口四个端点日期钉成测试(注释与测试等精度,腐烂有信号)。

## 验收

- `--clean --cmake --build --test` EXIT 0;**直跑 `build/test/*`:220 全过、0 个二进制失败**,与 `TEST(` 宏计数 **220** 对账相等(不信 ctest 的数字)
- `linter.py --ruff --abi-layout --ctypes-smoke` EXIT 0(13 structs / 10 cases)
- 钉版 clang-tidy 18.1.8 对改动 TU EXIT 0(本机门禁曾漏跑 clang-tidy 致 CI 红一次,`be83a8d` 前进修复,此后每提交补跑)
- 突变针谱:布局闸门 6/6 红、ctypes 探针 2/2 红(均先核未突变基线绿、红色为闸门自身输出)
- ctypes 功能探针:2023 双向 + algo3 range + 负例,EXIT 0

## 已知限制(刻意不修,理由在案)

- 布局闸门**不守 argtypes/restype**(#85 那类错由 `--ctypes-smoke` 的运行时面 + 人工审兜底,本 PR 两个新包装已被盲审席逐行审过)。
- `c_header_check.c` 只钉 sizeof/offset;同宽类型身份由 `--abi-layout` 类型名层补,两道闸在同一 CI 面互补。
- `--ctypes-smoke` 覆盖两个新包装 + range 入口;既有包装函数仍无执行路径(**存量债,非本 PR 引入**),留待后续。
- 前缀/导出宏/visibility/SOVERSION/install 全归 P7b(#91),不在本 PR。
