### PR TITLE
test(astro,calendar): 补上 #87 的四条覆盖缺口 —— 转换链与守卫都没有各自的家

### DIFF
--- a/src/test/astro/julian_day_test.cpp
+++ b/src/test/astro/julian_day_test.cpp
@@ -25,6 +25,7 @@
 
 #include <tuple>
 #include <limits>
+#include <vector>
 #include <unordered_map>
 #include "util.hpp"
 #include "datetime.hpp"
@@ -125,6 +126,76 @@ TEST(JulianDay, Consistency) {
     const auto recovered_tt = jde_to_tt(recovered_jde);
     ASSERT_EQ(tt.ymd, recovered_tt.ymd);
     ASSERT_NEAR(tt.fraction(), recovered_tt.fraction(), EPSILON);
+  }
+}
+
+TEST(JulianDay, JdeUt1Anchors) {
+  // The UT1 family composes ΔT on top of the TT conversion: UT1 = TT − ΔT. The anchors pin the
+  // composition against *observed* ΔT values, not `delta_t::compute` itself — a sign flip in the
+  // composition would err by 2ΔT (~128 s at the modern anchors), far outside any tolerance here.
+  //
+  // Provenance: observed ΔT (TT − UT1) at the anchors — 63.83 s at 2000-01-01 and 69.18 s at
+  // 2020-01-01 (USNO/IERS, via https://eclipse.gsfc.nasa.gov/SEcat5/deltat.html); 5710 s at
+  // year 500 (Stephenson & Morrison, the same table the ΔT models fit, so the models sit within
+  // ~1 s of it there). The per-anchor tolerance bounds |model − observation| at that epoch;
+  // the conversion itself is far tighter than that.
+  struct Anchor {
+    Datetime tt;
+    Datetime ut1;    // tt − observed ΔT
+    double tol_sec;  // |model ΔT − observed ΔT| bound at this epoch
+  };
+
+  const std::vector<Anchor> anchors {
+    { Datetime { to_ymd(2000, 1, 1), 0.0 },
+      Datetime { to_ymd(1999, 12, 31), hh_mm_ss { 23h + 58min + 56s + 170ms } },
+      0.2 },
+    { Datetime { to_ymd(2020, 1, 1), 0.0 },
+      Datetime { to_ymd(2019, 12, 31), hh_mm_ss { 23h + 58min + 50s + 820ms } },
+      1.0 },
+    { Datetime { to_ymd(500, 1, 1), 0.0 },
+      Datetime { to_ymd(499, 12, 31), hh_mm_ss { 22h + 24min + 50s } },
+      2.0 },
+  };
+
+  for (const auto& [tt, ut1, tol_sec] : anchors) {
+    const double tol_day = tol_sec / 86400.0;
+    const double jde = tt_to_jde(tt);
+
+    // Forward: a TT jde lands on the observed UT1 moment.
+    const auto converted_ut1 = jde_to_ut1(jde);
+    ASSERT_EQ(converted_ut1.ymd, ut1.ymd);
+    ASSERT_NEAR(converted_ut1.fraction(), ut1.fraction(), tol_day);
+
+    // Reverse: the observed UT1 moment maps back to the same jde.
+    ASSERT_NEAR(ut1_to_jde(ut1), jde, tol_day);
+  }
+
+  // The delegation to `jd_to_ut1` keeps its domain gates: the JD of 1-01-01 sits below the
+  // 401-01-01 bound (see `JulianDay.InvalidInput` for the full boundary battery).
+  ASSERT_THROW(std::ignore = jde_to_ut1(1721425.5), std::runtime_error);
+}
+
+TEST(JulianDay, JdeUt1Consistency) {
+  // ΔT evaluation is mildly asymmetric: `jde_to_ut1` reads ΔT on the TT date, `ut1_to_jde` on the
+  // UT1 date. The residual of a round trip is the ΔT slope applied to a ΔT-sized time shift —
+  // ~1e-6 s over 401-2100 — plus double rounding, so 1e-6 day leaves orders of magnitude of room
+  // while still catching a flipped sign or a stale/wrong scale in either direction.
+  constexpr double TOLERANCE = 1e-6;
+
+  for (auto i = 0; i < 2000; ++i) {
+    // 401-01-01 (the `jd_to_ut1` bound) through year 2100.
+    const double jde = util::random(1867522.5, 2488070.5);
+    ASSERT_NEAR(ut1_to_jde(jde_to_ut1(jde)), jde, TOLERANCE);
+  }
+
+  for (auto i = 0; i < 2000; ++i) {
+    // Round trips only close from 401-01-01 onwards (see `JulianDay.InvalidInput`).
+    const auto ymd = to_ymd(util::random(401, 2100), util::random(1, 12), util::random(1, 28));
+    const Datetime ut1 { ymd, util::random(0.0, 1.0) };
+
+    const auto recovered_ut1 = jde_to_ut1(ut1_to_jde(ut1));
+    ASSERT_EQ(ut1.ymd, recovered_ut1.ymd);
+    ASSERT_NEAR(ut1.fraction(), recovered_ut1.fraction(), TOLERANCE);
   }
 }
 

--- a/src/test/astro/julian_day_test.cpp
+++ b/src/test/astro/julian_day_test.cpp
@@ -134,11 +134,14 @@ TEST(JulianDay, JdeUt1Anchors) {
   // composition against *observed* ΔT values, not `delta_t::compute` itself — a sign flip in the
   // composition would err by 2ΔT (~128 s at the modern anchors), far outside any tolerance here.
   //
-  // Provenance: observed ΔT (TT − UT1) at the anchors — 63.83 s at 2000-01-01 and 69.18 s at
-  // 2020-01-01 (USNO/IERS, via https://eclipse.gsfc.nasa.gov/SEcat5/deltat.html); 5710 s at
-  // year 500 (Stephenson & Morrison, the same table the ΔT models fit, so the models sit within
-  // ~1 s of it there). The per-anchor tolerance bounds |model − observation| at that epoch;
-  // the conversion itself is far tighter than that.
+  // Provenance for the observed ΔT (TT − UT1) at each anchor:
+  //   2000-01-01: 63.83 s — NASA eclipse ΔT table (https://eclipse.gsfc.nasa.gov/SEcat5/deltat.html).
+  //   2020-01-01: 69.36 s — USNO observations (https://maia.usno.navy.mil/ser7/deltat.data);
+  //               matches this repo's own ACCURATE_DELTA_T_TABLE (delta_t_test_helper.hpp).
+  //   year 500:   5710 s  — Stephenson & Morrison, the same table the ΔT models fit, so the
+  //               models sit within ~1 s of it there.
+  // The per-anchor tolerance bounds |model − observation| at that epoch; the conversion itself
+  // is far tighter than that.
   struct Anchor {
     Datetime tt;
     Datetime ut1;    // tt − observed ΔT
@@ -146,15 +149,10 @@ TEST(JulianDay, JdeUt1Anchors) {
   };
 
   const std::vector<Anchor> anchors {
-    { Datetime { to_ymd(2000, 1, 1), 0.0 },
-      Datetime { to_ymd(1999, 12, 31), hh_mm_ss { 23h + 58min + 56s + 170ms } },
-      0.2 },
-    { Datetime { to_ymd(2020, 1, 1), 0.0 },
-      Datetime { to_ymd(2019, 12, 31), hh_mm_ss { 23h + 58min + 50s + 820ms } },
-      1.0 },
-    { Datetime { to_ymd(500, 1, 1), 0.0 },
-      Datetime { to_ymd(499, 12, 31), hh_mm_ss { 22h + 24min + 50s } },
-      2.0 },
+    //                  tt                              ut1 (= tt − observed ΔT)                                     tol_sec
+    { Datetime { to_ymd(2000, 1, 1), 0.0 }, Datetime { to_ymd(1999, 12, 31), hh_mm_ss { 23h + 58min + 56s + 170ms } }, 0.2 },
+    { Datetime { to_ymd(2020, 1, 1), 0.0 }, Datetime { to_ymd(2019, 12, 31), hh_mm_ss { 23h + 58min + 50s + 640ms } }, 0.2 },
+    { Datetime { to_ymd( 500, 1, 1), 0.0 }, Datetime { to_ymd( 499, 12, 31), hh_mm_ss { 22h + 24min + 50s } },         2.0 },
   };
 
   for (const auto& [tt, ut1, tol_sec] : anchors) {
@@ -169,23 +167,17 @@ TEST(JulianDay, JdeUt1Anchors) {
     // Reverse: the observed UT1 moment maps back to the same jde.
     ASSERT_NEAR(ut1_to_jde(ut1), jde, tol_day);
   }
-
-  // The delegation to `jd_to_ut1` keeps its domain gates: the JD of 1-01-01 sits below the
-  // 401-01-01 bound (see `JulianDay.InvalidInput` for the full boundary battery).
-  ASSERT_THROW(std::ignore = jde_to_ut1(1721425.5), std::runtime_error);
 }
 
 TEST(JulianDay, JdeUt1Consistency) {
-  // ΔT evaluation is mildly asymmetric: `jde_to_ut1` reads ΔT on the TT date, `ut1_to_jde` on the
-  // UT1 date. The residual of a round trip is the ΔT slope applied to a ΔT-sized time shift —
-  // ~1e-6 s over 401-2100 — plus double rounding, so 1e-6 day leaves orders of magnitude of room
+  // The two directions read ΔT on different dates: `jde_to_ut1` on the TT date, `ut1_to_jde` on
+  // the UT1 date. The round-trip residual is the ΔT slope applied to a ΔT-sized time shift, plus
+  // `Datetime` rounding — ~1e-8 day in practice — so EPSILON leaves orders of magnitude of room
   // while still catching a flipped sign or a stale/wrong scale in either direction.
-  constexpr double TOLERANCE = 1e-6;
-
   for (auto i = 0; i < 2000; ++i) {
     // 401-01-01 (the `jd_to_ut1` bound) through year 2100.
     const double jde = util::random(1867522.5, 2488070.5);
-    ASSERT_NEAR(ut1_to_jde(jde_to_ut1(jde)), jde, TOLERANCE);
+    ASSERT_NEAR(ut1_to_jde(jde_to_ut1(jde)), jde, EPSILON);
   }
 
   for (auto i = 0; i < 2000; ++i) {
@@ -195,7 +187,7 @@ TEST(JulianDay, JdeUt1Consistency) {
 
     const auto recovered_ut1 = jde_to_ut1(ut1_to_jde(ut1));
     ASSERT_EQ(ut1.ymd, recovered_ut1.ymd);
-    ASSERT_NEAR(ut1.fraction(), recovered_ut1.fraction(), TOLERANCE);
+    ASSERT_NEAR(ut1.fraction(), recovered_ut1.fraction(), EPSILON);
   }
 }
 
@@ -209,6 +201,10 @@ TEST(JulianDay, InvalidInput) {
 
   // The wrappers propagate the throw (this is what turns the C-ABI garbage into an error).
   ASSERT_THROW(std::ignore = tt_to_jde(Datetime { to_ymd(0, 1, 1), 0.0 }), std::runtime_error);
+
+  // `jde_to_ut1` still runs `jd_to_ut1`'s domain gates: the JD of 1-01-01 sits below the
+  // 401-01-01 bound pinned below.
+  ASSERT_THROW(std::ignore = jde_to_ut1(1721425.5), std::runtime_error);
 
   // Both directions throw the same exception type on out-of-domain input. Their domains differ:
   // `ut1_to_jd` accepts years 1-400 that sit below `jd_to_ut1`'s bound, so round-trips only

--- a/src/test/astro/julian_day_test.cpp
+++ b/src/test/astro/julian_day_test.cpp
@@ -140,8 +140,7 @@ TEST(JulianDay, JdeUt1Anchors) {
   //               matches this repo's own ACCURATE_DELTA_T_TABLE (delta_t_test_helper.hpp).
   //   year 500:   5710 s  — Stephenson & Morrison, the same table the ΔT models fit, so the
   //               models sit within ~1 s of it there.
-  // The per-anchor tolerance bounds |model − observation| at that epoch; the conversion itself
-  // is far tighter than that.
+  // The conversion itself is far tighter than these tolerances.
   struct Anchor {
     Datetime tt;
     Datetime ut1;    // tt − observed ΔT
@@ -171,8 +170,8 @@ TEST(JulianDay, JdeUt1Anchors) {
 
 TEST(JulianDay, JdeUt1Consistency) {
   // The two directions read ΔT on different dates: `jde_to_ut1` on the TT date, `ut1_to_jde` on
-  // the UT1 date. The round-trip residual is the ΔT slope applied to a ΔT-sized time shift, plus
-  // `Datetime` rounding — ~1e-8 day in practice — so EPSILON leaves orders of magnitude of room
+  // the UT1 date. The round-trip residual is the ΔT slope applied to a ΔT-sized shift — ~2e-8 day
+  // at the 401-600 end of the span, bit-exact from 1900 on — so EPSILON keeps ~40x of headroom
   // while still catching a flipped sign or a stale/wrong scale in either direction.
   for (auto i = 0; i < 2000; ++i) {
     // 401-01-01 (the `jd_to_ut1` bound) through year 2100.

--- a/src/test/astro/moon_phase_test.cpp
+++ b/src/test/astro/moon_phase_test.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 #include <chrono>
 #include <ranges>
+#include <stdexcept>
 #include "julian_day.hpp"
 #include "util.hpp"
 #include "astro.hpp"
@@ -69,6 +70,26 @@ TEST(NewMoon, RootGenerator) {
     const double day_diff = *next - *it;
     ASSERT_NEAR(day_diff, 29.5, 0.75);
   }
+}
+
+
+TEST(NewMoon, InvalidArgument) {
+  // `newton_method` demands both endpoints within BRACKET_TOLERANCE_DEG (15°) of conjunction —
+  // the left one trailing (elongation just under 360°) and the right one leading (just above 0°).
+  // The Moon's elongation rate runs 10.5–14.5°/day, so these cases sit far outside the window in
+  // either configuration and must be rejected. Negative-path assertions pin the exception type
+  // only; the message wording is free to change (#86).
+  const double root = moments(2024).front();
+
+  // Three days past conjunction the left endpoint already leads by ~31–44°: not a bracket at all.
+  ASSERT_THROW(std::ignore = newton_method(root + 3.0, root + 4.0), std::invalid_argument);
+
+  // Half a day before conjunction the left endpoint is fine, but two days after (~21–29° past)
+  // the right endpoint has left the tolerance window.
+  ASSERT_THROW(std::ignore = newton_method(root - 0.5, root + 2.0), std::invalid_argument);
+
+  // `next_root` insists its seed is a root: ten days past conjunction it is ~105–145° away.
+  ASSERT_THROW(std::ignore = next_root(root + 10.0), std::invalid_argument);
 }
 
 

--- a/src/test/astro/moon_phase_test.cpp
+++ b/src/test/astro/moon_phase_test.cpp
@@ -23,6 +23,7 @@
 
 #include <gtest/gtest.h>
 #include <print>
+#include <tuple>
 #include <vector>
 #include <chrono>
 #include <ranges>
@@ -74,21 +75,22 @@ TEST(NewMoon, RootGenerator) {
 
 
 TEST(NewMoon, InvalidArgument) {
-  // `newton_method` demands both endpoints within BRACKET_TOLERANCE_DEG (15°) of conjunction —
-  // the left one trailing (elongation just under 360°) and the right one leading (just above 0°).
-  // The Moon's elongation rate runs 10.5–14.5°/day, so these cases sit far outside the window in
-  // either configuration and must be rejected. Negative-path assertions pin the exception type
-  // only; the message wording is free to change (#86).
+  // `newton_method` demands both endpoints within BRACKET_TOLERANCE_DEG (15 deg) of conjunction —
+  // the left one trailing (elongation just under 360 deg) and the right one leading (just above
+  // 0 deg). The Moon's elongation rate runs 10.5-14.5 deg/day, so these cases sit far outside
+  // the window in either configuration and must be rejected.
   const double root = moments(2024).front();
 
-  // Three days past conjunction the left endpoint already leads by ~31–44°: not a bracket at all.
+  // Three days past conjunction, the left endpoint already leads by tens of degrees:
+  // not a bracket at all.
   ASSERT_THROW(std::ignore = newton_method(root + 3.0, root + 4.0), std::invalid_argument);
 
-  // Half a day before conjunction the left endpoint is fine, but two days after (~21–29° past)
-  // the right endpoint has left the tolerance window.
+  // Half a day before conjunction the left endpoint is fine, but two days after, the right
+  // endpoint has left the tolerance window.
   ASSERT_THROW(std::ignore = newton_method(root - 0.5, root + 2.0), std::invalid_argument);
 
-  // `next_root` insists its seed is a root: ten days past conjunction it is ~105–145° away.
+  // `next_root` insists its seed is a root: ten days past conjunction the elongation is
+  // a third of a turn away.
   ASSERT_THROW(std::ignore = next_root(root + 10.0), std::invalid_argument);
 }
 

--- a/src/test/astro/moon_phase_test.cpp
+++ b/src/test/astro/moon_phase_test.cpp
@@ -90,7 +90,7 @@ TEST(NewMoon, InvalidArgument) {
   ASSERT_THROW(std::ignore = newton_method(root - 0.5, root + 2.0), std::invalid_argument);
 
   // `next_root` insists its seed is a root: ten days past conjunction the elongation is
-  // a third of a turn away.
+  // ~120 deg away.
   ASSERT_THROW(std::ignore = next_root(root + 10.0), std::invalid_argument);
 }
 

--- a/src/test/astro/vsop87d_test.cpp
+++ b/src/test/astro/vsop87d_test.cpp
@@ -22,6 +22,9 @@
  */
 
 #include <gtest/gtest.h>
+#include <ranges>
+#include <tuple>
+#include <unordered_map>
 #include "julian_day.hpp"
 #include "vsop87d/vsop87d.hpp"
 
@@ -32,7 +35,7 @@ using namespace astro::vsop87d;
 // Data was obtained from PyMeeus (https://pypi.org/project/PyMeeus/).
 // PyMeeus is a well-implemented Python library for astronomical calculations.
 //
-// The values are directly returned by VSOP87D models, no any adjustment or correction.
+// The values are directly returned by VSOP87D models, no adjustment or correction.
 const std::unordered_map<double, std::tuple<double, double, double>> EARTH_DATASET {
   //    JDE          L-tables expected   B-tables expected        R-tables expected
   {     2445701.1, { -98.77924318611353, -2.4184395622860954e-07, 0.9832889892830442 } },
@@ -57,16 +60,11 @@ TEST(Vsop87d, Evaluate) {
 
 TEST(Vsop87d, EvaluateTemplate) {
   // `evaluate<Planet::EAR>` is the field-mapping layer over `evaluate_tables`: .λ ← L, .β ← B,
-  // .r ← R, unadjusted. A swapped or rescaled field passes neither assertion family below.
-  for (const auto& [jde, expected] : EARTH_DATASET) {
-    const auto& [lon, lat, r] = expected;
+  // .r ← R, unadjusted. A swapped or rescaled field fails the bit-exact checks below.
+  // (The external anchoring of the tables themselves lives in `Vsop87d.Evaluate` above.)
+  for (const double jde : EARTH_DATASET | std::views::keys) {
     const auto jm = julian_day::jde_to_jm(jde);
     const auto eval = evaluate<Planet::EAR>(jm);
-
-    // The external dataset through the template path.
-    ASSERT_NEAR(eval.λ, lon, 1e-10);
-    ASSERT_NEAR(eval.β, lat, 1e-10);
-    ASSERT_NEAR(eval.r, r,   1e-10);
 
     // Same bits as reading the tables directly — the wrapper neither scales nor reorders.
     ASSERT_EQ(eval.λ, evaluate_tables(earth_coeff::L, jm));

--- a/src/test/astro/vsop87d_test.cpp
+++ b/src/test/astro/vsop87d_test.cpp
@@ -29,29 +29,49 @@ namespace astro::vsop87d::test {
 
 using namespace astro::vsop87d;
 
-TEST(Vsop87d, Evaluate) {
-  // Data was obtained from PyMeeus (https://pypi.org/project/PyMeeus/).
-  // PyMeeus is a well-implemented Python library for astronomical calculations.
-  //
-  // The values are directly returned by VSOP87D models, no any adjustment or correction.
-  const std::unordered_map<double, std::tuple<double, double, double>> dataset {
-    //    JDE          L-tables expected   B-tables expected        R-tables expected
-    {     2445701.1, { -98.77924318611353, -2.4184395622860954e-07, 0.9832889892830442 } },
-    {     2451545.0, {  1.751923868114564, -3.9655715721671785e-06, 0.9833276819105508 } },
-    {     2454359.1, {  50.13242197757078,  1.8719976476477224e-06, 1.0057018016353796 } },
-    { 2454774.36215, { 57.278324034743825,  1.7796468063658446e-06,  0.991769848723092 } },
-    {    2460505.25, {  155.8898001662818,   5.631659339720899e-07, 1.0165107642588653 } },
-    { 2462597.96105, { 191.92860080429793,  -5.548701174542588e-07, 1.0006923288119707 } },
-    {     2464080.5, { 217.42964975313058,  2.1118905113795144e-06, 1.0065840587631982 } },
-  };
+// Data was obtained from PyMeeus (https://pypi.org/project/PyMeeus/).
+// PyMeeus is a well-implemented Python library for astronomical calculations.
+//
+// The values are directly returned by VSOP87D models, no any adjustment or correction.
+const std::unordered_map<double, std::tuple<double, double, double>> EARTH_DATASET {
+  //    JDE          L-tables expected   B-tables expected        R-tables expected
+  {     2445701.1, { -98.77924318611353, -2.4184395622860954e-07, 0.9832889892830442 } },
+  {     2451545.0, {  1.751923868114564, -3.9655715721671785e-06, 0.9833276819105508 } },
+  {     2454359.1, {  50.13242197757078,  1.8719976476477224e-06, 1.0057018016353796 } },
+  { 2454774.36215, { 57.278324034743825,  1.7796468063658446e-06,  0.991769848723092 } },
+  {    2460505.25, {  155.8898001662818,   5.631659339720899e-07, 1.0165107642588653 } },
+  { 2462597.96105, { 191.92860080429793,  -5.548701174542588e-07, 1.0006923288119707 } },
+  {     2464080.5, { 217.42964975313058,  2.1118905113795144e-06, 1.0065840587631982 } },
+};
 
-  for (const auto& [jde, expected] : dataset) {
+TEST(Vsop87d, Evaluate) {
+  for (const auto& [jde, expected] : EARTH_DATASET) {
     const auto& [lon, lat, r] = expected;
     const auto jm = julian_day::jde_to_jm(jde);
 
     ASSERT_NEAR(evaluate_tables(earth_coeff::L, jm), lon, 1e-10);
     ASSERT_NEAR(evaluate_tables(earth_coeff::B, jm), lat, 1e-10);
     ASSERT_NEAR(evaluate_tables(earth_coeff::R, jm), r,   1e-10);
+  }
+}
+
+TEST(Vsop87d, EvaluateTemplate) {
+  // `evaluate<Planet::EAR>` is the field-mapping layer over `evaluate_tables`: .λ ← L, .β ← B,
+  // .r ← R, unadjusted. A swapped or rescaled field passes neither assertion family below.
+  for (const auto& [jde, expected] : EARTH_DATASET) {
+    const auto& [lon, lat, r] = expected;
+    const auto jm = julian_day::jde_to_jm(jde);
+    const auto eval = evaluate<Planet::EAR>(jm);
+
+    // The external dataset through the template path.
+    ASSERT_NEAR(eval.λ, lon, 1e-10);
+    ASSERT_NEAR(eval.β, lat, 1e-10);
+    ASSERT_NEAR(eval.r, r,   1e-10);
+
+    // Same bits as reading the tables directly — the wrapper neither scales nor reorders.
+    ASSERT_EQ(eval.λ, evaluate_tables(earth_coeff::L, jm));
+    ASSERT_EQ(eval.β, evaluate_tables(earth_coeff::B, jm));
+    ASSERT_EQ(eval.r, evaluate_tables(earth_coeff::R, jm));
   }
 }
 

--- a/src/test/jieqi_test.cpp
+++ b/src/test/jieqi_test.cpp
@@ -100,8 +100,8 @@ TEST(JieQi, GeneratorExclusiveStart) {
   ASSERT_EQ(jq2, Jieqi::春分);
   ASSERT_EQ(jde2, chunfen);
 
-  // The only deterministic way to hit the constructor's fall-through branch (jieqi.hpp:299-300):
-  // no jieqi of the start year lies ahead of 冬至, so it rolls over to next year's 小寒.
+  // The only deterministic way to hit the constructor's roll-over path (`++_year; _jq_index =
+  // 小寒`): no jieqi of the start year lies ahead of 冬至, so the next one is next year's 小寒.
   const auto [jq3, jde3] = JieqiGenerator { jieqi_jde(2025, Jieqi::冬至) }.next();
   ASSERT_EQ(jq3, Jieqi::小寒);
   ASSERT_EQ(jde3, jieqi_jde(2026, Jieqi::小寒));

--- a/src/test/jieqi_test.cpp
+++ b/src/test/jieqi_test.cpp
@@ -76,19 +76,19 @@ TEST(JieQi, YearGuard) {
 }
 
 TEST(JieQi, FromIndexBounds) {
-  // `from_index` guards its own domain — `Jieqi::COUNT` and the uint8_t ceiling are both out.
+  // 255 is the largest value the uint8_t parameter can carry — the input a checkless
+  // `static_cast` implementation would happily accept.
   ASSERT_THROW(std::ignore = from_index(JIEQI_COUNT), std::out_of_range);
   ASSERT_THROW(std::ignore = from_index(std::numeric_limits<uint8_t>::max()), std::out_of_range);
 
-  // Both ends of the valid range stay valid.
   ASSERT_EQ(from_index(0), Jieqi::立春);
   ASSERT_EQ(from_index(JIEQI_COUNT - 1), Jieqi::大寒);
 }
 
 TEST(JieQi, GeneratorExclusiveStart) {
-  // The generator's start is exclusive (see the class comment): starting exactly at a jieqi
-  // moment yields the *next* jieqi. The start here is the cached wrapper's own return value, so
-  // the comparison sees identical bits — this pins the boundary, not float luck.
+  // The generator's start is exclusive: starting exactly at a jieqi moment yields the *next*
+  // jieqi. The start here is the cached wrapper's own return value, so the comparison sees
+  // identical bits — this pins the boundary, not float luck.
   const double chunfen = jieqi_jde(2025, Jieqi::春分);
 
   const auto [jq1, jde1] = JieqiGenerator { chunfen }.next();
@@ -100,7 +100,8 @@ TEST(JieQi, GeneratorExclusiveStart) {
   ASSERT_EQ(jq2, Jieqi::春分);
   ASSERT_EQ(jde2, chunfen);
 
-  // Starting at the last jieqi of a year rolls over to next year's 小寒.
+  // The only deterministic way to hit the constructor's fall-through branch (jieqi.hpp:299-300):
+  // no jieqi of the start year lies ahead of 冬至, so it rolls over to next year's 小寒.
   const auto [jq3, jde3] = JieqiGenerator { jieqi_jde(2025, Jieqi::冬至) }.next();
   ASSERT_EQ(jq3, Jieqi::小寒);
   ASSERT_EQ(jde3, jieqi_jde(2026, Jieqi::小寒));

--- a/src/test/jieqi_test.cpp
+++ b/src/test/jieqi_test.cpp
@@ -22,7 +22,9 @@
  */
 
 #include <gtest/gtest.h>
+#include <cmath>
 #include <algorithm>
+#include <limits>
 #include <ranges>
 #include <type_traits>
 #include <vector>
@@ -71,6 +73,37 @@ TEST(JieQi, YearGuard) {
   // with `year + 1`.
   ASSERT_NO_THROW(std::ignore = calc_jieqi_jde(1, Jieqi::春分));
   ASSERT_NO_THROW(std::ignore = calc_jieqi_jde(32766, Jieqi::春分));
+}
+
+TEST(JieQi, FromIndexBounds) {
+  // `from_index` guards its own domain — `Jieqi::COUNT` and the uint8_t ceiling are both out.
+  ASSERT_THROW(std::ignore = from_index(JIEQI_COUNT), std::out_of_range);
+  ASSERT_THROW(std::ignore = from_index(std::numeric_limits<uint8_t>::max()), std::out_of_range);
+
+  // Both ends of the valid range stay valid.
+  ASSERT_EQ(from_index(0), Jieqi::立春);
+  ASSERT_EQ(from_index(JIEQI_COUNT - 1), Jieqi::大寒);
+}
+
+TEST(JieQi, GeneratorExclusiveStart) {
+  // The generator's start is exclusive (see the class comment): starting exactly at a jieqi
+  // moment yields the *next* jieqi. The start here is the cached wrapper's own return value, so
+  // the comparison sees identical bits — this pins the boundary, not float luck.
+  const double chunfen = jieqi_jde(2025, Jieqi::春分);
+
+  const auto [jq1, jde1] = JieqiGenerator { chunfen }.next();
+  ASSERT_EQ(jq1, Jieqi::清明);
+  ASSERT_EQ(jde1, jieqi_jde(2025, Jieqi::清明));
+
+  // One ulp before the moment, the moment itself is still ahead.
+  const auto [jq2, jde2] = JieqiGenerator { std::nextafter(chunfen, 0.0) }.next();
+  ASSERT_EQ(jq2, Jieqi::春分);
+  ASSERT_EQ(jde2, chunfen);
+
+  // Starting at the last jieqi of a year rolls over to next year's 小寒.
+  const auto [jq3, jde3] = JieqiGenerator { jieqi_jde(2025, Jieqi::冬至) }.next();
+  ASSERT_EQ(jq3, Jieqi::小寒);
+  ASSERT_EQ(jde3, jieqi_jde(2026, Jieqi::小寒));
 }
 
 TEST(JieQi, NameQuery) {


### PR DESCRIPTION
## 内容

补上 #87 的四条覆盖缺口,纯追加既有测试文件,+6 TEST(229 → 235):

- **jde↔ut1 转换链**(首次有测试):观测 ΔT 锚双向锚定 —— NASA eclipse 表 2000-01-01(63.83 s)/ USNO deltat.data 2020-01-01(69.36 s)/ Stephenson & Morrison 表 year 500(5710 s),容差按各锚点 |模型−观测| 上界写,不拿 `delta_t::compute` 当参照;401–2100 双向往返各 2000 抽样(EPSILON,实测残差 ~2e-8 day,余量 ~40x);域守卫负例并入 `JulianDay.InvalidInput` 与同族句式并排。
- **from_index 越界** + **JieqiGenerator 起点排他**三情形(恰在节气点 → 下一个;前一个 ulp → 本身;冬至 → ctor 的 roll-over 路径到次年小寒)。
- **`evaluate<Planet::EAR>` 字段映射**:与直读 `evaluate_tables` 按位相等(λ←L/β←B/r←R 的契约);PyMeeus 数据集提升为文件作用域 `EARTH_DATASET`,两个 TEST 共享。
- **moon_phase 三负例**:`newton_method` 端点窗口两负例 + `next_root` 非根种子负例。

约定(全仓负例一致遵守,写在这里而不是代码里):**负例只断言异常类型/谓词,不钉消息字符串** —— #86 将改 ~20 处 throw 措辞,钉了文本的负例会跟着碎。

#87 另两条候选核对后已有家:aberration、true_obliquity 已被 `earth_test.cpp` 覆盖(#100/#47);30° 护栏一条**有意不测**(800 年 585,250 个起点复扫,最大偏差 11.4056°,实际抛错 0)——合并后在 #87 回复注明。

## 审阅

- **R1**:grok 正确性盲审(P2×1 + P3×1)+ claude opus 风格(P2×3 + P3×12),T1 并行。
  - 最值钱的一条:grok 抓出 2020 锚 ΔT 写错年 —— 69.18 s 是 **2024** 的观测,2020-01-01 应为 69.36 s(USNO deltat.data,与仓内 `ACCURATE_DELTA_T_TABLE` 一致);测试在容差内照样绿,肉眼极难看出的那类。
- **R2**(原发现家复验):grok 全 GO;opus 13/15 GO + 四条分钟级文本待办(已修,opus 明示不需要第三轮)。
- 拒一条:负例种子改 HKO 字面值(低置信提案;求解器回归时满屏皆红,种子耦合的诊断损失接近零,字面值反引入无 provenance 魔数)。
- 转池一条:PyMeeus 数据集 provenance 缺采集日期/版本(既有欠账,真实日期不可考;观察池 #9,可执行形式 = 钉版重生成)。

## 验证

- 30/30 测试二进制绿,与 `TEST(` 宏对账相等(235);ruff / self-contained 32/32 / features 全绿。
- 检出率:六处注入全红 —— ΔT 符号翻转、from_index 守卫移除、Generator `>`→`>=`、evaluate λ/β 对调、newton_method 端点检查移除、next_root 种子守卫失效;修复批后两处复注入(ΔT 符号、λ/β 对调)仍全红。
- 审阅材料归档:side-projects vault `celestial/attachments/2026-08-06-nv-pr-a-审阅/`。

## 范围说明

纯测试追加,无生产代码改动。与 Pε(#51,已合 `a965ca6`)零交集。三个提交对应 施工 → R1 修复批 → R2 修复批,squash 合并即单提交。
