### PR TITLE
fix(calendar): jieqi 年份守卫 —— 截断的静默错答案变成 out_of_range

### DIFF
--- a/src/calendar/jieqi.hpp
+++ b/src/calendar/jieqi.hpp
@@ -205,19 +205,21 @@ static_assert("大寒" == JIEQI_NAME.at(to_index(Jieqi::大寒)));
 
 /**
  * @brief Get the JDE for the given `year` and `jieqi`.
- * @param year The year, in gregorian calendar, in [1, 32767].
+ * @param year The gregorian year, in [1, 32766].
  * @param jq The jieqi.
  * @return The JDE (Julian Ephemeris Day).
- * @throw std::out_of_range if `year` is outside [1, 32767], or `jq` is not a valid Jieqi.
+ * @throw std::out_of_range if `year` is outside [1, 32766], or `jq` is not a valid Jieqi.
  * @throw std::runtime_error if the root search does not yield exactly one root.
  */
 [[nodiscard]] inline auto calc_jieqi_jde(const int32_t year, const Jieqi jq) -> double {
-  // A representability guard, not an accuracy one: the conversion chain wraps years past
-  // 32767 (`std::chrono::year` is a `short`) into silently wrong answers — and the cached
-  // wrapper would store them under the *unwrapped* key.
-  if (year < 1 or year > static_cast<int32_t>(static_cast<int>(std::chrono::year::max()))) {
+  // A representability guard, not an accuracy one: `std::chrono::year` stores an unspecified
+  // value beyond ±32767, and the conversion chain turns that into silently wrong answers —
+  // the cached wrapper would store them under the *unwrapped* key. The root search brackets
+  // with `year + 1`, so the usable ceiling is one below `year::max()`.
+  constexpr int32_t MAX_YEAR = static_cast<int32_t>(std::chrono::year::max()) - 1;
+  if (year < 1 or year > MAX_YEAR) {
     throw std::out_of_range {
-      std::vformat("The year {} is out of the range [1, 32767].", std::make_format_args(year))
+      std::vformat("The year {} is outside [1, {}].", std::make_format_args(year, MAX_YEAR))
     };
   }
 
@@ -238,10 +240,10 @@ static_assert("大寒" == JIEQI_NAME.at(to_index(Jieqi::大寒)));
 
 /**
  * @brief Get the JDE for the given `year` and `jieqi`, using cache.
- * @param year The year, in gregorian calendar, in [1, 32767].
+ * @param year The gregorian year, in [1, 32766].
  * @param jq The jieqi.
  * @return The JDE (Julian Ephemeris Day).
- * @throw std::out_of_range if `year` is outside [1, 32767], or `jq` is not a valid Jieqi.
+ * @throw std::out_of_range if `year` is outside [1, 32766], or `jq` is not a valid Jieqi.
  * @throw std::runtime_error if the root search does not yield exactly one root.
  */
 // Function-local static: a namespace-scope wrapper would initialize at image load (#67).

--- a/src/calendar/jieqi.hpp
+++ b/src/calendar/jieqi.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <array>
+#include <chrono>
 #include <format>
 #include <ranges>
 #include <cstdint>
@@ -204,11 +205,22 @@ static_assert("大寒" == JIEQI_NAME.at(to_index(Jieqi::大寒)));
 
 /**
  * @brief Get the JDE for the given `year` and `jieqi`.
- * @param year The year, in gregorian calendar.
+ * @param year The year, in gregorian calendar, in [1, 32767].
  * @param jq The jieqi.
  * @return The JDE (Julian Ephemeris Day).
+ * @throw std::out_of_range if `year` is outside [1, 32767], or `jq` is not a valid Jieqi.
+ * @throw std::runtime_error if the root search does not yield exactly one root.
  */
 [[nodiscard]] inline auto calc_jieqi_jde(const int32_t year, const Jieqi jq) -> double {
+  // A representability guard, not an accuracy one: the conversion chain wraps years past
+  // 32767 (`std::chrono::year` is a `short`) into silently wrong answers — and the cached
+  // wrapper would store them under the *unwrapped* key.
+  if (year < 1 or year > static_cast<int32_t>(static_cast<int>(std::chrono::year::max()))) {
+    throw std::out_of_range {
+      std::vformat("The year {} is out of the range [1, 32767].", std::make_format_args(year))
+    };
+  }
+
   const auto lon = longitude_of(jq);
   const auto roots = astro::sun::geocentric_coord::math::find_roots(year, lon);
 
@@ -226,12 +238,11 @@ static_assert("大寒" == JIEQI_NAME.at(to_index(Jieqi::大寒)));
 
 /**
  * @brief Get the JDE for the given `year` and `jieqi`, using cache.
- * @param year The year, in gregorian calendar.
+ * @param year The year, in gregorian calendar, in [1, 32767].
  * @param jq The jieqi.
  * @return The JDE (Julian Ephemeris Day).
- * @throw std::out_of_range if `jq` is not a valid Jieqi.
- * @throw std::runtime_error if the root search does not yield exactly one root, or a `year`
- *        before 1 — inherited from `ut1_to_jd` (#77).
+ * @throw std::out_of_range if `year` is outside [1, 32767], or `jq` is not a valid Jieqi.
+ * @throw std::runtime_error if the root search does not yield exactly one root.
  */
 // Function-local static: a namespace-scope wrapper would initialize at image load (#67).
 [[nodiscard]] inline auto jieqi_jde(const int32_t year, const Jieqi jq) -> double {

--- a/src/test/jieqi_test.cpp
+++ b/src/test/jieqi_test.cpp
@@ -53,6 +53,21 @@ TEST(JieQi, CachedWrapperIsLazilyInitialized) {
   static_assert(std::is_function_v<decltype(jieqi_jde)>);
 }
 
+TEST(JieQi, YearGuard) {
+  // The conversion chain wraps years past 32767 (`std::chrono::year` is a `short`): 65537 used
+  // to silently compute as year 1 — and `jieqi_jde` cached that under key 65537; 100000 used
+  // to throw "The year -31072 is < 1". The guard keeps both from ever reaching the wrap.
+  ASSERT_THROW(std::ignore = calc_jieqi_jde(0, Jieqi::春分), std::out_of_range);
+  ASSERT_THROW(std::ignore = calc_jieqi_jde(-5, Jieqi::春分), std::out_of_range);
+  ASSERT_THROW(std::ignore = calc_jieqi_jde(32768, Jieqi::春分), std::out_of_range);
+  ASSERT_THROW(std::ignore = calc_jieqi_jde(65537, Jieqi::春分), std::out_of_range);
+  ASSERT_THROW(std::ignore = calc_jieqi_jde(100000, Jieqi::春分), std::out_of_range);
+
+  // The cached wrapper goes through the same guard — a poisoned entry never forms.
+  ASSERT_THROW(std::ignore = jieqi_jde(65537, Jieqi::春分), std::out_of_range);
+  ASSERT_THROW(std::ignore = jieqi_jde(100000, Jieqi::春分), std::out_of_range);
+}
+
 TEST(JieQi, NameQuery) {
   ASSERT_EQ(longitude_of(Jieqi::立春), 315.0);
   ASSERT_EQ(longitude_of(Jieqi::雨水), 330.0);

--- a/src/test/jieqi_test.cpp
+++ b/src/test/jieqi_test.cpp
@@ -54,18 +54,23 @@ TEST(JieQi, CachedWrapperIsLazilyInitialized) {
 }
 
 TEST(JieQi, YearGuard) {
-  // The conversion chain wraps years past 32767 (`std::chrono::year` is a `short`): 65537 used
-  // to silently compute as year 1 — and `jieqi_jde` cached that under key 65537; 100000 used
-  // to throw "The year -31072 is < 1". The guard keeps both from ever reaching the wrap.
+  // Without the guard the conversion chain wraps out-of-range years: 65537 wraps to year 1
+  // and would be cached under the *unwrapped* key; negative wraps hit the Julian-day layer's
+  // lower gate with a misleading message.
   ASSERT_THROW(std::ignore = calc_jieqi_jde(0, Jieqi::春分), std::out_of_range);
   ASSERT_THROW(std::ignore = calc_jieqi_jde(-5, Jieqi::春分), std::out_of_range);
-  ASSERT_THROW(std::ignore = calc_jieqi_jde(32768, Jieqi::春分), std::out_of_range);
+  ASSERT_THROW(std::ignore = calc_jieqi_jde(32767, Jieqi::春分), std::out_of_range);
   ASSERT_THROW(std::ignore = calc_jieqi_jde(65537, Jieqi::春分), std::out_of_range);
   ASSERT_THROW(std::ignore = calc_jieqi_jde(100000, Jieqi::春分), std::out_of_range);
 
   // The cached wrapper goes through the same guard — a poisoned entry never forms.
   ASSERT_THROW(std::ignore = jieqi_jde(65537, Jieqi::春分), std::out_of_range);
   ASSERT_THROW(std::ignore = jieqi_jde(100000, Jieqi::春分), std::out_of_range);
+
+  // Boundary years stay computable — the ceiling is 32766 because the root search brackets
+  // with `year + 1`.
+  ASSERT_NO_THROW(std::ignore = calc_jieqi_jde(1, Jieqi::春分));
+  ASSERT_NO_THROW(std::ignore = calc_jieqi_jde(32766, Jieqi::春分));
 }
 
 TEST(JieQi, NameQuery) {


### PR DESCRIPTION
## 内容

`calc_jieqi_jde` 入口加年份守卫(观察池首条捞出,util 层契约批 PR-D 审阅发现,不开 issue 直接 PR):

- `to_ymd` 的 `std::chrono::year` 对超 ±32767 的输入存 unspecified 值,而 `calc_jieqi_jde`
  此前没有任何年份闸门。探针三形态(未修前实测):
  - `calc_jieqi_jde(65537, 春分)` **不抛**,返回 year 1 的 JDE —— 静默错答案;
  - `jieqi_jde(65537, 春分)` 与 `jieqi_jde(1, 春分)` **同值** —— 缓存 key 未截断、
    值是截断后的,毒化条目,且 key 空间因此无界(恰踩「从不 erase、key 有界靠调用方」
    不变量);
  - `calc_jieqi_jde(100000, …)` 抛「The year **-31072** is < 1」—— 回绕后撞 #77 下界
    闸门,消息完全误导。
- 守卫:year ∉ [1, 32766] → `std::out_of_range`(消息带原年份与区间,区间绑常量)。
  口径 = **防截断不是精度承诺**;上界 32766 而非 `year::max()` 32767,因为
  `find_roots` 的区间端点要 `year + 1`(grok R1 实测 32767 必炸且抛错类型)。
- 缓存包装器同路继承守卫,毒化条目从源头消失;`@throw`/`@param` 文档同步
  (year < 1 的异常类型由 #77 的 `runtime_error` 变 `out_of_range` —— 有意改契约,
  仓内无按具体类型 catch 的依赖)。

## 测试

- `JieQi.YearGuard` 9 断言:拒绝 0 / -5 / 32767 / 65537 / 100000(入口)+ 65537 /
  100000(缓存包装器)+ **正向钉** 1 与 32766 可算。
- 检出率两注入:摘守卫全红;上界退回 32767 时 32767 断言红。
- 224/224 跑二进制与 `TEST(` 宏对账相等;自包含闸门 32/32(`<chrono>` 随守卫新增)。

## 验证

- 审阅:grok 正确性轮 GO-WITH-CHANGES(P1 假上界实测 32766 全 24 节气可算 /
  32767 抛 `invalid_argument`;P2 只测拒绝)+ kimi 风格轮(1 P2 历史叙事 + 4 P3
  措辞,全收)→ grok R2 **GO**(突变证红复核,零新发现)。
- 底层 `find_roots` 仍无守卫(65537 在那一层仍静默 = year 1)—— 属更底层 API 的
  既有面,不在本 PR 声明范围,观察池留痕。
