### PR TITLE
refactor(calendar): algo2 窗口 [410, 5000] → [410, 2500] —— 有误差预算的收窄 (#139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 * Time scales and time-related quantities: UT1 / UTC / TT with leap seconds and ΔT, Julian Day, sidereal time, obliquity, nutation (时标转换、儒略日、恒星时、黄赤交角、章动)
 * A C ABI shared library (`src/shared_lib/celestial.h`), so the library is consumable from other languages (C 接口动态库)
 
-The supported year range of lunar conversions depends on the algorithm: 1901–2099 for algo1 (Hong Kong Observatory data), 1600–2199 for algo3 (baked table), and 410–2500 for algo2 (computed from VSOP87D / ELP2000-82B — that window is a convention rather than a limit of the method, and it is enforced: years outside it are rejected. The 2500 ceiling is where the UTC+8 civil-day assignment stays reliable under the #139 error budget — frozen ΔAT table vs. unknowable future leap seconds, ~3.6% day-flip risk per new moon there). In C++ the bounds are the `START_YEAR` / `END_YEAR` constants of each `calendar::lunar::algoN`; the C ABI exports algo1 and algo2, and `get_supported_lunar_year_range` reports their bounds.
+The supported year range of lunar conversions depends on the algorithm: 1901–2099 for algo1 (Hong Kong Observatory data), 1600–2199 for algo3 (baked table), and 410–2500 for algo2 (computed from VSOP87D / ELP2000-82B — that window is a convention rather than a limit of the method, and it is enforced: years outside it are rejected; the 2500 ceiling comes from the #139 error budget). In C++ the bounds are the `START_YEAR` / `END_YEAR` constants of each `calendar::lunar::algoN`; the C ABI exports algo1 and algo2, and `get_supported_lunar_year_range` reports their bounds.
 
 ## 2. Requirements
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 * Time scales and time-related quantities: UT1 / UTC / TT with leap seconds and ΔT, Julian Day, sidereal time, obliquity, nutation (时标转换、儒略日、恒星时、黄赤交角、章动)
 * A C ABI shared library (`src/shared_lib/celestial.h`), so the library is consumable from other languages (C 接口动态库)
 
-The supported year range of lunar conversions depends on the algorithm: 1901–2099 for algo1 (Hong Kong Observatory data), 1600–2199 for algo3 (baked table), and 410–5000 for algo2 (computed from VSOP87D / ELP2000-82B — that window is a convention rather than a limit of the method, and it is enforced: years outside it are rejected). In C++ the bounds are the `START_YEAR` / `END_YEAR` constants of each `calendar::lunar::algoN`; the C ABI exports algo1 and algo2, and `get_supported_lunar_year_range` reports their bounds.
+The supported year range of lunar conversions depends on the algorithm: 1901–2099 for algo1 (Hong Kong Observatory data), 1600–2199 for algo3 (baked table), and 410–2500 for algo2 (computed from VSOP87D / ELP2000-82B — that window is a convention rather than a limit of the method, and it is enforced: years outside it are rejected. The 2500 ceiling is where the UTC+8 civil-day assignment stays reliable under the #139 error budget — frozen ΔAT table vs. unknowable future leap seconds, ~3.6% day-flip risk per new moon there). In C++ the bounds are the `START_YEAR` / `END_YEAR` constants of each `calendar::lunar::algoN`; the C ABI exports algo1 and algo2, and `get_supported_lunar_year_range` reports their bounds.
 
 ## 2. Requirements
 

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -50,8 +50,8 @@ using calendar::lunar::common::LunarYear;
 
 // A convention, not a physical ceiling — the method computes rather than looks up. The ceiling
 // sits where the UTC+8 civil-day assignment stops being reliable: the ΔAT table freezes at 37 s
-// past its last entry (2017), so if UTC keeps tracking UT1 — leap seconds or whatever succeeds
-// them (CGPM 2022 Res. 4) — the rendered civil time drifts from the real one by an unknowable
+// past its last entry (2017), so if UTC keeps tracking UT1 — leap seconds or a successor
+// mechanism (CGPM 2022 Res. 4) — the rendered civil time drifts from the real one by an unknowable
 // amount; VSOP·ELP drift is second-order. Error budget, measurement, threshold decision: #139.
 
 /** @brief The first supported lunar year. */

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -48,16 +48,18 @@ namespace calendar::lunar::algo2 {
 
 using calendar::lunar::common::LunarYear;
 
-// A convention, not a physical ceiling — the method computes rather than looks up. Past ~2100 ΔT
-// is extrapolated with no observational anchor; by year 5000 it reaches ~0.36 day and is uncertain
-// to its own order, enough to move a new moon across the UTC+8 midnight that starts a month.
-// Narrowing the window needs an error budget, not a cliff to cut at (#139).
+// A convention, not a physical ceiling — the method computes rather than looks up. The ceiling
+// sits where the UTC+8 civil-day assignment stops being reliable: post-1972 the frozen ΔAT
+// table (37 s) diverges from future reality by ΔT − 69.184 s, and ΔT itself is unknowable
+// (Huber Brownian σ); VSOP·ELP drift is second-order. At 2500 the day-flip risk is ~3.6% per
+// new moon (~1.5% counting only the unknowable part); by 5000 the answer is essentially random.
+// Error budget, measurement, and the threshold decision: #139.
 
 /** @brief The first supported lunar year. */
 inline constexpr int32_t START_YEAR = 410;
 
 /** @brief The last supported lunar year. */
-inline constexpr int32_t END_YEAR = 5000;
+inline constexpr int32_t END_YEAR = 2500;
 
 
 /**

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -49,11 +49,10 @@ namespace calendar::lunar::algo2 {
 using calendar::lunar::common::LunarYear;
 
 // A convention, not a physical ceiling — the method computes rather than looks up. The ceiling
-// sits where the UTC+8 civil-day assignment stops being reliable: post-1972 the frozen ΔAT
-// table (37 s) diverges from future reality by ΔT − 69.184 s, and ΔT itself is unknowable
-// (Huber Brownian σ); VSOP·ELP drift is second-order. At 2500 the day-flip risk is ~3.6% per
-// new moon (~1.5% counting only the unknowable part); by 5000 the answer is essentially random.
-// Error budget, measurement, and the threshold decision: #139.
+// sits where the UTC+8 civil-day assignment stops being reliable: the ΔAT table freezes at 37 s
+// past its last entry (2017), so if UTC keeps tracking UT1 — leap seconds or whatever succeeds
+// them (CGPM 2022 Res. 4) — the rendered civil time drifts from the real one by an unknowable
+// amount; VSOP·ELP drift is second-order. Error budget, measurement, threshold decision: #139.
 
 /** @brief The first supported lunar year. */
 inline constexpr int32_t START_YEAR = 410;

--- a/src/test/astro/sun_horizons_golden_test.cpp
+++ b/src/test/astro/sun_horizons_golden_test.cpp
@@ -48,9 +48,9 @@
 //   derived from THIS query pipeline agree with the HKO almanac (HMNAO/USNO — independent
 //   pipeline, same DE family) to 0.51 min worst over 168 values — validating both sources
 //   before either was pinned. Pre-1582 Horizons date comments are in the Julian calendar.
-// - Epoch bands mirror moon_horizons_golden_test.cpp, plus the lunar-algo2 boundary years
-//   ~410 and ~5001 demanded by #94 (the algo2 ceiling later narrowed to 2500 under #139;
-//   5001 stays as far-future coverage); JD 2^22 straddle guards the #76 cliff region.
+// - Epoch bands mirror moon_horizons_golden_test.cpp, plus ~410 (the lunar-algo2 lower bound)
+//   and ~5001 (far-future coverage, not the algo2 ceiling — #139) demanded by #94;
+//   JD 2^22 straddle guards the #76 cliff region.
 // Measured worst residuals are recorded above each tolerance; mutation detection results
 // are in the header of jieqi_golden_test.cpp (shared mutants exercise both files).
 
@@ -145,8 +145,8 @@ const std::vector<HorizonsSunRow> SUN_CORE_ROWS {
   {  2486166.25,  202.9117822,  -0.0000328,  0.9973374702 },  // 2094-Oct-15 18:00:00.000 TT, rdot -0.5028 km/s
 };
 
-// ~410 / ~501 / ~999 / ~1599 / ~2500 / ~3000 / ~5001 CE (410 and 5001 were the lunar-algo2
-// boundary years, #94; the ceiling narrowed to 2500 under #139, 5001 stays as far coverage).
+// ~410 / ~501 / ~999 / ~1599 / ~2500 / ~3000 / ~5001 CE (410 is the lunar-algo2 lower bound;
+// 5001 is far coverage, not the algo2 ceiling — #139).
 const std::vector<HorizonsSunRow> SUN_EXTENDED_ROWS {
   {  1870800.50,  271.7952269,  -0.0000561,  0.9833447140 },  // 0409-Dec-22 00:00:00.000 TT, rdot +0.1442 km/s
   {  1904000.50,  233.9657282,  -0.0000150,  0.9840446824 },  // 0500-Nov-14 00:00:00.000 TT, rdot -0.2157 km/s

--- a/src/test/astro/sun_horizons_golden_test.cpp
+++ b/src/test/astro/sun_horizons_golden_test.cpp
@@ -49,7 +49,8 @@
 //   pipeline, same DE family) to 0.51 min worst over 168 values — validating both sources
 //   before either was pinned. Pre-1582 Horizons date comments are in the Julian calendar.
 // - Epoch bands mirror moon_horizons_golden_test.cpp, plus the lunar-algo2 boundary years
-//   ~410 and ~5001 demanded by #94; JD 2^22 straddle guards the #76 cliff region.
+//   ~410 and ~5001 demanded by #94 (the algo2 ceiling later narrowed to 2500 under #139;
+//   5001 stays as far-future coverage); JD 2^22 straddle guards the #76 cliff region.
 // Measured worst residuals are recorded above each tolerance; mutation detection results
 // are in the header of jieqi_golden_test.cpp (shared mutants exercise both files).
 
@@ -144,8 +145,8 @@ const std::vector<HorizonsSunRow> SUN_CORE_ROWS {
   {  2486166.25,  202.9117822,  -0.0000328,  0.9973374702 },  // 2094-Oct-15 18:00:00.000 TT, rdot -0.5028 km/s
 };
 
-// ~410 / ~501 / ~999 / ~1599 / ~2500 / ~3000 / ~5001 CE (410 and 5001 are the lunar-algo2
-// boundary years, #94).
+// ~410 / ~501 / ~999 / ~1599 / ~2500 / ~3000 / ~5001 CE (410 and 5001 were the lunar-algo2
+// boundary years, #94; the ceiling narrowed to 2500 under #139, 5001 stays as far coverage).
 const std::vector<HorizonsSunRow> SUN_EXTENDED_ROWS {
   {  1870800.50,  271.7952269,  -0.0000561,  0.9833447140 },  // 0409-Dec-22 00:00:00.000 TT, rdot +0.1442 km/s
   {  1904000.50,  233.9657282,  -0.0000150,  0.9840446824 },  // 0500-Nov-14 00:00:00.000 TT, rdot -0.2157 km/s

--- a/src/test/jieqi_golden_test.cpp
+++ b/src/test/jieqi_golden_test.cpp
@@ -45,7 +45,9 @@
 //   fixed-slope Newton iteration to < 0.05 s. Pure TT on both sides of the comparison —
 //   no ΔT model anywhere in this axis. Sampling: all 24 for 2026; the equinox/solstice
 //   quartet for 1900/1950/2000/2050/2100 (core), 410/1000/1600/3000/5001 (extended, incl.
-//   the lunar-algo2 boundary years, #94) and 6771/6772/9420 (JD 2^22 straddle, #76 guard).
+//   the lunar-algo2 boundary years at the time, #94 — the algo2 ceiling later narrowed to
+//   2500 under #139; 5001 stays as far-future coverage of the solar chain) and 6771/6772/9420
+//   (JD 2^22 straddle, #76 guard).
 //   Row semantics: the crossing CONTAINED in the calendar year, like `jieqi_jde` (the
 //   crawler pins containment on proleptic-Gregorian TT civil days while the C++ window is
 //   UT1-based — a ΔT-scale difference with days of margin for every jieqi). The crawler's

--- a/src/test/jieqi_golden_test.cpp
+++ b/src/test/jieqi_golden_test.cpp
@@ -44,10 +44,9 @@
 //   31, IAU76/80 true-ecliptic-of-date) crosses k·15°, solved by the crawler's batched
 //   fixed-slope Newton iteration to < 0.05 s. Pure TT on both sides of the comparison —
 //   no ΔT model anywhere in this axis. Sampling: all 24 for 2026; the equinox/solstice
-//   quartet for 1900/1950/2000/2050/2100 (core), 410/1000/1600/3000/5001 (extended, incl.
-//   the lunar-algo2 boundary years at the time, #94 — the algo2 ceiling later narrowed to
-//   2500 under #139; 5001 stays as far-future coverage of the solar chain) and 6771/6772/9420
-//   (JD 2^22 straddle, #76 guard).
+//   quartet for 1900/1950/2000/2050/2100 (core), 410/1000/1600/3000/5001 (extended — 410 is
+//   the lunar-algo2 lower bound; 5001 is far-future coverage, not the algo2 ceiling, #139)
+//   and 6771/6772/9420 (JD 2^22 straddle, #76 guard).
 //   Row semantics: the crossing CONTAINED in the calendar year, like `jieqi_jde` (the
 //   crawler pins containment on proleptic-Gregorian TT civil days while the C++ window is
 //   UT1-based — a ΔT-scale difference with days of margin for every jieqi). The crawler's

--- a/src/test/lunar/converter_test.cpp
+++ b/src/test/lunar/converter_test.cpp
@@ -54,8 +54,8 @@ TEST(Converter, IsValidGregorian) {
 
     ASSERT_TRUE(Converter::is_valid_gregorian(2024y / 3 / 17));
 
-    ASSERT_TRUE(Converter::is_valid_gregorian(5000y / 2 / 8));
-    ASSERT_FALSE(Converter::is_valid_gregorian(5002y / 2 / 9));
+    ASSERT_TRUE(Converter::is_valid_gregorian(2500y / 2 / 8));
+    ASSERT_FALSE(Converter::is_valid_gregorian(2502y / 2 / 9));
   }
 
   {
@@ -103,6 +103,9 @@ TEST(Converter, IsValidLunar) {
     
     ASSERT_FALSE(Converter::is_valid_lunar(409y / 12 / 29));
     ASSERT_TRUE(Converter::is_valid_lunar(410y / 1 / 1));
+
+    ASSERT_TRUE(Converter::is_valid_lunar(2500y / 1 / 1));
+    ASSERT_FALSE(Converter::is_valid_lunar(2501y / 1 / 1));
   }
 
   {
@@ -139,8 +142,8 @@ TEST(Converter, GregorianToLunarNegative) {
     ASSERT_EQ(std::nullopt, Converter::gregorian_to_lunar(400y / 12 / 29));
     ASSERT_NE(std::nullopt, Converter::gregorian_to_lunar(411y / 1 / 1));
 
-    ASSERT_NE(std::nullopt, Converter::gregorian_to_lunar(5000y / 1 / 1));
-    ASSERT_EQ(std::nullopt, Converter::gregorian_to_lunar(5002y / 1 / 1));
+    ASSERT_NE(std::nullopt, Converter::gregorian_to_lunar(2500y / 1 / 1));
+    ASSERT_EQ(std::nullopt, Converter::gregorian_to_lunar(2502y / 1 / 1));
   }
 
   {

--- a/statistics/lunar_calendar.ipynb
+++ b/statistics/lunar_calendar.ipynb
@@ -326,7 +326,7 @@
      "output_type": "stream",
      "text": [
       "Algo1 range: SupportedLunarYearRange(start=1901, end=2099)\n",
-      "Algo2 range: SupportedLunarYearRange(start=410, end=5000)\n"
+      "Algo2 range: SupportedLunarYearRange(start=410, end=2500)\n"
      ]
     }
    ],

--- a/statistics/sun_jieqi_golden_crawler.py
+++ b/statistics/sun_jieqi_golden_crawler.py
@@ -53,8 +53,8 @@ MEAN_MOTION = 360.0 / 365.2422
 # --- Axis 1 epochs (same banding philosophy as moon_horizons_crawler.py) ---
 # Core band 1901-2094 (32 epochs stepped 2283.25 days) + the Meeus 25.b anchor.
 SUN_CORE_EPOCHS = [2415385.5 + k * 2283.25 for k in range(32)] + [2448908.5]
-# ~501/999/1599/2500/3000 CE, plus ~410 and ~5001 — the lunar-algo2 boundary years at the
-# time (#94); the algo2 ceiling later narrowed to 2500 (#139), 5001 stays as far coverage.
+# ~501/999/1599/2500/3000 CE; ~410 is the lunar-algo2 lower bound and ~5001 is far-future
+# coverage (not the algo2 ceiling — #139).
 SUN_EXTENDED_EPOCHS = [1870800.5, 1904000.5, 2086000.5, 2305000.5, 2634000.5, 2817000.5, 3547660.5]
 # JD 2^22 straddle (~6771 CE, #76 cliff guard) and ~9420 CE.
 SUN_FAR_EPOCHS = [4194303.5, 4194304.5, 5161700.5]

--- a/statistics/sun_jieqi_golden_crawler.py
+++ b/statistics/sun_jieqi_golden_crawler.py
@@ -53,7 +53,8 @@ MEAN_MOTION = 360.0 / 365.2422
 # --- Axis 1 epochs (same banding philosophy as moon_horizons_crawler.py) ---
 # Core band 1901-2094 (32 epochs stepped 2283.25 days) + the Meeus 25.b anchor.
 SUN_CORE_EPOCHS = [2415385.5 + k * 2283.25 for k in range(32)] + [2448908.5]
-# ~501/999/1599/2500/3000 CE, plus the lunar-algo2 boundary years ~410 and ~5001 (#94).
+# ~501/999/1599/2500/3000 CE, plus ~410 and ~5001 — the lunar-algo2 boundary years at the
+# time (#94); the algo2 ceiling later narrowed to 2500 (#139), 5001 stays as far coverage.
 SUN_EXTENDED_EPOCHS = [1870800.5, 1904000.5, 2086000.5, 2305000.5, 2634000.5, 2817000.5, 3547660.5]
 # JD 2^22 straddle (~6771 CE, #76 cliff guard) and ~9420 CE.
 SUN_FAR_EPOCHS = [4194303.5, 4194304.5, 5161700.5]


### PR DESCRIPTION
## 内容

algo2 声明窗口 **[410, 5000] → [410, 2500]**(#139 关账)。5000 一直是约定不是物理上界,但赖在那里等于「自信地给一个本质是随机的答案」(5000 处 μ=8.7h ± σ=3.4h,民用日归属已无可靠含义)。

收窄依据 = 三源误差预算(ΔT 历史不确定度 / 冻结 ΔAT 表 + 未来闰秒不可知 / VSOP·ELP 漂移),测量 = 59,356 个朔的日界相位扫描(相位均匀,翻转率线性)。**完整预算、风险曲线、阈值决策与三项待办核销在 [#139 这层评论](https://github.com/0xf3cd/celestial-calendar/issues/139#issuecomment-5201501842)** —— 代码注释只留失效模式与指针。

改动面(6 文件 + notebook):
- `algo2.hpp`:`END_YEAR` 5000 → 2500;约定注释 = 失效模式(UTC+8 民用日归属)+ 误差源主次(冻结 ΔAT 主导、VSOP·ELP 二阶)+ 前提条件句(CGPM 2022 Res.4)+ #139 指针,无预算数字。
- `converter_test.cpp`:四处端点断言追改(2500/2502 镜像原 5000/5002 形状)+ `IsValidLunar` 补上界对(2500 ✓/2501 ✗);其余全走符号化 bounds 零改动。
- `README.md`:窗口 410–2500 + 「#139 error budget」一层。
- 三处 golden/crawler 注释现在时化(410 是下界;5001 是太阳链远覆盖,不是 algo2 上界;数据行不动不重爬)。
- `lunar_calendar.ipynb` cell 13 录制输出刷新(5000 → 2500,按原代码真跑)。

阈值 2500 是用户拍板的产品判断:risk_total 2.53%(每 ~3.2 个阴历年约一次日界分歧);下界 410 不动(0.67% 自洽)。

## 审阅

R1 三席 T1 并行:kimi k3 清单(8 条核验,P1=0 · P2=1 · P3=3)+ claude opus 盲审(P2=1 · P3=5)+ grok 风格(P2=2 · P3=2)。最值钱两条:

- **opus:初版预算把系统偏置 μ 按双边计,2× 高估翻转率**(3.6% → 正确 2.53%)。opus 用 12,047 个朔实测验证单边口径(实际改日 1.82% vs 单边预测 1.64%)。方向保守,阈值不受影响;已修模型与全部数字。
- **kimi:notebook cell 13 残留旧窗口**(全仓唯一真残留);grok:预算数字住错层(常量定义/README 不该嵌测量报告)——两席合流 = 数字出代码、住 #139。

R2 三席原发现家复验:**全部 GO**(opus 复算 2500→2.53% 与它的口径逐位一致)。opus R2 指出「#139 还是开工单、审计链指向空位」——本 PR 先把预算长评贴进了 #139(见上链接)。

转池:jieqi_golden extended 带补 2500 行(对称性,下次爬时;观察池 #10)。

## 验证

- 30/30 测试二进制绿,TEST 235 对账;ruff / self-contained 32/32 绿。
- 检出率:`END_YEAR` 回改 5000 → `Converter.IsValidGregorian` / `IsValidLunar` / `GregorianToLunarNegative` 三红(`algo2_test` 走符号不打值,符合预期)。
- opus 盲审独立核验:收窄无漏网消费者(2501–5000 无人消费)、ABI 零传导风险、2500 以内无 regression(235/235 绿 + 新上沿边界实测 2501-02-18 ✓/02-19 ✗)。

## 范围说明

行为变化只有一处:阴历年 > 2500 的查询从「给答案」变 `out_of_range`(C ABI `valid=false`)。天文层(jieqi/sun/moon)无窗口,不受影响(5001 golden 仍绿)。两个提交 = 收窄施工 + R1 修复批,squash 合并即单提交。
