### PR TITLE
refactor(calendar): 闭集 chrono 别名 + 长尾全限定,关 #51 calendar/util 半边

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,10 +210,13 @@ is intentional. Keep it. That buys a discipline:
   Closed-set forms that *are* allowed: `using X = Y` type aliases, and using-declarations that
   import a named template from another namespace (see `datetime.hpp` for the chrono set —
   class templates for CTAD, plus matching shape for stdlib alias templates). Remaining
-  ordinary using-declarations in production lunar headers (`using std::chrono::year_month_day`
-  in common/converter; `using common::LunarYear` in algo2) are leftovers from the #51 sweep —
-  fully-qualify when those files are next touched. Test-only headers may still carry
-  function-body or file-local usings (e.g. `delta_t_test_helper.hpp`).
+  ordinary using-declarations still left in production lunar headers after the #51 sweep
+  (documented exceptions, not a live cleanup ticket):
+  `using std::chrono::year_month_day` in `lunar/common.hpp` and `lunar/converter.hpp`;
+  `using std::chrono::sys_days` in `lunar/converter.hpp`;
+  `using calendar::lunar::common::LunarYear` in `lunar/algo2.hpp`.
+  Fully-qualify those when the files are next touched for other reasons. Test-only headers
+  may still carry function-body or file-local usings (e.g. `delta_t_test_helper.hpp`).
 - **Nested `lower_case` namespaces** by domain (`astro::earth::nutation`,
   `lib::`, `calendar::`); close with a `} // namespace …` comment.
 - **Trailing return types**: `inline auto f(const double jde) -> SphericalCoordinate`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,11 @@ is intentional. Keep it. That buys a discipline:
 - **No `using namespace` and no namespace-scope `using` declarations in headers** — they leak
   into every including TU and cause conflicts / ambiguity. Put `using` inside function bodies
   (as `sun.hpp` already does with `using namespace astro::toolbox::literals;`) or fully-qualify.
-  Existing violations tracked in #51.
+  Closed-set forms that *are* allowed: `using X = Y` type aliases, and using-declarations that
+  import a class template so CTAD still works (see `datetime.hpp` for the chrono set). Remaining
+  ordinary using-declarations in lunar headers (`using std::chrono::year_month_day` etc.;
+  `using common::LunarYear` in algo2) are leftovers from the #51 sweep — fully-qualify when
+  those files are next touched.
 - **Nested `lower_case` namespaces** by domain (`astro::earth::nutation`,
   `lib::`, `calendar::`); close with a `} // namespace …` comment.
 - **Trailing return types**: `inline auto f(const double jde) -> SphericalCoordinate`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,10 +208,12 @@ is intentional. Keep it. That buys a discipline:
   into every including TU and cause conflicts / ambiguity. Put `using` inside function bodies
   (as `sun.hpp` already does with `using namespace astro::toolbox::literals;`) or fully-qualify.
   Closed-set forms that *are* allowed: `using X = Y` type aliases, and using-declarations that
-  import a class template so CTAD still works (see `datetime.hpp` for the chrono set). Remaining
-  ordinary using-declarations in lunar headers (`using std::chrono::year_month_day` etc.;
-  `using common::LunarYear` in algo2) are leftovers from the #51 sweep — fully-qualify when
-  those files are next touched.
+  import a named template from another namespace (see `datetime.hpp` for the chrono set —
+  class templates for CTAD, plus matching shape for stdlib alias templates). Remaining
+  ordinary using-declarations in production lunar headers (`using std::chrono::year_month_day`
+  in common/converter; `using common::LunarYear` in algo2) are leftovers from the #51 sweep —
+  fully-qualify when those files are next touched. Test-only headers may still carry
+  function-body or file-local usings (e.g. `delta_t_test_helper.hpp`).
 - **Nested `lower_case` namespaces** by domain (`astro::earth::nutation`,
   `lib::`, `calendar::`); close with a `} // namespace …` comment.
 - **Trailing return types**: `inline auto f(const double jde) -> SphericalCoordinate`.

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -43,9 +43,9 @@ namespace calendar {
 // (`duration_cast` / `floor`) resolve via ADL and are intentionally not listed;
 // cross-stdlib risk is covered by CI (Windows/macOS).
 // Type aliases: `using X = …`. Templates imported by using-declaration:
-// `hh_mm_ss` / `time_point` are class templates (CTAD); `sys_time` is itself an
-// alias template in the standard library — same shape for consistency, not for
-// CTAD. Alias-template CTAD fails on the clang 18 frontend (CI compile + tidy).
+// `hh_mm_ss` / `time_point` are class templates (CTAD applies). `sys_time` is an
+// alias template in the standard library — imported in the same shape for
+// consistency only; do not rely on CTAD through it.
 using days            = std::chrono::days;
 using seconds         = std::chrono::seconds;
 using nanoseconds     = std::chrono::nanoseconds;

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -37,7 +37,22 @@
 
 namespace calendar {
 
-using namespace std::chrono;
+// Closed set of chrono names used by this header and its callers (#51).
+// Replaces open `using namespace std::chrono;`. New chrono dependencies need an
+// explicit line here — do not reopen the namespace.
+// Type aliases stay `using X = …`. Class templates use using-declarations so
+// CTAD keeps working (alias-template CTAD is rejected by clang-tidy 18).
+using days            = std::chrono::days;
+using seconds         = std::chrono::seconds;
+using nanoseconds     = std::chrono::nanoseconds;
+using microseconds    = std::chrono::microseconds;
+using system_clock    = std::chrono::system_clock;
+using year_month_day  = std::chrono::year_month_day;
+using sys_days        = std::chrono::sys_days;
+
+using std::chrono::sys_time;
+using std::chrono::time_point;
+using std::chrono::hh_mm_ss;
 
 
 /** 

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -42,9 +42,10 @@ namespace calendar {
 // explicit line here — do not reopen the namespace. Function templates
 // (`duration_cast` / `floor`) resolve via ADL and are intentionally not listed;
 // cross-stdlib risk is covered by CI (Windows/macOS).
-// Type aliases: `using X = …`. Class templates: using-declarations (keeps CTAD
-// for `hh_mm_ss`; alias-template CTAD fails on the clang 18 frontend used by
-// clang-tidy — `sys_time` / `time_point` match that shape for consistency).
+// Type aliases: `using X = …`. Templates imported by using-declaration:
+// `hh_mm_ss` / `time_point` are class templates (CTAD); `sys_time` is itself an
+// alias template in the standard library — same shape for consistency, not for
+// CTAD. Alias-template CTAD fails on the clang 18 frontend (CI compile + tidy).
 using days            = std::chrono::days;
 using seconds         = std::chrono::seconds;
 using nanoseconds     = std::chrono::nanoseconds;

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -37,11 +37,14 @@
 
 namespace calendar {
 
-// Closed set of chrono names used by this header and its callers (#51).
-// Replaces open `using namespace std::chrono;`. New chrono dependencies need an
-// explicit line here — do not reopen the namespace.
-// Type aliases stay `using X = …`. Class templates use using-declarations so
-// CTAD keeps working (alias-template CTAD is rejected by clang-tidy 18).
+// Closed set of chrono *type* names used by this header and its callers (#51).
+// Replaces open `using namespace std::chrono;`. New type dependencies need an
+// explicit line here — do not reopen the namespace. Function templates
+// (`duration_cast` / `floor`) resolve via ADL and are intentionally not listed;
+// cross-stdlib risk is covered by CI (Windows/macOS).
+// Type aliases: `using X = …`. Class templates: using-declarations (keeps CTAD
+// for `hh_mm_ss`; alias-template CTAD fails on the clang 18 frontend used by
+// clang-tidy — `sys_time` / `time_point` match that shape for consistency).
 using days            = std::chrono::days;
 using seconds         = std::chrono::seconds;
 using nanoseconds     = std::chrono::nanoseconds;

--- a/src/calendar/lunar/algo1.hpp
+++ b/src/calendar/lunar/algo1.hpp
@@ -85,7 +85,7 @@ inline constexpr std::array<uint32_t, (END_YEAR - START_YEAR + 1)> LUNAR_DATA = 
 }
 
 /** @brief The bounds of the algorithm, i.e. the supported range of lunar and Gregorian dates. */
-const inline auto bounds = calc_bounds(START_YEAR, END_YEAR, calc_lunar_year);
+const inline auto bounds = common::calc_bounds(START_YEAR, END_YEAR, calc_lunar_year);
 
 } // namespace calendar::lunar::algo1
 

--- a/src/calendar/lunar/algo1.hpp
+++ b/src/calendar/lunar/algo1.hpp
@@ -33,8 +33,6 @@
 
 namespace calendar::lunar::algo1 {
 
-using namespace calendar::lunar::common;
-
 /** @brief The first supported lunar year. */
 inline constexpr int32_t START_YEAR = 1901;
 
@@ -76,14 +74,14 @@ inline constexpr std::array<uint32_t, (END_YEAR - START_YEAR + 1)> LUNAR_DATA = 
  * @param year The Lunar year. 阴历年份。
  * @return The lunar year information. 阴历年信息。
  */
-[[nodiscard]] inline auto calc_lunar_year(int32_t year) -> LunarYear {
+[[nodiscard]] inline auto calc_lunar_year(int32_t year) -> common::LunarYear {
   if (year < START_YEAR or year > END_YEAR) {
     throw std::out_of_range {
       std::format("year {} is out of range [{}, {}]", year, START_YEAR, END_YEAR)
     };
   }
 
-  return parse_lunar_year(year, LUNAR_DATA[year - START_YEAR]); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+  return common::parse_lunar_year(year, LUNAR_DATA[year - START_YEAR]); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
 }
 
 /** @brief The bounds of the algorithm, i.e. the supported range of lunar and Gregorian dates. */

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -46,7 +46,6 @@
 
 namespace calendar::lunar::algo2 {
 
-using namespace calendar::jieqi;
 using calendar::lunar::common::LunarYear;
 
 // A convention, not a physical ceiling — the method computes rather than looks up. Past ~2100 ΔT
@@ -87,7 +86,7 @@ struct LunarMonth {
   calendar::Datetime end_moment_utc8;
 
   // Jieqis that fall in this lunar month.
-  std::vector<JieqiGenerator::JieqiPair> contained_jieqis;
+  std::vector<calendar::jieqi::JieqiGenerator::JieqiPair> contained_jieqis;
 
   [[nodiscard]] auto operator==(const LunarMonth& other) const -> bool = default;
 };
@@ -108,7 +107,7 @@ private:
   calendar::jieqi::JieqiGenerator _jieqi_gen;
 
   std::optional<double> _next_new_moon;
-  std::optional<JieqiGenerator::JieqiPair> _next_jieqi;
+  std::optional<calendar::jieqi::JieqiGenerator::JieqiPair> _next_jieqi;
 
   std::optional<LunarMonth> _next_month;
 
@@ -127,7 +126,7 @@ private:
     _next_new_moon = jde;
   }
 
-  [[nodiscard]] auto next_jieqi() -> JieqiGenerator::JieqiPair {
+  [[nodiscard]] auto next_jieqi() -> calendar::jieqi::JieqiGenerator::JieqiPair {
     if (_next_jieqi.has_value()) {
       auto jieqi = *_next_jieqi;
       _next_jieqi = std::nullopt;
@@ -137,7 +136,7 @@ private:
     return _jieqi_gen.next();
   }
 
-  auto put_back_jieqi(const JieqiGenerator::JieqiPair jieqi) -> void {
+  auto put_back_jieqi(const calendar::jieqi::JieqiGenerator::JieqiPair jieqi) -> void {
     assert(!_next_jieqi.has_value());
     _next_jieqi = jieqi;
   }
@@ -159,7 +158,7 @@ private:
     const auto end_moment_utc8 = jde_to_utc8(end_jde);
 
     // Get the Jieqis that fall in this lunar month.
-    std::vector<JieqiGenerator::JieqiPair> jieqis;
+    std::vector<calendar::jieqi::JieqiGenerator::JieqiPair> jieqis;
     while (true) {
       const auto jieqi = next_jieqi();
       const auto jieqi_moment_utc8 = jde_to_utc8(jieqi.jde);
@@ -226,7 +225,7 @@ using LunarMonthChunk = std::vector<LunarMonth>;
  */
 [[nodiscard]] inline auto calc_lunar_month_chunks(int32_t year) -> std::pair<LunarMonthChunk, LunarMonthChunk> {
   // The lunar month where Winter Solstice (i.e. Jieqi::冬至) occurs is defined as the 11th month.
-  const auto winter_solstice_last_year = jieqi_jde(year - 1, Jieqi::冬至);
+  const auto winter_solstice_last_year = calendar::jieqi::jieqi_jde(year - 1, calendar::jieqi::Jieqi::冬至);
 
   // Start from a bit earlier than the winter solstice, ensuring the entireness of the 11th lunar month.
   LunarMonthGenerator lunar_month_gen { winter_solstice_last_year - 90.0 };
@@ -234,7 +233,7 @@ using LunarMonthChunk = std::vector<LunarMonth>;
   // Define a helper function to check if the month is the 11th lunar month.
   const auto is_11th = [](const auto& month) {
     const auto& jieqis = month.contained_jieqis;
-    const auto is_winter_solstice = [](const auto& jq) { return jq.jieqi == Jieqi::冬至; };
+    const auto is_winter_solstice = [](const auto& jq) { return jq.jieqi == calendar::jieqi::Jieqi::冬至; };
     return std::ranges::any_of(jieqis, is_winter_solstice);
   };
 

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -276,7 +276,7 @@ using LunarMonthChunk = std::vector<LunarMonth>;
   for (const auto& [index, month] : std::views::zip(std::views::iota(0), chunk)) {
     const auto& jq_pairs = month.contained_jieqis;
     const bool has_qi = std::ranges::any_of(jq_pairs, [](const auto& pair) {
-      return is_qi(pair.jieqi);
+      return calendar::jieqi::is_qi(pair.jieqi);
     });
     if (not has_qi) {
       return index;

--- a/src/calendar/lunar/algo3.hpp
+++ b/src/calendar/lunar/algo3.hpp
@@ -33,8 +33,6 @@
 
 namespace calendar::lunar::algo3 {
 
-using namespace calendar::lunar::common;
-
 /** @brief The first supported lunar year. */
 inline constexpr int32_t START_YEAR = 1600;
 
@@ -138,14 +136,14 @@ inline constexpr std::array<uint32_t, (END_YEAR - START_YEAR + 1)> LUNAR_DATA = 
  * @param year The Lunar year. 阴历年份。
  * @return The lunar year information. 阴历年信息。
  */
-[[nodiscard]] inline auto calc_lunar_year(int32_t year) -> LunarYear {
+[[nodiscard]] inline auto calc_lunar_year(int32_t year) -> common::LunarYear {
   if (year < START_YEAR or year > END_YEAR) {
     throw std::out_of_range {
       std::format("year {} is out of range [{}, {}]", year, START_YEAR, END_YEAR)
     };
   }
 
-  return parse_lunar_year(year, LUNAR_DATA[year - START_YEAR]); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+  return common::parse_lunar_year(year, LUNAR_DATA[year - START_YEAR]); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
 }
 
 /** @brief The bounds of the algorithm, i.e. the supported range of lunar and Gregorian dates. */

--- a/src/calendar/lunar/algo3.hpp
+++ b/src/calendar/lunar/algo3.hpp
@@ -147,7 +147,7 @@ inline constexpr std::array<uint32_t, (END_YEAR - START_YEAR + 1)> LUNAR_DATA = 
 }
 
 /** @brief The bounds of the algorithm, i.e. the supported range of lunar and Gregorian dates. */
-const inline auto bounds = calc_bounds(START_YEAR, END_YEAR, calc_lunar_year);
+const inline auto bounds = common::calc_bounds(START_YEAR, END_YEAR, calc_lunar_year);
 
 } // namespace calendar::lunar::algo3
 

--- a/src/calendar/lunar/converter.hpp
+++ b/src/calendar/lunar/converter.hpp
@@ -37,7 +37,6 @@ namespace calendar::lunar::converter {
 
 using std::chrono::year_month_day;
 using std::chrono::sys_days;
-using namespace calendar::lunar::common;
 
 /**
  * @struct Converter

--- a/src/test/lunar/algo2_test.cpp
+++ b/src/test/lunar/algo2_test.cpp
@@ -163,7 +163,7 @@ TEST(LunarAlgo2, LeapMonth) {
     const auto is_leap = [](const LunarMonth& month) {
       const auto& jq_pairs = month.contained_jieqis;
       return not std::ranges::any_of(jq_pairs, [](const auto& jq_pair) {
-        return is_qi(jq_pair.jieqi);
+        return calendar::jieqi::is_qi(jq_pair.jieqi);
       });
     };
 

--- a/src/test/lunar/algo2_test.cpp
+++ b/src/test/lunar/algo2_test.cpp
@@ -53,7 +53,7 @@ TEST(LunarAlgo2, LunarMonthGenerator) {
   // TODO: Use `std::views::pairwise` once every CI leg has it (./linter.py --features).
   const auto lunar_month_pairs = std::views::zip(lunar_months, lunar_months | std::views::drop(1));
 
-  std::vector<JieqiGenerator::JieqiPair> jieqi_pairs;
+  std::vector<calendar::jieqi::JieqiGenerator::JieqiPair> jieqi_pairs;
   for (const auto &[a, b] : lunar_month_pairs) {
     ASSERT_EQ(a.end_moment_utc8, b.start_moment_utc8);
 
@@ -80,8 +80,8 @@ TEST(LunarAlgo2, LunarMonthGenerator) {
   ASSERT_LT(first_jieqi_jde, random_jde + 45.0);
 
   // Ensure the Jieqis are consecutive and correct.
-  std::vector<JieqiGenerator::JieqiPair> expected_jieqi_pairs;
-  JieqiGenerator jieqi_gen { random_jde };
+  std::vector<calendar::jieqi::JieqiGenerator::JieqiPair> expected_jieqi_pairs;
+  calendar::jieqi::JieqiGenerator jieqi_gen { random_jde };
 
   while (true) {
     const auto jq_pair = jieqi_gen.next();

--- a/src/util/ymd.hpp
+++ b/src/util/ymd.hpp
@@ -73,8 +73,6 @@ concept DaysConvertible = requires (const T& t) {
 
 namespace util::ymd_operator {
 
-using util::DaysConvertible;
-
 [[nodiscard]] constexpr auto operator+(
   const std::chrono::year_month_day& ymd, 
   const DaysConvertible auto& days


### PR DESCRIPTION
## 做什么

收完 #51 的 **calendar/util 半边**（astro 侧 P3 已做）：头文件里的开放 `using namespace` 与两条死 using 清掉，长尾改全限定。行为零改动。

Closes #51

## 怎么做

**混合路**（侦察拍板）：

1. **`datetime.hpp`** — 删 `using namespace std::chrono;`，换成闭集类型名单：
   - 类型别名 `using X = std::chrono::X`
   - 模板用 using-declaration（`hh_mm_ss` / `time_point` 保 CTAD；`sys_time` 在标准库里本身是别名模板，同形一致性）
   - 函数模板（`duration_cast` / `floor`）故意不进名单，靠 ADL；跨 stdlib 由 CI 的 Windows/macOS 腿回答
   - **调用点零改**（含测试里的 CTAD 拼法）
2. **死 using** — 删前复证「摘除即零诊断」：
   - `converter.hpp` 的 `using namespace calendar::lunar::common`
   - `ymd.hpp` 的 `using util::DaysConvertible`（嵌套命名空间查找已见概念）
3. **长尾全限定** — algo1/algo3 的 `common::*`；algo2（+ test）的 `calendar::jieqi::*`，含 R1 补的 `calc_bounds` / `is_qi`（原先只靠 ADL 编过）

`AGENTS.md` 同步：写明合宪闭集形状，并点名仍留在 lunar 生产头里的 ordinary using-declaration（下次动那些文件时再收）。

## 没做什么

- 不改行为 / 数值 / API 契约
- 不动 converter 里仍在用的 `using std::chrono::year_month_day` / `sys_days`，也不动 algo2 的 `using common::LunarYear`（范围锁死）
- 不动 astro 侧、不动 util/cache 等侦察表外项

## 三个数字（口径不同，都对）

| 数字 | 口径 |
|---:|---|
| **48** | 历史上「using 行」计数（issue 早期盘点口径） |
| **931** | 摘掉若干 `using namespace` 后，跨 TU 诊断**实例**合计（非源码改点数；本机复测约 915，方法同） |
| **~30** | 本 PR **真实源码改点**（别名块塌缩 datetime 大头后的长尾 + 死 using + 测试） |

## 验证

- 直接跑测试二进制 **229/229** == `TEST(` 宏 229
- `linter.py --all` EXIT 0（ruff · clang-tidy 18.1.8 · 自包含 32/32 · `--abi-layout` · `--ctypes-smoke` · features）
- `datetime.hpp` 单头 `-fsyntax-only` EXIT 0
- R1 席：shared_lib 目标文件 vs `origin/main` **逐字节相同**（零行为的校验和）
- Windows/macOS 腿：本机未复现 libc++/MSVC；红 = 侦察 ADL 假设被证伪

## 审阅

- R1 正确性/符合性：opus 单席 · P1=0 P2=3 P3=2 · 全采
- R2 同席复验：`FIXES VERIFIED` · 再收 3×P3 注释精度
