### PR TITLE
导出面收口与发布链路 —— 显式 CELESTIAL_API + 集合闸门 + 产物必须属于 tag (#91, #72)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -103,6 +103,11 @@ jobs:
 
           # Take what `cmake --install` produced in the container: real library file,
           # SOVERSION symlinks, and the published header (lib/ + include/ tree).
+          # The symlinks are checked below but do NOT survive the upload: upload-artifact@v7
+          # dereferences them, so a consumer downloading the artifact gets three identical
+          # copies rather than a version chain (measured on this PR's first green run).
+          # Harmless to link against -- the unversioned name is still there -- but do not
+          # promise a consumer a symlink chain.
           cp -r "$OUTPUT_DIR/install/." "$DEST_DIR/"
 
           VERSION="${{ steps.get-build-version.outputs.BUILD_VERSION }}"
@@ -186,6 +191,9 @@ jobs:
         CC:  clang
       run: |
         # Install by CMake's rules: real .dylib + version symlinks + the published header.
+        # The symlinks do not survive upload-artifact@v7 (it dereferences them) -- see the
+        # linux-docker packaging step for the measurement. Guard on install's output anyway:
+        # that is the step this job owns.
         cmake --install ./build --prefix ./macos_arm64
 
         VERSION=$(./project.py --version)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -87,8 +87,8 @@ jobs:
             --build-arg CELESTIAL_TEST_SEED=${{ env.CELESTIAL_TEST_SEED }} \
             --load .
 
-          # Run the Docker image and copy build artifacts to the output directory
-          docker run --rm -v $OUTPUT_DIR:/output $IMAGE_TAG /bin/bash -c 'tree /app/build && cp -r /app/build/shared_lib /output/ && cp /app/*.json /output/'
+          # Run the Docker image and install the artifacts to the output directory
+          docker run --rm -v $OUTPUT_DIR:/output $IMAGE_TAG /bin/bash -c 'tree /app/build && cmake --install /app/build --prefix /output/install && cp /app/*.json /output/'
 
 
       - name: Rename Shared Library
@@ -97,37 +97,31 @@ jobs:
           # Store the current working directory
           ROOT_DIR=$(pwd)
 
-          # Change to the directory containing the shared libraries
-          cd "$OUTPUT_DIR/shared_lib" || exit
-
-          # Create an array of shared library files
-          libs=(*.dylib *.so *.dll)
-
           # Create a destination directory
           DEST_DIR="$ROOT_DIR/${OS}_${ARCH}"
           mkdir -p "$DEST_DIR"
 
-          # Copy the shared libraries to the destination directory
-          for lib in "${libs[@]}"; do
-            if [ -f "$lib" ]; then
-              cp "$lib" "$DEST_DIR/"
-            fi
-          done
+          # Take what `cmake --install` produced in the container: real library file,
+          # SOVERSION symlinks, and the published header (lib/ + include/ tree).
+          cp -r "$OUTPUT_DIR/install/." "$DEST_DIR/"
 
-          # Guard on what was copied. The JSON files and the header below keep this directory
-          # non-empty whatever happens, so `if-no-files-found: error` on the upload cannot catch
-          # an artifact that ships with no library in it (#72).
-          if [ "$(find "$DEST_DIR" \( -name '*.so' -o -name '*.dylib' -o -name '*.dll' \) -type f | wc -l)" -eq 0 ]; then
-            echo "No shared library copied out of $OUTPUT_DIR/shared_lib"
-            exit 1
-          fi
+          VERSION="${{ steps.get-build-version.outputs.BUILD_VERSION }}"
+          SOVERSION="${VERSION%.*}"  # major.minor -- the CMakeLists SOVERSION rule while 0.x
+
+          # Guard on what install produced, not on what a glob matched (#72): the JSON
+          # files below keep this directory non-empty whatever happens, so
+          # `if-no-files-found: error` on the upload cannot catch an artifact that ships
+          # with no library in it.
+          ok=1
+          [ -f "$DEST_DIR/lib/libcelestial_calendar.so.${VERSION}" ] || { echo "missing lib/libcelestial_calendar.so.${VERSION}"; ok=0; }
+          [ -L "$DEST_DIR/lib/libcelestial_calendar.so.${SOVERSION}" ] || { echo "missing symlink lib/libcelestial_calendar.so.${SOVERSION}"; ok=0; }
+          [ -L "$DEST_DIR/lib/libcelestial_calendar.so" ] || { echo "missing symlink lib/libcelestial_calendar.so"; ok=0; }
+          [ -f "$DEST_DIR/include/celestial.h" ] || { echo "missing include/celestial.h"; ok=0; }
+          [ "$ok" -eq 1 ] || exit 1
 
           # Copy the build info JSON files to the destination directory
           cp "$OUTPUT_DIR/build_info.json" "$DEST_DIR/"
           cp "$OUTPUT_DIR/cpu_info.json" "$DEST_DIR/"
-
-          # Ship the published C-ABI header alongside the library
-          cp "$ROOT_DIR/src/shared_lib/celestial.h" "$DEST_DIR/"
 
           # Set environment variables for GitHub Actions
           {
@@ -191,22 +185,22 @@ jobs:
         CXX: clang++
         CC:  clang
       run: |
-        # Create a folder "macos_arm64" at root dir and copy the new shared library to it
-        mkdir -p ./macos_arm64
+        # Install by CMake's rules: real .dylib + version symlinks + the published header.
+        cmake --install ./build --prefix ./macos_arm64
 
-        # Find and copy real files (not symlinks)
-        find ./build/shared_lib -name "*.dylib" -type f -exec cp {} ./macos_arm64 \;
+        VERSION=$(./project.py --version)
+        SOVERSION="${VERSION%.*}"  # major.minor -- the CMakeLists SOVERSION rule while 0.x
 
-        # Guard on what was copied, not on what a glob matched: with only symlinks and no real
-        # file, `-type f` copies nothing while `celestial.h` and `build_info.json` keep the
-        # directory non-empty, so `if-no-files-found: error` never fires (#72).
-        if [ "$(find ./macos_arm64 -name '*.dylib' -type f | wc -l)" -eq 0 ]; then
-          echo "No real .dylib copied out of ./build/shared_lib"
-          exit 1
-        fi
-
-        # Ship the published C-ABI header alongside the library
-        cp ./src/shared_lib/celestial.h ./macos_arm64/
+        # Guard on what install produced, not on what a glob matched (#72). macOS puts the
+        # version inside the name: real file libcelestial_calendar.${VERSION}.dylib with
+        # .${SOVERSION}.dylib and .dylib symlinks (shape pinned by the first CI run of this
+        # step, 2026-08).
+        ok=1
+        [ -f "./macos_arm64/lib/libcelestial_calendar.${VERSION}.dylib" ] || { echo "missing lib/libcelestial_calendar.${VERSION}.dylib"; ok=0; }
+        [ -L "./macos_arm64/lib/libcelestial_calendar.${SOVERSION}.dylib" ] || { echo "missing symlink lib/libcelestial_calendar.${SOVERSION}.dylib"; ok=0; }
+        [ -L "./macos_arm64/lib/libcelestial_calendar.dylib" ] || { echo "missing symlink lib/libcelestial_calendar.dylib"; ok=0; }
+        [ -f "./macos_arm64/include/celestial.h" ] || { echo "missing include/celestial.h"; ok=0; }
+        [ "$ok" -eq 1 ] || exit 1
 
         # Pack the "build_info.json" to the "macos_arm64" folder
         chmod +x ./toolbox/build_info.py
@@ -270,36 +264,21 @@ jobs:
         run: |
           # Define the root directory and output directory
           $ROOT_DIR = (Get-Location).Path
-          $LIB_DIR = "./build/shared_lib"
-
-          # Create a folder "windows_x86_64" at root dir
           $destDir = "$ROOT_DIR/windows_x86_64"
-          New-Item -ItemType Directory -Path $destDir -Force
 
-          # Get all .dll and .lib files
-          $dllFiles = Get-ChildItem -Path "$LIB_DIR" -Filter *.dll
-          $libFiles = Get-ChildItem -Path "$LIB_DIR" -Filter *.lib
+          # Install by CMake's rules: the .dll lands in bin/, its import .lib in lib/,
+          # the published header in include/.
+          cmake --install ./build --prefix $destDir
 
-          # Copy all .dll files to the destination directory
-          foreach ($dll in $dllFiles) {
-            Copy-Item -Path $dll.FullName -Destination $destDir
-          }
-
-          # Copy all .lib files to the destination directory
-          foreach ($lib in $libFiles) {
-            Copy-Item -Path $lib.FullName -Destination $destDir
-          }
-
-          # Guard on what was copied. The header and build_info.json below keep this directory
-          # non-empty whatever happens, so `if-no-files-found: error` on the upload cannot catch an
-          # artifact that ships with no library in it (#72).
-          if (@(Get-ChildItem -Path $destDir -File | Where-Object { $_.Extension -in '.dll', '.lib' }).Count -eq 0) {
-            Write-Error "No shared library copied out of $LIB_DIR"
-            exit 1
-          }
-
-          # Ship the published C-ABI header alongside the library
-          Copy-Item -Path ./src/shared_lib/celestial.h -Destination $destDir
+          # Guard on what install produced, not on what a glob matched (#72):
+          # build_info.json below keeps this directory non-empty whatever happens, so
+          # `if-no-files-found: error` on the upload cannot catch an artifact that ships
+          # with no library in it.
+          $ok = $true
+          if (!(Test-Path "$destDir/bin/celestial_calendar.dll")) { Write-Output "missing bin/celestial_calendar.dll"; $ok = $false }
+          if (!(Test-Path "$destDir/lib/celestial_calendar.lib")) { Write-Output "missing lib/celestial_calendar.lib"; $ok = $false }
+          if (!(Test-Path "$destDir/include/celestial.h")) { Write-Output "missing include/celestial.h"; $ok = $false }
+          if (!$ok) { exit 1 }
 
           # Pack the "build_info.json" to the "windows_x86_64" folder
           python3 ./toolbox/build_info.py --save-to $destDir

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -193,8 +193,7 @@ jobs:
 
         # Guard on what install produced, not on what a glob matched (#72). macOS puts the
         # version inside the name: real file libcelestial_calendar.${VERSION}.dylib with
-        # .${SOVERSION}.dylib and .dylib symlinks (shape pinned by the first CI run of this
-        # step, 2026-08).
+        # .${SOVERSION}.dylib and .dylib symlinks.
         ok=1
         [ -f "./macos_arm64/lib/libcelestial_calendar.${VERSION}.dylib" ] || { echo "missing lib/libcelestial_calendar.${VERSION}.dylib"; ok=0; }
         [ -L "./macos_arm64/lib/libcelestial_calendar.${SOVERSION}.dylib" ] || { echo "missing symlink lib/libcelestial_calendar.${SOVERSION}.dylib"; ok=0; }

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -134,6 +134,15 @@ jobs:
       - name: Smoke-test the ctypes bindings
         run: python3 ./linter.py --ctypes-smoke
 
+      # The export-surface gate (#91) needs the built library for its dynamic half
+      # (nm/readelf on the real .so), so it sits next to the ctypes smoke gate. One leg
+      # is enough: the static half parses the header on any platform, and the dynamic
+      # verdict -- strong exports plus std vague-linkage survivors -- is
+      # toolchain-independent. What it cannot prove is the Windows/macOS branch of the
+      # CELESTIAL_API macro; only cabi_smoke_test linking the DLL on those CI legs can.
+      - name: Check the export surface
+        run: python3 ./linter.py --export-surface
+
 
   # macOS and Windows build+test are not here: they live in `build_and_test.yml`, which runs on
   # pull requests to main and packages the artifacts -- running them here too repeated the same

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -143,6 +143,12 @@ jobs:
       - name: Check the export surface
         run: python3 ./linter.py --export-surface
 
+      # The log-names gate (#72) is pure parsing -- but it shares the entry-point parser
+      # with the export-surface gate above, so it sits on the same leg: one place to look
+      # when a header change trips the pair.
+      - name: Check the log strings
+        run: python3 ./linter.py --log-names
+
 
   # macOS and Windows build+test are not here: they live in `build_and_test.yml`, which runs on
   # pull requests to main and packages the artifacts -- running them here too repeated the same

--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ There are basically two ways to download:
   # Download artifacts from a given run to the specified dir
   python3 ./toolbox/artifact_downloader.py -id <run-id> -s <directory>
 
-  # Download artifacts from latest run to the specified dir
+  # Download artifacts from the successful run that built HEAD, to the specified dir
   python3 ./toolbox/artifact_downloader.py -s <directory>
 
-  # Download artifacts from latest run to the specified dir and unzips them
+  # Same, and unzips them
   python3 ./toolbox/artifact_downloader.py -s <directory> --unzip
 
   # More usages

--- a/automation/__init__.py
+++ b/automation/__init__.py
@@ -30,6 +30,7 @@ from .self_contained import check_self_contained
 from .feature_probe import probe_features
 from .abi_layout import check_abi_layout
 from .ctypes_smoke import check_ctypes_smoke
+from .export_surface import check_export_surface
 from .bench import build_benchmarks, run_benchmarks, find_benchmarks
 
 __all__ = [
@@ -41,6 +42,6 @@ __all__ = [
   "run_cmd", "ProcReturn", "time_execution",
   "proj_root", "build_dir", "cpp_src_dir", "python_requirements", "cpp_test_dir",
   "GitHub", "run_ruff", "run_clang_tidy", "check_self_contained", "probe_features",
-  "check_abi_layout", "check_ctypes_smoke",
+  "check_abi_layout", "check_ctypes_smoke", "check_export_surface",
   "build_benchmarks", "run_benchmarks", "find_benchmarks"
 ]

--- a/automation/__init__.py
+++ b/automation/__init__.py
@@ -31,6 +31,7 @@ from .feature_probe import probe_features
 from .abi_layout import check_abi_layout
 from .ctypes_smoke import check_ctypes_smoke
 from .export_surface import check_export_surface
+from .log_names import check_log_names
 from .bench import build_benchmarks, run_benchmarks, find_benchmarks
 
 __all__ = [
@@ -42,6 +43,6 @@ __all__ = [
   "run_cmd", "ProcReturn", "time_execution",
   "proj_root", "build_dir", "cpp_src_dir", "python_requirements", "cpp_test_dir",
   "GitHub", "run_ruff", "run_clang_tidy", "check_self_contained", "probe_features",
-  "check_abi_layout", "check_ctypes_smoke", "check_export_surface",
+  "check_abi_layout", "check_ctypes_smoke", "check_export_surface", "check_log_names",
   "build_benchmarks", "run_benchmarks", "find_benchmarks"
 ]

--- a/automation/export_surface.py
+++ b/automation/export_surface.py
@@ -1,0 +1,243 @@
+# CelestialCalendar Automation:
+#   Python automation scripts for building and testing the CelestialCalendar C++ project.
+#
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+# License: GNU General Public License v3.0
+#
+# This software is distributed without any warranty.
+# See <https://www.gnu.org/licenses/> for more details.
+
+import re
+import shutil
+
+from pathlib import Path
+from typing import Dict, Final, List, Optional, Tuple
+
+from . import paths
+from .abi_layout import STRUCT_RE
+from .utils import run_cmd, green_print, red_print, yellow_print
+
+
+# Non-entry exports that must stay exported anyway, each mapped to the reason it cannot
+# be hidden (#91: list every survivor with its reason, never fold them into a count).
+# Empty today: every current survivor is a std vague-linkage weak/unique symbol, matched
+# by the vague-linkage predicate below rather than listed here. The human-facing copy of
+# this list lives in src/shared_lib/CMakeLists.txt; this constant is the machine-readable
+# source.
+SURVIVOR_EXCEPTIONS: Final[Dict[str, str]] = {
+}
+
+# What a survivor may look like without being listed in SURVIVOR_EXCEPTIONS: vague-linkage
+# artifacts of C++ itself. Namespace std carries an explicit default-visibility attribute
+# that overrides -fvisibility=hidden, and cross-DSO coalescing of these weak symbols needs
+# them visible; RTTI for builtin or function types names no symbol a consumer could link
+# against. Anything else that escapes the hiding must be named in SURVIVOR_EXCEPTIONS
+# with a reason -- widening this predicate instead defeats the gate.
+def is_std_vague_linkage(demangled: str) -> bool:
+  """Whether a demangled survivor is a C++ vague-linkage artifact rather than API surface."""
+  if "std::" in demangled or "__gnu_cxx::" in demangled:
+    return True
+  # "typeinfo for double", "typeinfo name for double (int, Jieqi)" -- the latter embeds
+  # our type names in the signature, but the symbol itself is anonymous RTTI.
+  return demangled.startswith(("typeinfo for ", "typeinfo name for "))
+
+# Parser self-test samples (shape -> expected (name, has_macro) pairs). The gate runs
+# these before trusting the parser: a parser that cannot read the declaration shapes in
+# use would report a maimed entry set and call it green. One sample per shape in play:
+# macro-prefixed plain, pointer return type, multi-line parameter list, and one
+# declaration without the macro (the mutation the static half exists to catch).
+PARSER_SELF_TEST: Final[List[Tuple[str, List[Tuple[str, bool]]]]] = [
+  ("CELESTIAL_API bool alpha(uint8_t v);", [("alpha", True)]),
+  ("CELESTIAL_API const char *beta(void);", [("beta", True)]),
+  ("CELESTIAL_API uint32_t gamma(int32_t year,\n"
+   "                                double longitude,\n"
+   "                                double *slots,\n"
+   "                                uint32_t slot_count);", [("gamma", True)]),
+  ("double delta(double jde);", [("delta", False)]),
+]
+
+FUNC_NAME_RE: Final[re.Pattern] = re.compile(r"(\w+)\s*\(")
+SONAME_RE: Final[re.Pattern] = re.compile(r"Library soname: \[(libcelestial_calendar\.so\.\d+\.\d+)\]")
+REAL_SO_RE: Final[re.Pattern] = re.compile(r"^libcelestial_calendar\.so\.(\d+)\.(\d+)\.(\d+)$")
+
+
+def strip_comments(text: str) -> str:
+  """Remove /* */ and // comments so they cannot fake or hide declarations."""
+  text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+  return re.sub(r"//[^\n]*", "", text)
+
+
+def parse_declarations(text: str) -> List[Tuple[str, bool]]:
+  """Parse file-scope function declarations in `celestial.h` -> (name, has_macro) pairs.
+
+  Preprocessor lines and `typedef struct` bodies are removed first; what remains at
+  file scope is split into `;`-terminated statements, and every statement containing
+  `(` is a function declaration. Declarations WITHOUT the macro are returned too --
+  flagging them is exactly what the static half of the gate is for.
+  """
+  text = strip_comments(text)
+  text = "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
+  text = STRUCT_RE.sub("", text)
+
+  decls: List[Tuple[str, bool]] = []
+  for stmt in text.split(";"):
+    if "(" not in stmt:
+      continue
+    m = FUNC_NAME_RE.search(stmt)
+    if m is None:
+      continue
+    decls.append((m.group(1), "CELESTIAL_API" in stmt))
+  return decls
+
+
+def entry_point_names(header: Path) -> List[str]:
+  """The entry-point set of `celestial.h`, macro status ignored (the gate checks that)."""
+  return sorted(name for name, _ in parse_declarations(header.read_text()))
+
+
+def self_test_parser() -> List[str]:
+  """Hold the parser to the pinned shape samples; a failure means the gate is broken."""
+  failures: List[str] = []
+  for sample, expected in PARSER_SELF_TEST:
+    actual = parse_declarations(sample)
+    if actual != expected:
+      failures.append(f"parser self-test: {sample!r} -> {actual!r}, expected {expected!r}")
+  return failures
+
+
+def find_real_so(shared_lib_dir: Path) -> Optional[Path]:
+  """Locate the real built library (not a symlink); None means the build is missing."""
+  for candidate in sorted(shared_lib_dir.iterdir()) if shared_lib_dir.is_dir() else []:
+    if REAL_SO_RE.match(candidate.name) and not candidate.is_symlink():
+      return candidate
+  return None
+
+
+def nm_defined(so: Path) -> Dict[str, str]:
+  """`nm -D --defined-only` as a name -> type-letter map. A missing nm turns the gate red."""
+  if shutil.which("nm") is None:
+    raise RuntimeError("nm not found (needs binutils)")
+  ret = run_cmd(["nm", "-D", "--defined-only", str(so)], print_cmd=False, print_stdout=False)
+  if ret.retcode != 0:
+    raise RuntimeError(f"nm failed on {so} (exit {ret.retcode})")
+  symbols: Dict[str, str] = {}
+  for line in ret.stdout.splitlines():
+    parts = line.split()
+    if len(parts) >= 3:
+      symbols[parts[2]] = parts[1]
+  return symbols
+
+
+def demangle(names: List[str]) -> Dict[str, str]:
+  """c++filt the given names. A missing c++filt turns the gate red, never a silent pass."""
+  if shutil.which("c++filt") is None:
+    raise RuntimeError("c++filt not found (needs binutils)")
+  ret = run_cmd(["c++filt"] + names, print_cmd=False, print_stdout=False)
+  if ret.retcode != 0:
+    raise RuntimeError(f"c++filt failed (exit {ret.retcode})")
+  return dict(zip(names, ret.stdout.splitlines(), strict=True))
+
+
+def read_soname(so: Path) -> Optional[str]:
+  """The DT_SONAME of the built library, via `readelf -d`."""
+  if shutil.which("readelf") is None:
+    raise RuntimeError("readelf not found (needs binutils)")
+  ret = run_cmd(["readelf", "-d", str(so)], print_cmd=False, print_stdout=False)
+  if ret.retcode != 0:
+    raise RuntimeError(f"readelf failed on {so} (exit {ret.retcode})")
+  m = SONAME_RE.search(ret.stdout)
+  return m.group(1) if m else None
+
+
+def check_export_surface() -> int:
+  """Hold the export surface of the built library to the entry points of `celestial.h` (#91).
+
+  Two halves, each covering what the other cannot:
+  - static: every file-scope declaration in celestial.h carries CELESTIAL_API. A missing
+    macro is a missing export on Windows -- caught here, without needing a Windows leg.
+  - dynamic: the strong defined symbols of the built .so are exactly the entry set plus
+    SURVIVOR_EXCEPTIONS, and every survivor beyond that is a std vague-linkage weak/unique
+    symbol (the vague-linkage predicate). This is the half that proves the hiding held.
+  Plus a SONAME pin: DT_SONAME must be the major.minor form of the real file's version,
+  which is the promise the CMakeLists SOVERSION comment makes while 0.x.
+
+  Needs the built library (`./project.py --build`): a missing build turns the gate red,
+  never a silent skip. The parser self-test runs first -- a broken parser must fail the
+  gate, not pass it with a maimed entry set.
+  """
+  print("#" * 60)
+  yellow_print("Checking that the export surface matches the celestial.h entry points...")
+
+  failures: List[str] = self_test_parser()
+  if failures:
+    for f in failures:
+      red_print(f"  - {f}")
+    red_print("Export-surface gate is broken (parser self-test failed); fix the parser, not the data")
+    return 1
+
+  header = paths.proj_root() / "src" / "shared_lib" / "celestial.h"
+  decls = parse_declarations(header.read_text())
+  if not decls:
+    red_print(f"No entry declarations parsed from {header}; the parser is broken")
+    return 1
+
+  # Static half: every declaration carries the macro.
+  for name, has_macro in decls:
+    if not has_macro:
+      failures.append(f"{name}: declaration in celestial.h without CELESTIAL_API")
+  entries = {name for name, _ in decls}
+
+  # Dynamic half, on the real built library.
+  so = find_real_so(paths.build_dir() / "shared_lib")
+  if so is None:
+    red_print("Built library not found (run ./project.py --build first)")
+    return 1
+
+  try:
+    symbols = nm_defined(so)
+  except RuntimeError as e:
+    red_print(str(e))
+    return 1
+
+  exported = set(symbols.keys())
+
+  missing = sorted(entries - exported)
+  for name in missing:
+    failures.append(f"{name}: entry point not exported by {so.name}")
+
+  survivors = sorted(exported - entries)
+  demangled = demangle(survivors) if survivors else {}
+  for name in survivors:
+    if name in SURVIVOR_EXCEPTIONS:
+      continue
+    if is_std_vague_linkage(demangled[name]):
+      continue
+    failures.append(
+      f"{name} ({demangled[name]}): exported but neither an entry point nor a std "
+      f"vague-linkage symbol -- hide it, or add it to SURVIVOR_EXCEPTIONS with a reason"
+    )
+
+  # SONAME pin: major.minor of the real file's version, per the CMakeLists comment.
+  version = REAL_SO_RE.match(so.name)
+  assert version is not None  # find_real_so only returns REAL_SO_RE matches
+  expected_soname = f"libcelestial_calendar.so.{version.group(1)}.{version.group(2)}"
+  try:
+    soname = read_soname(so)
+  except RuntimeError as e:
+    red_print(str(e))
+    return 1
+  if soname != expected_soname:
+    failures.append(f"SONAME is {soname!r}, expected {expected_soname!r} (major.minor of VERSION while 0.x)")
+
+  print("#" * 60)
+  if failures:
+    red_print(f"Export-surface gate failed ({len(failures)} finding(s)):")
+    for f in failures:
+      red_print(f"  - {f}")
+    return 1
+
+  green_print(f"export surface == celestial.h entry points ({len(entries)} entries, "
+              f"{len(survivors)} std vague-linkage survivors, SONAME {soname})")
+  return 0

--- a/automation/export_surface.py
+++ b/automation/export_surface.py
@@ -53,22 +53,30 @@ PREDICATE_SELF_TEST: Final[List[Tuple[str, bool]]] = [
   ("astro::Foo::operator std::vector<double>()", False),
   ("typeinfo for astro::Foo", False),
   ("vtable for astro::Foo", False),
-  # The two residuals the predicate knowingly passes, pinned so that tightening the
-  # rule shows up here as a diff instead of silently changing what the gate accepts.
+  # The hole below, pinned on the shape that can actually reach the gate: a
+  # global-namespace user type is spelled like a builtin, and celestial.h's C-ABI
+  # structs are exactly that. Tightening the rule turns this line red instead of
+  # silently changing what the gate accepts.
+  ("typeinfo for JulianDay", True),
+  # The other pass-through, for symmetry: "(" is a stand-in for "function type".
   ("typeinfo for astro::Fn<double (int)>", True),
-  ("typeinfo for (anonymous namespace)::Foo", True),
 ]
 
 
 def is_std_vague_linkage(demangled: str) -> bool:
   """Whether a demangled survivor is a C++ vague-linkage artifact rather than API surface."""
-  # RTTI: a builtin's or a function type's typeinfo names nothing a consumer could link
-  # against; a user type's is a defined data symbol in the dynamic table, so it takes the
-  # qualified-name check like a vtable. Two residuals, both knowingly left: "(" stands in
-  # for "function type", so `Fn<double(int)>` and `(anonymous namespace)::Foo` pass; and a
-  # global-namespace class reads exactly like a builtin here -- celestial.h's C-ABI structs
-  # are that shape, and emit no RTTI only because they are POD. Both are strictly narrower
-  # than the "pass every typeinfo" this replaced; tighten if a survivor ever leaks through.
+  # RTTI. The line to draw is whether the name mentions a type this library owns: that
+  # is what a consumer could name, catch, or dynamic_cast against, so it takes the
+  # qualified-name check like a vtable. Being a defined data symbol does not separate
+  # anything -- function-type RTTI is one too (this .so exports `typeinfo for double
+  # (int, calendar::jieqi::Jieqi)`).
+  #
+  # The name is all we have, and it leaves one hole: a global-namespace user type is
+  # spelled exactly like a builtin. celestial.h's C-ABI structs are that shape; they
+  # emit no RTTI today because they are non-polymorphic and never an operand of typeid
+  # or throw -- POD-ness is not what decides it. Closing the hole means enumerating the
+  # builtin spellings; until something leaks, the hole is pinned in the self-test above.
+  # Using "(" for "function type" is the other approximation, kept for the same reason.
   for prefix in ("typeinfo for ", "typeinfo name for "):
     if demangled.startswith(prefix):
       rest = demangled[len(prefix):]

--- a/automation/export_surface.py
+++ b/automation/export_surface.py
@@ -32,48 +32,51 @@ SURVIVOR_EXCEPTIONS: Final[Dict[str, str]] = {
 # What a survivor may look like without being listed in SURVIVOR_EXCEPTIONS: vague-linkage
 # artifacts of C++ itself. Namespace std carries an explicit default-visibility attribute
 # that overrides -fvisibility=hidden, and cross-DSO coalescing of these weak symbols needs
-# them visible; RTTI for builtin or function types names no symbol a consumer could link
-# against. Anything else that escapes the hiding must be named in SURVIVOR_EXCEPTIONS
-# with a reason -- widening this predicate instead defeats the gate.
-VAGUE_LINKAGE_PREFIXES: Final[Tuple[str, ...]] = (
-  "vtable for ",
-  "VTT for ",
-  "guard variable for ",
-)
+# them visible; RTTI for builtin or function types is anonymous. Anything else that
+# escapes the hiding must be named in SURVIVOR_EXCEPTIONS with a reason -- widening this
+# predicate instead defeats the gate.
 
 # Predicate self-test: std-owned shapes must pass, user-owned shapes must not -- in
-# particular a user symbol whose argument or return type merely mentions std:: (that
-# substring must not whitewash it), the hole this predicate was tightened for.
+# particular a user symbol whose argument, return type, or conversion-operator target
+# merely mentions std:: (that substring must not whitewash it), and user-type RTTI,
+# which unlike builtin/function-type RTTI names a type a consumer can link against.
 PREDICATE_SELF_TEST: Final[List[Tuple[str, bool]]] = [
   ("char* std::__add_grouping<char>(char*, char*, char)", True),
   ("vtable for std::vector<double, std::allocator<double> >", True),
+  ("typeinfo for double", True),
   ("typeinfo for double (int, calendar::jieqi::Jieqi)", True),
   ("typeinfo name for std::vector<double>", True),
   ("astro::sun::geocentric_coord(double)", False),
   ("astro::foo(std::basic_string<char, std::char_traits<char> >)", False),
   ("std::vector<double> astro::make_vec(double)", False),
   ("astro::Holder<std::string>::get()", False),
+  ("astro::Foo::operator std::vector<double>()", False),
+  ("typeinfo for astro::Foo", False),
+  ("vtable for astro::Foo", False),
 ]
 
 
 def is_std_vague_linkage(demangled: str) -> bool:
   """Whether a demangled survivor is a C++ vague-linkage artifact rather than API surface."""
-  # "typeinfo for double", "typeinfo name for double (int, Jieqi)" -- the latter embeds
-  # our type names in the signature, but the symbol itself is anonymous RTTI. User-type
-  # RTTI passes too: RTTI is not a linkable API.
-  if demangled.startswith(("typeinfo for ", "typeinfo name for ")):
-    return True
-  core = demangled
-  for prefix in VAGUE_LINKAGE_PREFIXES:
-    if core.startswith(prefix):
-      core = core[len(prefix):]
-      break
+  # RTTI: builtin and function types are anonymous -- no named type to link against.
+  # A USER type's typeinfo is a linkable data symbol (cross-DSO catch / dynamic_cast
+  # match on its address), so it takes the qualified-name check like a vtable. An
+  # unqualified user type is indistinguishable from a builtin here; every class in
+  # this repo is namespaced.
+  for prefix in ("typeinfo for ", "typeinfo name for "):
+    if demangled.startswith(prefix):
+      rest = demangled[len(prefix):]
+      if "(" in rest or "::" not in rest:
+        return True
+      return rest.startswith(("std::", "__gnu_cxx::"))
   # Only the qualified name may lend its std::-ness. Squeeze spaces inside <...> so the
   # name is a single token, drop the argument list (the first "(" outside any template),
-  # and take the last token before it -- a return type, when demangled, comes first.
+  # and take the last token before it -- a return type, when demangled, comes first, and
+  # prefixes of the "vtable for X" shape fall away the same way. A conversion operator
+  # puts its target type AFTER the name, so cut at "::operator " first.
   squeezed: List[str] = []
   depth = 0
-  for ch in core:
+  for ch in demangled:
     if ch == "<":
       depth += 1
     elif ch == ">":
@@ -91,7 +94,7 @@ def is_std_vague_linkage(demangled: str) -> bool:
     elif ch == "(" and depth == 0:
       cut = i
       break
-  name = head[:cut].rsplit(" ", 1)[-1]
+  name = head[:cut].split("::operator ", 1)[0].rsplit(" ", 1)[-1]
   return name.startswith(("std::", "__gnu_cxx::"))
 
 
@@ -120,7 +123,7 @@ PARSER_SELF_TEST: Final[List[Tuple[str, List[Tuple[str, bool]]]]] = [
 ]
 
 FUNC_NAME_RE: Final[re.Pattern] = re.compile(r"(\w+)\s*\(")
-SONAME_RE: Final[re.Pattern] = re.compile(r"Library soname: \[(libcelestial_calendar\.so\.[^\]]+)\]")
+SONAME_RE: Final[re.Pattern] = re.compile(r"Library soname: \[([^\]]+)\]")
 REAL_SO_RE: Final[re.Pattern] = re.compile(r"^libcelestial_calendar\.so\.(\d+)\.(\d+)\.(\d+)$")
 
 
@@ -250,8 +253,9 @@ def check_export_surface() -> int:
       failures.append(f"{name}: declaration in celestial.h without CELESTIAL_API")
   entries = {name for name, _ in decls}
 
-  # Dynamic half, on the real built library. A missing build fails the gate but must not
-  # swallow the static half's findings -- they are the part any leg can check.
+  # Dynamic half, on the real built library. A missing build or a missing/failing
+  # binutils tool fails the gate but must not swallow the findings collected so far,
+  # static or dynamic -- the static half is the part any leg can check.
   so = find_real_so(paths.build_dir() / "shared_lib")
   soname: Optional[str] = None
   if so is None:
@@ -259,39 +263,33 @@ def check_export_surface() -> int:
   else:
     try:
       symbols = nm_defined(so)
-    except RuntimeError as e:
-      red_print(str(e))
-      return 1
+      exported = set(symbols.keys())
 
-    exported = set(symbols.keys())
+      missing = sorted(entries - exported)
+      for name in missing:
+        failures.append(f"{name}: entry point not exported by {so.name}")
 
-    missing = sorted(entries - exported)
-    for name in missing:
-      failures.append(f"{name}: entry point not exported by {so.name}")
+      survivors = sorted(exported - entries)
+      demangled = demangle(survivors) if survivors else {}
+      for name in survivors:
+        if name in SURVIVOR_EXCEPTIONS:
+          continue
+        if is_std_vague_linkage(demangled[name]):
+          continue
+        failures.append(
+          f"{name} ({demangled[name]}): exported but neither an entry point nor a std "
+          f"vague-linkage symbol -- hide it, or add it to SURVIVOR_EXCEPTIONS with a reason"
+        )
 
-    survivors = sorted(exported - entries)
-    demangled = demangle(survivors) if survivors else {}
-    for name in survivors:
-      if name in SURVIVOR_EXCEPTIONS:
-        continue
-      if is_std_vague_linkage(demangled[name]):
-        continue
-      failures.append(
-        f"{name} ({demangled[name]}): exported but neither an entry point nor a std "
-        f"vague-linkage symbol -- hide it, or add it to SURVIVOR_EXCEPTIONS with a reason"
-      )
-
-    # SONAME pin: major.minor of the real file's version, per the CMakeLists comment.
-    version = REAL_SO_RE.match(so.name)
-    assert version is not None  # find_real_so only returns REAL_SO_RE matches
-    expected_soname = f"libcelestial_calendar.so.{version.group(1)}.{version.group(2)}"
-    try:
+      # SONAME pin: major.minor of the real file's version, per the CMakeLists comment.
+      version = REAL_SO_RE.match(so.name)
+      assert version is not None  # find_real_so only returns REAL_SO_RE matches
+      expected_soname = f"libcelestial_calendar.so.{version.group(1)}.{version.group(2)}"
       soname = read_soname(so)
-    except RuntimeError as e:
-      red_print(str(e))
-      return 1
-    if soname != expected_soname:
-      failures.append(f"SONAME is {soname!r}, expected {expected_soname!r} (major.minor of VERSION while 0.x)")
+      if soname != expected_soname:
+        failures.append(f"SONAME is {soname!r}, expected {expected_soname!r} (major.minor of VERSION while 0.x)")
+    except RuntimeError as e:  # nm / c++filt / readelf missing or failed
+      failures.append(str(e))
 
   print("#" * 60)
   if failures:

--- a/automation/export_surface.py
+++ b/automation/export_surface.py
@@ -20,12 +20,10 @@ from .abi_layout import STRUCT_RE
 from .utils import run_cmd, green_print, red_print, yellow_print
 
 
-# Non-entry exports that must stay exported anyway, each mapped to the reason it cannot
-# be hidden (#91: list every survivor with its reason, never fold them into a count).
-# Empty today: every current survivor is a std vague-linkage weak/unique symbol, matched
-# by the vague-linkage predicate below rather than listed here. The human-facing copy of
-# this list lives in src/shared_lib/CMakeLists.txt; this constant is the machine-readable
-# source.
+# Non-entry exports that must stay exported anyway, each mapped to the reason it cannot be
+# hidden (#91: every survivor gets a reason, never a count). Empty while the predicate below
+# accounts for all of them. Machine-readable source; the human-facing copy of whatever lands
+# here belongs in src/shared_lib/CMakeLists.txt.
 SURVIVOR_EXCEPTIONS: Final[Dict[str, str]] = {
 }
 
@@ -36,10 +34,8 @@ SURVIVOR_EXCEPTIONS: Final[Dict[str, str]] = {
 # escapes the hiding must be named in SURVIVOR_EXCEPTIONS with a reason -- widening this
 # predicate instead defeats the gate.
 
-# Predicate self-test: std-owned shapes must pass, user-owned shapes must not -- in
-# particular a user symbol whose argument, return type, or conversion-operator target
-# merely mentions std:: (that substring must not whitewash it), and user-type RTTI,
-# which unlike builtin/function-type RTTI names a type a consumer can link against.
+# Predicate self-test: std-owned shapes pass, user-owned shapes do not. The samples that
+# matter are the ones where a std:: substring must NOT whitewash a symbol we own.
 PREDICATE_SELF_TEST: Final[List[Tuple[str, bool]]] = [
   ("char* std::__add_grouping<char>(char*, char*, char)", True),
   ("vtable for std::vector<double, std::allocator<double> >", True),
@@ -52,27 +48,18 @@ PREDICATE_SELF_TEST: Final[List[Tuple[str, bool]]] = [
   ("astro::Foo::operator std::vector<double>()", False),
   ("typeinfo for astro::Foo", False),
   ("vtable for astro::Foo", False),
-  # A global-namespace class: the shape of celestial.h's own C-ABI structs, and the one
-  # the "no :: means builtin" branch used to wave through. Blocked now, and pinned here
-  # so that re-widening the rule turns this line red.
+  # A global-namespace class -- the shape of celestial.h's own structs. Re-widening the
+  # rule to wave these through turns this line red.
   ("typeinfo for JulianDay", False),
-  # "(" still stands in for "function type", so a function type mentioning a type this
-  # library owns passes. Pinned as the approximation it is.
+  # "(" stands in for "function type", so a function type naming one of ours passes.
   ("typeinfo for astro::Fn<double (int)>", True),
 ]
 
 
 def is_std_vague_linkage(demangled: str) -> bool:
   """Whether a demangled survivor is a C++ vague-linkage artifact rather than API surface."""
-  # RTTI for a function type is anonymous -- it names no type, so nobody can link
-  # against it. Everything else goes through the same qualified-name check as a vtable.
-  # An earlier version also waved through any RTTI whose name carried no "::", meaning
-  # to spare the builtins; that also spared every global-namespace class, which is the
-  # shape of celestial.h's own C-ABI structs. None of the 43 survivors this library
-  # actually exports took that branch -- builtin RTTI is referenced here, never defined
-  # -- so the branch is gone rather than justified. A builtin's RTTI turning up defined
-  # in this library would now be a finding, which is the right way round: put it in
-  # SURVIVOR_EXCEPTIONS with the reason it is there.
+  # RTTI for a function type is anonymous -- it names no type, so nobody can link against
+  # it. Every other RTTI takes the same qualified-name check as a vtable, builtins included.
   for prefix in ("typeinfo for ", "typeinfo name for "):
     if demangled.startswith(prefix):
       rest = demangled[len(prefix):]
@@ -117,11 +104,9 @@ def self_test_predicate() -> List[str]:
       failures.append(f"predicate self-test: {sample!r} -> {actual}, expected {expected}")
   return failures
 
-# Parser self-test samples (shape -> expected (name, has_macro) pairs). The gate runs
-# these before trusting the parser: a parser that cannot read the declaration shapes in
-# use would report a maimed entry set and call it green. One sample per shape in play:
-# macro-prefixed plain, pointer return type, multi-line parameter list, and one
-# declaration without the macro (the mutation the static half exists to catch).
+# Parser self-test samples (shape -> expected (name, has_macro) pairs), one per declaration
+# shape in play. A parser that cannot read them all would report a maimed entry set and
+# call the gate green, so these run before the parser is trusted.
 PARSER_SELF_TEST: Final[List[Tuple[str, List[Tuple[str, bool]]]]] = [
   ("CELESTIAL_API bool alpha(uint8_t v);", [("alpha", True)]),
   ("CELESTIAL_API const char *beta(void);", [("beta", True)]),
@@ -232,14 +217,11 @@ def check_export_surface() -> int:
   - static: every file-scope declaration in celestial.h carries CELESTIAL_API. A missing
     macro is a missing export on Windows -- caught here, without needing a Windows leg.
   - dynamic: the strong defined symbols of the built .so are exactly the entry set plus
-    SURVIVOR_EXCEPTIONS, and every survivor beyond that is a std vague-linkage weak/unique
-    symbol (the vague-linkage predicate). This is the half that proves the hiding held.
-  Plus a SONAME pin: DT_SONAME must be the major.minor form of the real file's version,
-  which is the promise the CMakeLists SOVERSION comment makes while 0.x.
+    SURVIVOR_EXCEPTIONS, everything else being vague linkage. This half proves the hiding held.
+  Plus a SONAME pin against the major.minor form the CMakeLists promises while 0.x.
 
-  Needs the built library (`./project.py --build`): a missing build turns the gate red,
-  never a silent skip. The parser self-test runs first -- a broken parser must fail the
-  gate, not pass it with a maimed entry set.
+  Needs the built library (`./project.py --build`); a missing build turns the gate red,
+  never a silent skip.
   """
   print("#" * 60)
   yellow_print("Checking that the export surface matches the celestial.h entry points...")

--- a/automation/export_surface.py
+++ b/automation/export_surface.py
@@ -35,13 +35,74 @@ SURVIVOR_EXCEPTIONS: Final[Dict[str, str]] = {
 # them visible; RTTI for builtin or function types names no symbol a consumer could link
 # against. Anything else that escapes the hiding must be named in SURVIVOR_EXCEPTIONS
 # with a reason -- widening this predicate instead defeats the gate.
+VAGUE_LINKAGE_PREFIXES: Final[Tuple[str, ...]] = (
+  "vtable for ",
+  "VTT for ",
+  "guard variable for ",
+)
+
+# Predicate self-test: std-owned shapes must pass, user-owned shapes must not -- in
+# particular a user symbol whose argument or return type merely mentions std:: (that
+# substring must not whitewash it), the hole this predicate was tightened for.
+PREDICATE_SELF_TEST: Final[List[Tuple[str, bool]]] = [
+  ("char* std::__add_grouping<char>(char*, char*, char)", True),
+  ("vtable for std::vector<double, std::allocator<double> >", True),
+  ("typeinfo for double (int, calendar::jieqi::Jieqi)", True),
+  ("typeinfo name for std::vector<double>", True),
+  ("astro::sun::geocentric_coord(double)", False),
+  ("astro::foo(std::basic_string<char, std::char_traits<char> >)", False),
+  ("std::vector<double> astro::make_vec(double)", False),
+  ("astro::Holder<std::string>::get()", False),
+]
+
+
 def is_std_vague_linkage(demangled: str) -> bool:
   """Whether a demangled survivor is a C++ vague-linkage artifact rather than API surface."""
-  if "std::" in demangled or "__gnu_cxx::" in demangled:
-    return True
   # "typeinfo for double", "typeinfo name for double (int, Jieqi)" -- the latter embeds
-  # our type names in the signature, but the symbol itself is anonymous RTTI.
-  return demangled.startswith(("typeinfo for ", "typeinfo name for "))
+  # our type names in the signature, but the symbol itself is anonymous RTTI. User-type
+  # RTTI passes too: RTTI is not a linkable API.
+  if demangled.startswith(("typeinfo for ", "typeinfo name for ")):
+    return True
+  core = demangled
+  for prefix in VAGUE_LINKAGE_PREFIXES:
+    if core.startswith(prefix):
+      core = core[len(prefix):]
+      break
+  # Only the qualified name may lend its std::-ness. Squeeze spaces inside <...> so the
+  # name is a single token, drop the argument list (the first "(" outside any template),
+  # and take the last token before it -- a return type, when demangled, comes first.
+  squeezed: List[str] = []
+  depth = 0
+  for ch in core:
+    if ch == "<":
+      depth += 1
+    elif ch == ">":
+      depth -= 1
+    if ch != " " or depth == 0:
+      squeezed.append(ch)
+  head = "".join(squeezed)
+  depth = 0
+  cut = len(head)
+  for i, ch in enumerate(head):
+    if ch == "<":
+      depth += 1
+    elif ch == ">":
+      depth -= 1
+    elif ch == "(" and depth == 0:
+      cut = i
+      break
+  name = head[:cut].rsplit(" ", 1)[-1]
+  return name.startswith(("std::", "__gnu_cxx::"))
+
+
+def self_test_predicate() -> List[str]:
+  """Hold the vague-linkage predicate to pinned shapes; a failure means the gate is broken."""
+  failures: List[str] = []
+  for sample, expected in PREDICATE_SELF_TEST:
+    actual = is_std_vague_linkage(sample)
+    if actual != expected:
+      failures.append(f"predicate self-test: {sample!r} -> {actual}, expected {expected}")
+  return failures
 
 # Parser self-test samples (shape -> expected (name, has_macro) pairs). The gate runs
 # these before trusting the parser: a parser that cannot read the declaration shapes in
@@ -59,7 +120,7 @@ PARSER_SELF_TEST: Final[List[Tuple[str, List[Tuple[str, bool]]]]] = [
 ]
 
 FUNC_NAME_RE: Final[re.Pattern] = re.compile(r"(\w+)\s*\(")
-SONAME_RE: Final[re.Pattern] = re.compile(r"Library soname: \[(libcelestial_calendar\.so\.\d+\.\d+)\]")
+SONAME_RE: Final[re.Pattern] = re.compile(r"Library soname: \[(libcelestial_calendar\.so\.[^\]]+)\]")
 REAL_SO_RE: Final[re.Pattern] = re.compile(r"^libcelestial_calendar\.so\.(\d+)\.(\d+)\.(\d+)$")
 
 
@@ -170,11 +231,11 @@ def check_export_surface() -> int:
   print("#" * 60)
   yellow_print("Checking that the export surface matches the celestial.h entry points...")
 
-  failures: List[str] = self_test_parser()
+  failures: List[str] = self_test_parser() + self_test_predicate()
   if failures:
     for f in failures:
       red_print(f"  - {f}")
-    red_print("Export-surface gate is broken (parser self-test failed); fix the parser, not the data")
+    red_print("Export-surface gate is broken (self-test failed); fix the gate, not the data")
     return 1
 
   header = paths.proj_root() / "src" / "shared_lib" / "celestial.h"
@@ -189,47 +250,48 @@ def check_export_surface() -> int:
       failures.append(f"{name}: declaration in celestial.h without CELESTIAL_API")
   entries = {name for name, _ in decls}
 
-  # Dynamic half, on the real built library.
+  # Dynamic half, on the real built library. A missing build fails the gate but must not
+  # swallow the static half's findings -- they are the part any leg can check.
   so = find_real_so(paths.build_dir() / "shared_lib")
+  soname: Optional[str] = None
   if so is None:
-    red_print("Built library not found (run ./project.py --build first)")
-    return 1
+    failures.append("Built library not found (run ./project.py --build first); dynamic half not run")
+  else:
+    try:
+      symbols = nm_defined(so)
+    except RuntimeError as e:
+      red_print(str(e))
+      return 1
 
-  try:
-    symbols = nm_defined(so)
-  except RuntimeError as e:
-    red_print(str(e))
-    return 1
+    exported = set(symbols.keys())
 
-  exported = set(symbols.keys())
+    missing = sorted(entries - exported)
+    for name in missing:
+      failures.append(f"{name}: entry point not exported by {so.name}")
 
-  missing = sorted(entries - exported)
-  for name in missing:
-    failures.append(f"{name}: entry point not exported by {so.name}")
+    survivors = sorted(exported - entries)
+    demangled = demangle(survivors) if survivors else {}
+    for name in survivors:
+      if name in SURVIVOR_EXCEPTIONS:
+        continue
+      if is_std_vague_linkage(demangled[name]):
+        continue
+      failures.append(
+        f"{name} ({demangled[name]}): exported but neither an entry point nor a std "
+        f"vague-linkage symbol -- hide it, or add it to SURVIVOR_EXCEPTIONS with a reason"
+      )
 
-  survivors = sorted(exported - entries)
-  demangled = demangle(survivors) if survivors else {}
-  for name in survivors:
-    if name in SURVIVOR_EXCEPTIONS:
-      continue
-    if is_std_vague_linkage(demangled[name]):
-      continue
-    failures.append(
-      f"{name} ({demangled[name]}): exported but neither an entry point nor a std "
-      f"vague-linkage symbol -- hide it, or add it to SURVIVOR_EXCEPTIONS with a reason"
-    )
-
-  # SONAME pin: major.minor of the real file's version, per the CMakeLists comment.
-  version = REAL_SO_RE.match(so.name)
-  assert version is not None  # find_real_so only returns REAL_SO_RE matches
-  expected_soname = f"libcelestial_calendar.so.{version.group(1)}.{version.group(2)}"
-  try:
-    soname = read_soname(so)
-  except RuntimeError as e:
-    red_print(str(e))
-    return 1
-  if soname != expected_soname:
-    failures.append(f"SONAME is {soname!r}, expected {expected_soname!r} (major.minor of VERSION while 0.x)")
+    # SONAME pin: major.minor of the real file's version, per the CMakeLists comment.
+    version = REAL_SO_RE.match(so.name)
+    assert version is not None  # find_real_so only returns REAL_SO_RE matches
+    expected_soname = f"libcelestial_calendar.so.{version.group(1)}.{version.group(2)}"
+    try:
+      soname = read_soname(so)
+    except RuntimeError as e:
+      red_print(str(e))
+      return 1
+    if soname != expected_soname:
+      failures.append(f"SONAME is {soname!r}, expected {expected_soname!r} (major.minor of VERSION while 0.x)")
 
   print("#" * 60)
   if failures:

--- a/automation/export_surface.py
+++ b/automation/export_surface.py
@@ -43,7 +43,6 @@ SURVIVOR_EXCEPTIONS: Final[Dict[str, str]] = {
 PREDICATE_SELF_TEST: Final[List[Tuple[str, bool]]] = [
   ("char* std::__add_grouping<char>(char*, char*, char)", True),
   ("vtable for std::vector<double, std::allocator<double> >", True),
-  ("typeinfo for double", True),
   ("typeinfo for double (int, calendar::jieqi::Jieqi)", True),
   ("typeinfo name for std::vector<double>", True),
   ("astro::sun::geocentric_coord(double)", False),
@@ -53,34 +52,31 @@ PREDICATE_SELF_TEST: Final[List[Tuple[str, bool]]] = [
   ("astro::Foo::operator std::vector<double>()", False),
   ("typeinfo for astro::Foo", False),
   ("vtable for astro::Foo", False),
-  # The hole below, pinned on the shape that can actually reach the gate: a
-  # global-namespace user type is spelled like a builtin, and celestial.h's C-ABI
-  # structs are exactly that. Tightening the rule turns this line red instead of
-  # silently changing what the gate accepts.
-  ("typeinfo for JulianDay", True),
-  # The other pass-through, for symmetry: "(" is a stand-in for "function type".
+  # A global-namespace class: the shape of celestial.h's own C-ABI structs, and the one
+  # the "no :: means builtin" branch used to wave through. Blocked now, and pinned here
+  # so that re-widening the rule turns this line red.
+  ("typeinfo for JulianDay", False),
+  # "(" still stands in for "function type", so a function type mentioning a type this
+  # library owns passes. Pinned as the approximation it is.
   ("typeinfo for astro::Fn<double (int)>", True),
 ]
 
 
 def is_std_vague_linkage(demangled: str) -> bool:
   """Whether a demangled survivor is a C++ vague-linkage artifact rather than API surface."""
-  # RTTI. The line to draw is whether the name mentions a type this library owns: that
-  # is what a consumer could name, catch, or dynamic_cast against, so it takes the
-  # qualified-name check like a vtable. Being a defined data symbol does not separate
-  # anything -- function-type RTTI is one too (this .so exports `typeinfo for double
-  # (int, calendar::jieqi::Jieqi)`).
-  #
-  # The name is all we have, and it leaves one hole: a global-namespace user type is
-  # spelled exactly like a builtin. celestial.h's C-ABI structs are that shape; they
-  # emit no RTTI today because they are non-polymorphic and never an operand of typeid
-  # or throw -- POD-ness is not what decides it. Closing the hole means enumerating the
-  # builtin spellings; until something leaks, the hole is pinned in the self-test above.
-  # Using "(" for "function type" is the other approximation, kept for the same reason.
+  # RTTI for a function type is anonymous -- it names no type, so nobody can link
+  # against it. Everything else goes through the same qualified-name check as a vtable.
+  # An earlier version also waved through any RTTI whose name carried no "::", meaning
+  # to spare the builtins; that also spared every global-namespace class, which is the
+  # shape of celestial.h's own C-ABI structs. None of the 43 survivors this library
+  # actually exports took that branch -- builtin RTTI is referenced here, never defined
+  # -- so the branch is gone rather than justified. A builtin's RTTI turning up defined
+  # in this library would now be a finding, which is the right way round: put it in
+  # SURVIVOR_EXCEPTIONS with the reason it is there.
   for prefix in ("typeinfo for ", "typeinfo name for "):
     if demangled.startswith(prefix):
       rest = demangled[len(prefix):]
-      if "(" in rest or "::" not in rest:
+      if "(" in rest:
         return True
       return rest.startswith(("std::", "__gnu_cxx::"))
   # Only the qualified name may lend its std::-ness. Squeeze spaces inside <...> so the

--- a/automation/export_surface.py
+++ b/automation/export_surface.py
@@ -53,16 +53,22 @@ PREDICATE_SELF_TEST: Final[List[Tuple[str, bool]]] = [
   ("astro::Foo::operator std::vector<double>()", False),
   ("typeinfo for astro::Foo", False),
   ("vtable for astro::Foo", False),
+  # The two residuals the predicate knowingly passes, pinned so that tightening the
+  # rule shows up here as a diff instead of silently changing what the gate accepts.
+  ("typeinfo for astro::Fn<double (int)>", True),
+  ("typeinfo for (anonymous namespace)::Foo", True),
 ]
 
 
 def is_std_vague_linkage(demangled: str) -> bool:
   """Whether a demangled survivor is a C++ vague-linkage artifact rather than API surface."""
-  # RTTI: builtin and function types are anonymous -- no named type to link against.
-  # A USER type's typeinfo is a linkable data symbol (cross-DSO catch / dynamic_cast
-  # match on its address), so it takes the qualified-name check like a vtable. An
-  # unqualified user type is indistinguishable from a builtin here; every class in
-  # this repo is namespaced.
+  # RTTI: a builtin's or a function type's typeinfo names nothing a consumer could link
+  # against; a user type's is a defined data symbol in the dynamic table, so it takes the
+  # qualified-name check like a vtable. Two residuals, both knowingly left: "(" stands in
+  # for "function type", so `Fn<double(int)>` and `(anonymous namespace)::Foo` pass; and a
+  # global-namespace class reads exactly like a builtin here -- celestial.h's C-ABI structs
+  # are that shape, and emit no RTTI only because they are POD. Both are strictly narrower
+  # than the "pass every typeinfo" this replaced; tighten if a survivor ever leaks through.
   for prefix in ("typeinfo for ", "typeinfo name for "):
     if demangled.startswith(prefix):
       rest = demangled[len(prefix):]
@@ -288,8 +294,12 @@ def check_export_surface() -> int:
       soname = read_soname(so)
       if soname != expected_soname:
         failures.append(f"SONAME is {soname!r}, expected {expected_soname!r} (major.minor of VERSION while 0.x)")
-    except RuntimeError as e:  # nm / c++filt / readelf missing or failed
-      failures.append(str(e))
+    except Exception as e:  # noqa: BLE001 -- see below
+      # Deliberately broad: the sentence above promises that no tool failure loses the
+      # static findings, and the failure modes are not all `RuntimeError` -- c++filt can
+      # exit 0 with a short output (`ValueError` from the strict `zip`), and an exec that
+      # gets past `which` raises `OSError`. Narrowing this re-opens the swallow.
+      failures.append(f"{type(e).__name__}: {e}")
 
   print("#" * 60)
   if failures:

--- a/automation/github.py
+++ b/automation/github.py
@@ -13,7 +13,7 @@ import os
 import asyncio
 import requests
 
-from typing import Dict, List
+from typing import Dict, List, Tuple
 from pathlib import Path
 from dataclasses import dataclass
 
@@ -96,37 +96,55 @@ class GitHub:
     name:        str
     run_number:  int
     status:      str
+    conclusion:  str
+    head_sha:    str
     workflow_id: int
     url:         str
     created_at:  str
     updated_at:  str
 
+  # Pagination cap for list_workflow_runs: 10 pages x 100 runs reaches far further back
+  # than a release ever needs to look; a caller that still finds nothing must say how
+  # many pages it scanned.
+  MAX_RUN_PAGES = 10
+
   @staticmethod
-  def list_runs() -> List[Run]:
-    """
-    List all runs in the repository.
+  def list_workflow_runs(workflow_id: int, max_pages: int = MAX_RUN_PAGES) -> Tuple[List[Run], int]:
+    """List the runs of ONE workflow, paginated (100 per page, newest first).
 
-    Returns:
-      List[str]: A list of run IDs.
+    Returns the runs and the number of pages scanned. The repo-wide
+    `.../actions/runs` endpoint is deliberately NOT the path here: it pages the whole
+    repo's history, and the workflow we care about can be a handful of entries inside
+    the first page -- client-side filtering of a global list silently narrows the
+    search window, so a "not found" answer from it means nothing.
     """
-    url = f"https://api.github.com/repos/{OWNER}/{REPO}/actions/runs"
-    response = requests.get(url, headers=gen_headers(), timeout=TIMEOUT)
-    response.raise_for_status()
+    runs: List[GitHub.Run] = []
+    for page in range(1, max_pages + 1):
+      url = (f"https://api.github.com/repos/{OWNER}/{REPO}"
+             f"/actions/workflows/{workflow_id}/runs?per_page=100&page={page}")
+      response = requests.get(url, headers=gen_headers(), timeout=TIMEOUT)
+      response.raise_for_status()
 
-    json_resp = response.json()
-    return [
-      GitHub.Run(
-        run["id"], 
-        run["name"],
-        run["run_number"],
-        run["status"],
-        run["workflow_id"],
-        run["url"],
-        run["created_at"],
-        run["updated_at"]
+      batch = response.json()["workflow_runs"]
+      runs.extend(
+        GitHub.Run(
+          run["id"],
+          run["name"],
+          run["run_number"],
+          run["status"],
+          run["conclusion"] or "",  # null while the run is still in progress
+          run["head_sha"],
+          run["workflow_id"],
+          run["url"],
+          run["created_at"],
+          run["updated_at"]
+        )
+        for run in batch
       )
-      for run in json_resp["workflow_runs"]
-    ]
+      if len(batch) < 100:
+        return runs, page
+
+    return runs, max_pages
 
 
   @staticmethod
@@ -202,6 +220,7 @@ class GitHub:
       queue.put_nowait((name, url))
 
     paths: List[Path] = []
+    failures: List[str] = []
 
     async def coro():
       while not queue.empty():
@@ -210,7 +229,10 @@ class GitHub:
           path = await asyncio.to_thread(GitHub.download_one_artifact, name, url, download_dir)
           paths.append(path)
         except Exception as e:
+          # Record, keep draining (or queue.join() hangs), then fail the whole call below:
+          # a release must never ship with artifacts silently missing.
           red_print(f"# Failed to download {name}: {e}")
+          failures.append(f"{name}: {e}")
         finally:
           queue.task_done()  # Signal that the current task is done.
 
@@ -221,6 +243,9 @@ class GitHub:
     await queue.join() 
     # Ensure all tasks are awaited.
     await asyncio.gather(*tasks)
+
+    if failures:
+      raise RuntimeError(f"{len(failures)} artifact(s) failed to download: {failures}")
 
     return paths
 

--- a/automation/log_names.py
+++ b/automation/log_names.py
@@ -1,0 +1,76 @@
+# CelestialCalendar Automation:
+#   Python automation scripts for building and testing the CelestialCalendar C++ project.
+#
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+# License: GNU General Public License v3.0
+#
+# This software is distributed without any warranty.
+# See <https://www.gnu.org/licenses/> for more details.
+
+import re
+
+from typing import Final, List, Set
+
+from . import paths
+from .export_surface import entry_point_names
+from .utils import green_print, red_print, yellow_print
+
+
+# Snake-case tokens that may appear in log strings without naming an entry point:
+# parameter and struct-field names the messages legitimately quote. A closed set --
+# a log string that needs another such token must extend this table deliberately,
+# not slip past the gate (#72: log strings name the exported function, or an FFI
+# user greps a name that does not exist).
+ALLOWED_NON_ENTRY_TOKENS: Final[Set[str]] = {
+  "is_leap",
+  "jq_idx",
+  "root_count",
+  "slot_count",
+}
+
+SNAKE_TOKEN_RE: Final[re.Pattern] = re.compile(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b")
+STRING_LITERAL_RE: Final[re.Pattern] = re.compile(r'"((?:[^"\\]|\\.)*)"')
+
+
+def check_log_names() -> int:
+  """Hold the log strings of `lib_*.cpp` to the entry-point names of `celestial.h`.
+
+  The log messages name functions so an FFI user can grep the exported symbol; a
+  message that names an internal or long-gone function sends that user chasing a
+  symbol that does not exist. The entry set is parsed from celestial.h (the same
+  parser the export-surface gate uses), so the check cannot drift from the header.
+  Pure parsing -- no build needed, any leg can run it.
+  """
+  print("#" * 60)
+  yellow_print("Checking that lib_*.cpp log strings name only celestial.h entry points...")
+
+  header = paths.proj_root() / "src" / "shared_lib" / "celestial.h"
+  entries = set(entry_point_names(header))
+  if not entries:
+    red_print(f"No entry points parsed from {header}; the parser is broken")
+    return 1
+  allowed = entries | ALLOWED_NON_ENTRY_TOKENS
+
+  failures: List[str] = []
+  lib_dir = paths.proj_root() / "src" / "shared_lib"
+  for source in sorted(lib_dir.glob("lib*.cpp")):
+    for lineno, line in enumerate(source.read_text().splitlines(), start=1):
+      for literal in STRING_LITERAL_RE.findall(line):
+        for token in SNAKE_TOKEN_RE.findall(literal):
+          if token not in allowed:
+            failures.append(
+              f"{source.name}:{lineno}: log string names `{token}`, which is not a "
+              f"celestial.h entry point (or an allowed parameter/field name)"
+            )
+
+  print("#" * 60)
+  if failures:
+    red_print(f"Log-names gate failed ({len(failures)} finding(s)):")
+    for f in failures:
+      red_print(f"  - {f}")
+    return 1
+
+  green_print(f"lib_*.cpp log strings name only entry points ({len(entries)} entries)")
+  return 0

--- a/automation/log_names.py
+++ b/automation/log_names.py
@@ -69,7 +69,7 @@ def check_log_names() -> int:
   lib_dir = paths.proj_root() / "src" / "shared_lib"
   for source in sorted(lib_dir.glob("lib*.cpp")):
     for lineno, line in enumerate(source.read_text().splitlines(), start=1):
-      if line.lstrip().startswith("#"):  # `#include "x.hpp"` is not a log string
+      if line.lstrip().startswith("#include"):  # an include path is not a log string
         continue
       for literal in STRING_LITERAL_RE.findall(line):
         for token in SNAKE_TOKEN_RE.findall(literal):

--- a/automation/log_names.py
+++ b/automation/log_names.py
@@ -14,7 +14,7 @@ import re
 from typing import Final, List, Set
 
 from . import paths
-from .export_surface import entry_point_names
+from .export_surface import entry_point_names, self_test_parser
 from .utils import green_print, red_print, yellow_print
 
 
@@ -30,6 +30,10 @@ ALLOWED_NON_ENTRY_TOKENS: Final[Set[str]] = {
   "slot_count",
 }
 
+# Only multi-word snake tokens are held: every entry point — and every function name a
+# log string could quote, by repo naming convention — is snake_case, while a lone
+# lowercase word cannot be told from English prose, and CamelCase/ALL_CAPS names are
+# types or constants, not functions (#72's defect class is function names).
 SNAKE_TOKEN_RE: Final[re.Pattern] = re.compile(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b")
 STRING_LITERAL_RE: Final[re.Pattern] = re.compile(r'"((?:[^"\\]|\\.)*)"')
 
@@ -41,10 +45,18 @@ def check_log_names() -> int:
   message that names an internal or long-gone function sends that user chasing a
   symbol that does not exist. The entry set is parsed from celestial.h (the same
   parser the export-surface gate uses), so the check cannot drift from the header.
-  Pure parsing -- no build needed, any leg can run it.
+  Only multi-word snake_case tokens are held (see SNAKE_TOKEN_RE). Pure parsing --
+  no build needed, any leg can run it.
   """
   print("#" * 60)
   yellow_print("Checking that lib_*.cpp log strings name only celestial.h entry points...")
+
+  failures: List[str] = self_test_parser()
+  if failures:
+    for f in failures:
+      red_print(f"  - {f}")
+    red_print("Log-names gate is broken (parser self-test failed); fix the parser, not the data")
+    return 1
 
   header = paths.proj_root() / "src" / "shared_lib" / "celestial.h"
   entries = set(entry_point_names(header))
@@ -53,10 +65,12 @@ def check_log_names() -> int:
     return 1
   allowed = entries | ALLOWED_NON_ENTRY_TOKENS
 
-  failures: List[str] = []
+  failures = []
   lib_dir = paths.proj_root() / "src" / "shared_lib"
   for source in sorted(lib_dir.glob("lib*.cpp")):
     for lineno, line in enumerate(source.read_text().splitlines(), start=1):
+      if line.lstrip().startswith("#"):  # `#include "x.hpp"` is not a log string
+        continue
       for literal in STRING_LITERAL_RE.findall(line):
         for token in SNAKE_TOKEN_RE.findall(literal):
           if token not in allowed:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Export surface closed to the published C ABI (#91): explicit `CELESTIAL_API` on every `celestial.h` entry point, hidden default visibility, `SOVERSION` = major.minor while 0.x, and release packaging via `cmake --install` — with a CI gate holding the exported symbol set to the header's entry points.
+- Release downloads now fail loud (#72): artifacts must come from a successful `build_and_test` run of the exact tagged commit, and a single failed artifact download fails the whole download. Cutting a release is now three deliberate steps — push the tag, dispatch `build_and_test` on it, rerun the release workflow.
+- Logging is opt-in: the default verbosity is `NONE`, so loading the library no longer writes to the host's stdout unless asked.
+
 ## [v0.4.0] - 2026-07-29
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Export surface closed to the published C ABI (#91): explicit `CELESTIAL_API` on every `celestial.h` entry point, hidden default visibility, `SOVERSION` = major.minor while 0.x, and release packaging via `cmake --install` — with a CI gate holding the exported symbol set to the header's entry points.
+- Export surface closed to the published C ABI (#91): explicit `CELESTIAL_API` on every `celestial.h` entry point, hidden default visibility, `SOVERSION` = major.minor while 0.x, and release packaging via `cmake --install` — with a CI gate holding the exported symbol set to the header's entry points. Release archives change shape: the library and its SOVERSION symlinks now sit under `lib/` and the header under `include/` (`bin/` on Windows), instead of a flat directory.
 - Release downloads now fail loud (#72): artifacts must come from a successful `build_and_test` run of the exact tagged commit, and a single failed artifact download fails the whole download. Cutting a release is now three deliberate steps — push the tag, dispatch `build_and_test` on it, rerun the release workflow.
 - Logging is opt-in: the default verbosity is `NONE`, so loading the library no longer writes to the host's stdout unless asked.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Export surface closed to the published C ABI (#91): explicit `CELESTIAL_API` on every `celestial.h` entry point, hidden default visibility, `SOVERSION` = major.minor while 0.x, and release packaging via `cmake --install` — with a CI gate holding the exported symbol set to the header's entry points. Release archives change shape: the library and its SOVERSION symlinks now sit under `lib/` and the header under `include/` (`bin/` on Windows), instead of a flat directory.
+- Export surface closed to the published C ABI (#91): explicit `CELESTIAL_API` on every `celestial.h` entry point, hidden default visibility, `SOVERSION` = major.minor while 0.x, and release packaging via `cmake --install` — with a CI gate holding the exported symbol set to the header's entry points. Release archives change shape: the library now sits under `lib/` (`bin/` on Windows, with the import library in `lib/`) and the header under `include/`; the JSON build metadata stays at the top level.
 - Release downloads now fail loud (#72): artifacts must come from a successful `build_and_test` run of the exact tagged commit, and a single failed artifact download fails the whole download. Cutting a release is now three deliberate steps — push the tag, dispatch `build_and_test` on it, rerun the release workflow.
 - Logging is opt-in: the default verbosity is `NONE`, so loading the library no longer writes to the host's stdout unless asked.
 

--- a/linter.py
+++ b/linter.py
@@ -19,7 +19,7 @@ import argparse
 
 from automation import (
   run_ruff, run_clang_tidy, check_self_contained, probe_features, check_abi_layout,
-  check_ctypes_smoke,
+  check_ctypes_smoke, check_export_surface,
 )
 
 
@@ -39,12 +39,15 @@ def parse_args() -> argparse.Namespace:
       "    ./linter.py --abi-layout\n\n"
       "  To run the ctypes wrappers against the built library (needs ./project.py --build first):\n"
       "    ./linter.py --ctypes-smoke\n\n"
+      "  To hold the built library's export surface to the celestial.h entry points\n"
+      "  (needs ./project.py --build first):\n"
+      "    ./linter.py --export-surface\n\n"
       "  To report which awaited C++ features this toolchain can compile:\n"
       "    ./linter.py --features\n\n"
       "  To hold a CI leg to the feature state this repo recorded for it:\n"
       "    ./linter.py --features libc++\n\n"
       "  To run every check (ruff, clang-tidy, self-containment, ABI layout, ctypes smoke,\n"
-      "  feature report):\n"
+      "  export surface, feature report):\n"
       "    ./linter.py -a/--all\n\n"
     ),
     formatter_class=argparse.RawTextHelpFormatter
@@ -59,6 +62,8 @@ def parse_args() -> argparse.Namespace:
                       help="Hold the ctypes mirror in statistics/common.py to the real ABI layout")
   parser.add_argument("--ctypes-smoke", action="store_true",
                       help="Run the ctypes wrappers against the built library (needs a build)")
+  parser.add_argument("--export-surface", action="store_true",
+                      help="Hold the built library's export surface to the celestial.h entry points")
   parser.add_argument("--features", nargs="?", const="", default=None, metavar="LEG",
                       help="Probe the awaited C++ features; with a CI leg name, hold it to the recorded state")
 
@@ -90,6 +95,11 @@ if __name__ == "__main__":
 
   if args.ctypes_smoke or args.all:
     ret_code = check_ctypes_smoke()
+    if ret_code != 0:
+      sys.exit(ret_code)
+
+  if args.export_surface or args.all:
+    ret_code = check_export_surface()
     if ret_code != 0:
       sys.exit(ret_code)
 

--- a/linter.py
+++ b/linter.py
@@ -19,7 +19,7 @@ import argparse
 
 from automation import (
   run_ruff, run_clang_tidy, check_self_contained, probe_features, check_abi_layout,
-  check_ctypes_smoke, check_export_surface,
+  check_ctypes_smoke, check_export_surface, check_log_names,
 )
 
 
@@ -42,12 +42,14 @@ def parse_args() -> argparse.Namespace:
       "  To hold the built library's export surface to the celestial.h entry points\n"
       "  (needs ./project.py --build first):\n"
       "    ./linter.py --export-surface\n\n"
+      "  To hold the lib_*.cpp log strings to the celestial.h entry-point names:\n"
+      "    ./linter.py --log-names\n\n"
       "  To report which awaited C++ features this toolchain can compile:\n"
       "    ./linter.py --features\n\n"
       "  To hold a CI leg to the feature state this repo recorded for it:\n"
       "    ./linter.py --features libc++\n\n"
       "  To run every check (ruff, clang-tidy, self-containment, ABI layout, ctypes smoke,\n"
-      "  export surface, feature report):\n"
+      "  export surface, log names, feature report):\n"
       "    ./linter.py -a/--all\n\n"
     ),
     formatter_class=argparse.RawTextHelpFormatter
@@ -64,6 +66,8 @@ def parse_args() -> argparse.Namespace:
                       help="Run the ctypes wrappers against the built library (needs a build)")
   parser.add_argument("--export-surface", action="store_true",
                       help="Hold the built library's export surface to the celestial.h entry points")
+  parser.add_argument("--log-names", action="store_true",
+                      help="Hold the lib_*.cpp log strings to the celestial.h entry-point names")
   parser.add_argument("--features", nargs="?", const="", default=None, metavar="LEG",
                       help="Probe the awaited C++ features; with a CI leg name, hold it to the recorded state")
 
@@ -100,6 +104,11 @@ if __name__ == "__main__":
 
   if args.export_surface or args.all:
     ret_code = check_export_surface()
+    if ret_code != 0:
+      sys.exit(ret_code)
+
+  if args.log_names or args.all:
+    ret_code = check_log_names()
     if ret_code != 0:
       sys.exit(ret_code)
 

--- a/src/shared_lib/CMakeLists.txt
+++ b/src/shared_lib/CMakeLists.txt
@@ -26,6 +26,12 @@ set_target_properties(celestial_calendar PROPERTIES
 # Windows. Consumers of celestial.h need no defines.
 target_compile_definitions(celestial_calendar PRIVATE CELESTIAL_BUILDING_DLL)
 
+# Surviving exports after the hiding (#91's exception list, human-facing copy; the
+# machine-readable source is SURVIVOR_EXCEPTIONS in automation/export_surface.py, empty
+# today): every remaining export is a weak/unique vague-linkage symbol from the standard
+# library — namespace std carries an explicit default-visibility attribute that overrides
+# -fvisibility=hidden, and cross-DSO coalescing of those symbols needs them visible.
+
 # SOVERSION tracks major.minor while 0.x: a 0.x minor may break the ABI, so SOVERSION=0
 # would falsely claim all 0.x releases mutually compatible. Trigger: at the 1.0 release,
 # switch to major-only — from then on the ABI holds within a major, which is exactly the

--- a/src/shared_lib/CMakeLists.txt
+++ b/src/shared_lib/CMakeLists.txt
@@ -28,9 +28,10 @@ target_compile_definitions(celestial_calendar PRIVATE CELESTIAL_BUILDING_DLL)
 
 # Surviving exports after the hiding (#91's exception list, human-facing copy; the
 # machine-readable source is SURVIVOR_EXCEPTIONS in automation/export_surface.py, empty
-# today): every remaining export is a weak/unique vague-linkage symbol from the standard
-# library — namespace std carries an explicit default-visibility attribute that overrides
-# -fvisibility=hidden, and cross-DSO coalescing of those symbols needs them visible.
+# today): every remaining export is a C++ vague-linkage artifact — a weak/unique symbol
+# from namespace std (std carries an explicit default-visibility attribute that overrides
+# -fvisibility=hidden, and cross-DSO coalescing needs those visible) or anonymous RTTI
+# for a builtin/function type (no symbol a consumer could link against).
 
 # SOVERSION tracks major.minor while 0.x: a 0.x minor may break the ABI, so SOVERSION=0
 # would falsely claim all 0.x releases mutually compatible. Trigger: at the 1.0 release,
@@ -44,9 +45,8 @@ set_target_properties(celestial_calendar PROPERTIES
 )
 
 # Release packaging runs `cmake --install` (build_and_test.yml): the real file and the
-# SOVERSION symlinks land by CMake's rules, replacing the hand-rolled `-type f` copy that
-# shipped only the real file. All three destinations are required — the Windows .dll goes
-# to RUNTIME, its import .lib to ARCHIVE, and without ARCHIVE no .lib is installed.
+# SOVERSION symlinks land by CMake's rules. All three destinations are required — the
+# Windows .dll goes to RUNTIME, its import .lib to ARCHIVE, and without ARCHIVE no .lib.
 # No COMPONENT split: the release shape is a single zip, there is no per-component
 # audience (package config / find_package is deliberately not offered — no consumer).
 install(TARGETS celestial_calendar

--- a/src/shared_lib/CMakeLists.txt
+++ b/src/shared_lib/CMakeLists.txt
@@ -43,6 +43,19 @@ set_target_properties(celestial_calendar PROPERTIES
   SOVERSION ${SOVERSION_NUMBER}
 )
 
+# Release packaging runs `cmake --install` (build_and_test.yml): the real file and the
+# SOVERSION symlinks land by CMake's rules, replacing the hand-rolled `-type f` copy that
+# shipped only the real file. All three destinations are required — the Windows .dll goes
+# to RUNTIME, its import .lib to ARCHIVE, and without ARCHIVE no .lib is installed.
+# No COMPONENT split: the release shape is a single zip, there is no per-component
+# audience (package config / find_package is deliberately not offered — no consumer).
+install(TARGETS celestial_calendar
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+install(FILES celestial.h DESTINATION include)
+
 # #67: compile-check the published C header as pure C (layouts pinned by `_Static_assert`
 # inside). Built as part of the default target, so CI exercises it on every platform.
 add_library(c_header_check OBJECT c_header_check.c)

--- a/src/shared_lib/CMakeLists.txt
+++ b/src/shared_lib/CMakeLists.txt
@@ -26,7 +26,16 @@ set_target_properties(celestial_calendar PROPERTIES
 # Windows. Consumers of celestial.h need no defines.
 target_compile_definitions(celestial_calendar PRIVATE CELESTIAL_BUILDING_DLL)
 
-set_target_properties(celestial_calendar PROPERTIES VERSION ${VERSION_NUMBER})
+# SOVERSION tracks major.minor while 0.x: a 0.x minor may break the ABI, so SOVERSION=0
+# would falsely claim all 0.x releases mutually compatible. Trigger: at the 1.0 release,
+# switch to major-only — from then on the ABI holds within a major, which is exactly the
+# promise SOVERSION makes.
+string(REGEX MATCH "^[0-9]+\\.[0-9]+" SOVERSION_NUMBER "${VERSION_NUMBER}")
+
+set_target_properties(celestial_calendar PROPERTIES
+  VERSION ${VERSION_NUMBER}
+  SOVERSION ${SOVERSION_NUMBER}
+)
 
 # #67: compile-check the published C header as pure C (layouts pinned by `_Static_assert`
 # inside). Built as part of the default target, so CI exercises it on every platform.

--- a/src/shared_lib/CMakeLists.txt
+++ b/src/shared_lib/CMakeLists.txt
@@ -14,7 +14,17 @@ message(STATUS "Building version ${VERSION_NUMBER}")
 
 add_library(celestial_calendar SHARED ${SOURCES})
 
-set_target_properties(celestial_calendar PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+# #91: the export set is exactly the entry points declared in celestial.h. Both halves
+# are required — hiding without CELESTIAL_API hides the entries too; the macro without
+# hiding exports internals as well (WINDOWS_EXPORT_ALL_SYMBOLS did the latter).
+set_target_properties(celestial_calendar PROPERTIES
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN ON
+)
+
+# Private to the library build: flips CELESTIAL_API from dllimport to dllexport on
+# Windows. Consumers of celestial.h need no defines.
+target_compile_definitions(celestial_calendar PRIVATE CELESTIAL_BUILDING_DLL)
 
 set_target_properties(celestial_calendar PROPERTIES VERSION ${VERSION_NUMBER})
 

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -56,14 +56,17 @@
  * a process-wide knob: writes are atomic — a concurrent reader always sees one
  * whole level or another — but which of two racing writes wins is unspecified.
  * `last_error` is per-thread: it reports the calling thread's most recent Julian
- * Day call, and no thread ever observes another's message. Two paths memoize per
- * argument — the Jieqi computation and the algo-2 lunar year info — and the algo-2
- * date range is a separate one-shot: it takes no argument, so it costs its first
- * caller the whole astronomical pipeline and is free from then on. Every other entry
- * point computes on each call. The per-argument memoization is shared process-wide
- * and entries are never erased: the first call with a given argument pays the
- * computation, later calls from any thread reuse it, and cache memory grows
- * monotonically with the number of distinct arguments ever queried.
+ * Day call, and no thread ever observes another's message. Two computations memoize
+ * per argument — the jieqi moments and the algo-2 lunar year info. Both caches are
+ * shared process-wide and never erased: the first call with a given argument pays for
+ * it, later calls from any thread reuse the result, and memory grows monotonically
+ * with the number of distinct arguments ever queried. Two threads that miss on the
+ * same argument at once both compute it, and one of the two results is discarded.
+ * Separately, the first `gregorian_to_lunar` or `lunar_to_gregorian` with `algo = 2`
+ * runs the astronomical pipeline once to establish that algorithm's supported range;
+ * unlike the caches above, that one blocks every thread that arrives while it is in
+ * flight, and costs nothing afterwards. Everything else recomputes on each call,
+ * apart from reads of compile-time constants such as `get_supported_lunar_year_range`.
  *
  * Platform note: the library logs to stdout and swallows any logging failure. On
  * Windows (UCRT), however, writing to a closed stdout fail-fasts the process

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -56,11 +56,12 @@
  * a process-wide knob: writes are atomic — a concurrent reader always sees one
  * whole level or another — but which of two racing writes wins is unspecified.
  * `last_error` is per-thread: it reports the calling thread's most recent Julian
- * Day call, and no thread ever observes another's message. The memoization caches
- * behind the astronomical functions are shared process-wide and entries are never
- * erased: the first call with a given argument pays the computation, later calls
- * from any thread reuse it, and cache memory grows monotonically with the number
- * of distinct arguments ever queried.
+ * Day call, and no thread ever observes another's message. Memoization is shared
+ * process-wide and entries are never erased: the Jieqi and lunar-algo2 paths are
+ * cached, so the first call with a given argument pays the computation, later
+ * calls from any thread reuse it, and cache memory grows monotonically with the
+ * number of distinct arguments ever queried. The sun/moon, solar-longitude,
+ * solar-time and ΔT entries are not cached — every call computes.
  *
  * Platform note: the library logs to stdout and swallows any logging failure. On
  * Windows (UCRT), however, writing to a closed stdout fail-fasts the process
@@ -72,8 +73,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-/* #91: export marker for the entry points below — see the contract in the header block
- * above. Consumers need no defines. */
+/* #91: export marker for the entry points below — contract in the header block above. */
 #if defined(_WIN32)
   #if defined(CELESTIAL_BUILDING_DLL)
     #define CELESTIAL_API __declspec(dllexport)

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -65,8 +65,9 @@
  * Separately, the first `gregorian_to_lunar` or `lunar_to_gregorian` with `algo = 2`
  * runs the astronomical pipeline once to establish that algorithm's supported range;
  * unlike the caches above, that one blocks every thread that arrives while it is in
- * flight, and costs nothing afterwards. Everything else recomputes on each call,
- * apart from reads of compile-time constants such as `get_supported_lunar_year_range`.
+ * flight, and costs nothing afterwards. Everything else recomputes on each call, apart
+ * from lookups of values already fixed before `main` — the supported ranges reported by
+ * `get_supported_lunar_year_range`, which are settled at load time at the latest.
  *
  * Platform note: the library logs to stdout and swallows any logging failure. On
  * Windows (UCRT), however, writing to a closed stdout fail-fasts the process

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -51,6 +51,17 @@
  * On failure the Julian Day functions also record a thread-local message readable
  * through `last_error` (#97 pilot).
  *
+ * Thread-safety contract: every entry point may be called concurrently from any
+ * number of threads, with no host-side synchronization. `set_log_verbosity` turns
+ * a process-wide knob: writes are atomic — a concurrent reader always sees one
+ * whole level or another — but which of two racing writes wins is unspecified.
+ * `last_error` is per-thread: it reports the calling thread's most recent Julian
+ * Day call, and no thread ever observes another's message. The memoization caches
+ * behind the astronomical functions are shared process-wide and entries are never
+ * erased: the first call with a given argument pays the computation, later calls
+ * from any thread reuse it, and cache memory grows monotonically with the number
+ * of distinct arguments ever queried.
+ *
  * Platform note: the library logs to stdout and swallows any logging failure. On
  * Windows (UCRT), however, writing to a closed stdout fail-fasts the process
  * (0xc0000409) through the invalid-parameter handler — not an exception path, so

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -88,7 +88,7 @@ extern "C" {
 /**
  * @brief Set the verbosity level of log printing.
  * @param new_value The new verbosity level (in `uint8_t`): 0 = none, 1 = info, 2 = debug.
- *                  The initial level is 2 (debug).
+ *                  The initial level is 0 (none) — logging is opt-in.
  * @returns `true` if the level was stored, `false` if `new_value` is out of range.
  */
 CELESTIAL_API bool set_log_verbosity(uint8_t new_value);

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -32,8 +32,10 @@
  *
  * Two deliberate decisions: the exported symbols carry no prefix, matching the exports
  * shipped since 0.3.0 — the collision risk is accepted and revisited at the next major
- * version. And no dllexport/dllimport macros: `WINDOWS_EXPORT_ALL_SYMBOLS` exports
- * everything, and imports resolve implicitly against the import library.
+ * version. And the export set is exactly the entry points declared below (#91): each one
+ * is marked `CELESTIAL_API`, and consumers need no defines — the macro reads as dllimport
+ * on Windows and default visibility elsewhere; only the library's own build defines
+ * `CELESTIAL_BUILDING_DLL` (CMake injects it privately) to get dllexport.
  *
  * ABI evolution policy (#129): within a major version, struct layouts never move —
  * sizes and offsets are pinned by `c_header_check.c` at compile time, and a struct is
@@ -59,6 +61,20 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+/* #91: export marker for the entry points below — see the contract in the header block
+ * above. Consumers need no defines. */
+#if defined(_WIN32)
+  #if defined(CELESTIAL_BUILDING_DLL)
+    #define CELESTIAL_API __declspec(dllexport)
+  #else
+    #define CELESTIAL_API __declspec(dllimport)
+  #endif
+#elif defined(__GNUC__) || defined(__clang__)
+  #define CELESTIAL_API __attribute__((visibility("default")))
+#else
+  #define CELESTIAL_API
+#endif
+
 /* NOLINTBEGIN(modernize-use-trailing-return-type, modernize-use-using):
  * this header must stay valid C — C has neither trailing return types nor `using`. */
 
@@ -75,7 +91,7 @@ extern "C" {
  *                  The initial level is 2 (debug).
  * @returns `true` if the level was stored, `false` if `new_value` is out of range.
  */
-bool set_log_verbosity(uint8_t new_value);
+CELESTIAL_API bool set_log_verbosity(uint8_t new_value);
 
 /**
  * @brief Get the last-error message of the calling thread.
@@ -86,7 +102,7 @@ bool set_log_verbosity(uint8_t new_value);
  *          until the next Julian Day call on the same thread.
  * @note #97 pilot: only the Julian Day functions record messages for now.
  */
-const char *last_error(void);
+CELESTIAL_API const char *last_error(void);
 
 
 /* ---------- Julian Days ---------- */
@@ -104,7 +120,7 @@ typedef struct JulianDay {
  * @param fraction The fraction of the day. Must be in the range [0.0, 1.0).
  * @returns A `JulianDay` struct. JD is based on UT1.
  */
-JulianDay ut1_to_jd(int32_t y, uint32_t m, uint32_t d, double fraction);
+CELESTIAL_API JulianDay ut1_to_jd(int32_t y, uint32_t m, uint32_t d, double fraction);
 
 /**
  * @brief Convert UT1 datetime to Julian Ephemeris Day Number (JDE).
@@ -114,7 +130,7 @@ JulianDay ut1_to_jd(int32_t y, uint32_t m, uint32_t d, double fraction);
  * @param fraction The fraction of the day. Must be in the range [0.0, 1.0).
  * @returns A `JulianDay` struct. JDE is based on TT.
  */
-JulianDay ut1_to_jde(int32_t y, uint32_t m, uint32_t d, double fraction);
+CELESTIAL_API JulianDay ut1_to_jde(int32_t y, uint32_t m, uint32_t d, double fraction);
 
 typedef struct UT1Time {
   bool     valid;    /* Indicates if the result is valid. */
@@ -129,7 +145,7 @@ typedef struct UT1Time {
  * @param jde The julian ephemeris day number, which is based on TT.
  * @returns A `UT1Time` struct.
  */
-UT1Time jde_to_ut1(double jde);
+CELESTIAL_API UT1Time jde_to_ut1(double jde);
 
 
 /* ---------- Sun and Moon Apparent Geocentric Position ---------- */
@@ -146,7 +162,7 @@ typedef struct SunCoordinate {
  * @param jde The julian ephemeris day number, which is based on TT.
  * @returns A `SunCoordinate` struct.
  */
-SunCoordinate sun_apparent_geocentric_coord(double jde);
+CELESTIAL_API SunCoordinate sun_apparent_geocentric_coord(double jde);
 
 typedef struct MoonCoordinate {
   bool   valid; /* Indicates if the result is valid. */
@@ -160,7 +176,7 @@ typedef struct MoonCoordinate {
  * @param jde The julian ephemeris day number, which is based on TT.
  * @returns A `MoonCoordinate` struct.
  */
-MoonCoordinate moon_apparent_geocentric_coord(double jde);
+CELESTIAL_API MoonCoordinate moon_apparent_geocentric_coord(double jde);
 
 
 /* ---------- Solar Longitude Roots ---------- */
@@ -178,7 +194,7 @@ typedef struct Discriminant {
  * @returns A `Discriminant` struct; `count` is 0, 1, or 2: the Sun won't reach the longitude
  *          in the year, reaches it once, or reaches it twice.
  */
-Discriminant solar_lon_root_discriminant(int32_t year, double longitude);
+CELESTIAL_API Discriminant solar_lon_root_discriminant(int32_t year, double longitude);
 
 /**
  * @brief Find the JDE(s) at which the Sun reaches `longitude` in `year`, written to `slots`.
@@ -189,7 +205,7 @@ Discriminant solar_lon_root_discriminant(int32_t year, double longitude);
  * @param slot_count The count of slots.
  * @returns How many slots are written.
  */
-uint32_t solar_lon_roots(int32_t year, double longitude, double *slots, uint32_t slot_count);
+CELESTIAL_API uint32_t solar_lon_roots(int32_t year, double longitude, double *slots, uint32_t slot_count);
 
 
 /* ---------- Sun Moon Conjunction ---------- */
@@ -202,7 +218,7 @@ uint32_t solar_lon_roots(int32_t year, double longitude, double *slots, uint32_t
  * @param slot_count The count of slots.
  * @returns How many slots are written.
  */
-uint32_t new_moons_after_jde(double jde, double *slots, uint32_t slot_count);
+CELESTIAL_API uint32_t new_moons_after_jde(double jde, double *slots, uint32_t slot_count);
 
 /**
  * @brief Find the new-moon JDE(s) in `year`; the total count goes to `root_count`,
@@ -214,7 +230,7 @@ uint32_t new_moons_after_jde(double jde, double *slots, uint32_t slot_count);
  * @param slot_count The count of slots.
  * @returns How many slots are written.
  */
-uint32_t new_moons_in_year(int32_t year, uint32_t *root_count, double *slots, uint32_t slot_count);
+CELESTIAL_API uint32_t new_moons_in_year(int32_t year, uint32_t *root_count, double *slots, uint32_t slot_count);
 
 
 /* ---------- Solar Time ---------- */
@@ -231,7 +247,7 @@ typedef struct EquationOfTime {
  * @returns An `EquationOfTime` struct; `value` is E in degrees of hour angle
  *          (x240 = seconds of time).
  */
-EquationOfTime equation_of_time(double jde);
+CELESTIAL_API EquationOfTime equation_of_time(double jde);
 
 typedef struct ApparentSolarTime {
   bool     valid;    /* Indicates if the result is valid. */
@@ -251,7 +267,7 @@ typedef struct ApparentSolarTime {
  * @returns An `ApparentSolarTime` struct; the local apparent solar date may differ from the
  *          input UTC date — a large enough longitude shifts the moment across midnight.
  */
-ApparentSolarTime apparent_solar_time(int32_t y, uint32_t m, uint32_t d, double fraction, double longitude);
+CELESTIAL_API ApparentSolarTime apparent_solar_time(int32_t y, uint32_t m, uint32_t d, double fraction, double longitude);
 
 
 /* ---------- Jieqi ---------- */
@@ -274,7 +290,7 @@ typedef struct JieqiMomentQuery {
  *       to within DUT1 (±0.9 s), so modern-era civil consumers may treat it as UTC.
  *       Past the ΔAT table freeze the modelled gap follows ΔT−(ΔAT+32.184) (#115).
  */
-JieqiMomentQuery query_jieqi_moment(int32_t year, uint8_t jq_idx);
+CELESTIAL_API JieqiMomentQuery query_jieqi_moment(int32_t year, uint8_t jq_idx);
 
 /**
  * @brief Write the Chinese name of the Jieqi to `buf`.
@@ -283,7 +299,7 @@ JieqiMomentQuery query_jieqi_moment(int32_t year, uint8_t jq_idx);
  * @param buf_size Maximum bytes that can be written to `buf`.
  * @returns `true` if the name is successfully written to `buf`.
  */
-bool get_jieqi_name(uint8_t jq_idx, char *buf, uint32_t buf_size);
+CELESTIAL_API bool get_jieqi_name(uint8_t jq_idx, char *buf, uint32_t buf_size);
 
 
 /* ---------- Lunar Calendar ---------- */
@@ -299,7 +315,7 @@ typedef struct SupportedLunarYearRange {
  * @param algo The algorithm. Expected to be 1, 2, or 3.
  * @returns A `SupportedLunarYearRange` struct.
  */
-SupportedLunarYearRange get_supported_lunar_year_range(uint8_t algo);
+CELESTIAL_API SupportedLunarYearRange get_supported_lunar_year_range(uint8_t algo);
 
 typedef struct LunarYearInfo {
   bool     valid;      /* Indicates if the result is valid. */
@@ -322,7 +338,7 @@ typedef struct LunarYearInfo {
  *             `algo`, the result is `valid = false`.
  * @returns A `LunarYearInfo` struct.
  */
-LunarYearInfo get_lunar_year_info(uint8_t algo, int32_t year);
+CELESTIAL_API LunarYearInfo get_lunar_year_info(uint8_t algo, int32_t year);
 
 typedef struct LunarDate {
   bool    valid;   /* Indicates if the result is valid. */
@@ -356,7 +372,7 @@ typedef struct GregorianDate {
  *       traditional 3rd month is `month = 3, is_leap = false`. This is NOT the positional
  *       month index that `LunarYearInfo.month_len` is indexed by.
  */
-LunarDate gregorian_to_lunar(uint8_t algo, int32_t year, uint8_t month, uint8_t day);
+CELESTIAL_API LunarDate gregorian_to_lunar(uint8_t algo, int32_t year, uint8_t month, uint8_t day);
 
 /**
  * @brief Convert a lunar date to a Gregorian date.
@@ -370,7 +386,7 @@ LunarDate gregorian_to_lunar(uint8_t algo, int32_t year, uint8_t month, uint8_t 
  * @returns A `GregorianDate` struct; `valid = false` when the input does not name a real
  *          lunar date (bad `algo`, year out of range, no such leap month, day out of range).
  */
-GregorianDate lunar_to_gregorian(uint8_t algo, int32_t year, uint8_t month, bool is_leap, uint8_t day);
+CELESTIAL_API GregorianDate lunar_to_gregorian(uint8_t algo, int32_t year, uint8_t month, bool is_leap, uint8_t day);
 
 
 /* ---------- Delta T ---------- */
@@ -385,37 +401,37 @@ typedef struct DeltaT {
  * @param year The year.
  * @returns A `DeltaT` struct.
  */
-DeltaT delta_t_algo1(double year);
+CELESTIAL_API DeltaT delta_t_algo1(double year);
 /**
  * @brief Compute delta T of a given moment using algorithm 2.
  * @param year The year.
  * @returns A `DeltaT` struct.
  */
-DeltaT delta_t_algo2(double year);
+CELESTIAL_API DeltaT delta_t_algo2(double year);
 /**
  * @brief Compute delta T of a given moment using algorithm 3.
  * @param year The year.
  * @returns A `DeltaT` struct.
  */
-DeltaT delta_t_algo3(double year);
+CELESTIAL_API DeltaT delta_t_algo3(double year);
 /**
  * @brief Compute delta T of a given moment using algorithm 4.
  * @param year The year.
  * @returns A `DeltaT` struct.
  */
-DeltaT delta_t_algo4(double year);
+CELESTIAL_API DeltaT delta_t_algo4(double year);
 /**
  * @brief Compute delta T of a given moment using algorithm 5.
  * @param year The year.
  * @returns A `DeltaT` struct.
  */
-DeltaT delta_t_algo5(double year);
+CELESTIAL_API DeltaT delta_t_algo5(double year);
 /**
  * @brief Compute delta T of a given moment, using the best algorithm.
  * @param year The year.
  * @returns A `DeltaT` struct.
  */
-DeltaT delta_t(double year);
+CELESTIAL_API DeltaT delta_t(double year);
 
 
 #ifdef __cplusplus

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -56,12 +56,14 @@
  * a process-wide knob: writes are atomic — a concurrent reader always sees one
  * whole level or another — but which of two racing writes wins is unspecified.
  * `last_error` is per-thread: it reports the calling thread's most recent Julian
- * Day call, and no thread ever observes another's message. Only two paths memoize —
- * the Jieqi computation and the algo-2 lunar year info; every other entry point
- * computes on each call. The memoization is shared process-wide and entries are
- * never erased: the first call with a given argument pays the computation, later
- * calls from any thread reuse it, and cache memory grows monotonically with the
- * number of distinct arguments ever queried.
+ * Day call, and no thread ever observes another's message. Two paths memoize per
+ * argument — the Jieqi computation and the algo-2 lunar year info — and the algo-2
+ * date range is a separate one-shot: it takes no argument, so it costs its first
+ * caller the whole astronomical pipeline and is free from then on. Every other entry
+ * point computes on each call. The per-argument memoization is shared process-wide
+ * and entries are never erased: the first call with a given argument pays the
+ * computation, later calls from any thread reuse it, and cache memory grows
+ * monotonically with the number of distinct arguments ever queried.
  *
  * Platform note: the library logs to stdout and swallows any logging failure. On
  * Windows (UCRT), however, writing to a closed stdout fail-fasts the process

--- a/src/shared_lib/celestial.h
+++ b/src/shared_lib/celestial.h
@@ -56,12 +56,12 @@
  * a process-wide knob: writes are atomic — a concurrent reader always sees one
  * whole level or another — but which of two racing writes wins is unspecified.
  * `last_error` is per-thread: it reports the calling thread's most recent Julian
- * Day call, and no thread ever observes another's message. Memoization is shared
- * process-wide and entries are never erased: the Jieqi and lunar-algo2 paths are
- * cached, so the first call with a given argument pays the computation, later
+ * Day call, and no thread ever observes another's message. Only two paths memoize —
+ * the Jieqi computation and the algo-2 lunar year info; every other entry point
+ * computes on each call. The memoization is shared process-wide and entries are
+ * never erased: the first call with a given argument pays the computation, later
  * calls from any thread reuse it, and cache memory grows monotonically with the
- * number of distinct arguments ever queried. The sun/moon, solar-longitude,
- * solar-time and ΔT entries are not cached — every call computes.
+ * number of distinct arguments ever queried.
  *
  * Platform note: the library logs to stdout and swallows any logging failure. On
  * Windows (UCRT), however, writing to a closed stdout fail-fasts the process

--- a/src/shared_lib/lib.cpp
+++ b/src/shared_lib/lib.cpp
@@ -27,6 +27,33 @@
 // This cpp file is holding the functions to control the global configuration, such as log verbosity level.
 // #67: every export catches all exceptions and degrades to `valid = false` / `0`; contract: see celestial.h.
 
+namespace lib {
+
+// #97 pilot: the calling thread's last-error message. Declared in lib.hpp and defined here so
+// that exactly one of it exists -- see the note there for what an `inline thread_local` cost
+// us on Mach-O once the inlines went hidden.
+namespace {
+thread_local std::string LAST_ERROR; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+} // namespace
+
+auto clear_last_error() -> void {
+  LAST_ERROR.clear();
+}
+
+auto set_last_error(const std::string& message) noexcept -> void {
+  try {
+    LAST_ERROR = message;
+  } catch (...) { // NOLINT(bugprone-empty-catch) — nowhere left to report; swallowing is the contract.
+  }
+}
+
+auto last_error_message() -> const char* {
+  return LAST_ERROR.c_str();
+}
+
+} // namespace lib
+
+
 extern "C" {
 
 auto set_log_verbosity(const uint8_t new_value) -> bool {

--- a/src/shared_lib/lib.hpp
+++ b/src/shared_lib/lib.hpp
@@ -49,7 +49,8 @@ enum class Verbosity : uint8_t {
  * @brief The global verbosity level of log printing.
  * @note #67: written via `set_log_verbosity` and read on every log path — atomic, or the two race.
  */
-inline std::atomic<Verbosity> GLOBAL_VERBOSITY = Verbosity::DEBUG; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+inline std::atomic<Verbosity> GLOBAL_VERBOSITY = Verbosity::NONE; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+// Default NONE (D-F): logging is opt-in — the library must not claim the host's stdout unasked.
 
 
 /** @brief Set the verbosity level of log printing.

--- a/src/shared_lib/lib.hpp
+++ b/src/shared_lib/lib.hpp
@@ -104,29 +104,28 @@ inline void debug(const std::string_view format_str, Args&&... args) { // NOLINT
  *       can learn *why* (the log goes to the library's stdout, which hosts may never see).
  *       Only the Julian Day exports fill it for now — pilot, not a full rollout.
  */
-inline thread_local std::string LAST_ERROR; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+/**
+ * @note The storage and these three bodies live in `lib.cpp`, deliberately not here. As an
+ *       `inline thread_local` in the header it had vague linkage, and under
+ *       `VISIBILITY_INLINES_HIDDEN` Mach-O does not coalesce a hidden TLS initialisation
+ *       routine across translation units -- the five `lib*.cpp` each kept one and the dylib
+ *       failed to link (2026-08-06, the macOS leg's first run after the visibility work).
+ *       One definition in one TU sidesteps the question instead of asking the linker to
+ *       merge something we have just told it to hide.
+ */
 
 /** @brief Clear the calling thread's last-error message. */
-inline auto clear_last_error() -> void {
-  LAST_ERROR.clear();
-}
+auto clear_last_error() -> void;
 
 /**
  * @brief Record the calling thread's last-error message.
  * @note `noexcept`: the string assignment can throw `bad_alloc`; on failure the previous
  *       message is kept.
  */
-inline auto set_last_error(const std::string& message) noexcept -> void {
-  try {
-    LAST_ERROR = message;
-  } catch (...) { // NOLINT(bugprone-empty-catch) — nowhere left to report; swallowing is the contract.
-  }
-}
+auto set_last_error(const std::string& message) noexcept -> void;
 
 /** @brief Read the calling thread's last-error message (empty if none). */
-[[nodiscard]] inline auto last_error_message() -> const char* {
-  return LAST_ERROR.c_str();
-}
+[[nodiscard]] auto last_error_message() -> const char*;
 
 
 } // namespace lib

--- a/src/shared_lib/lib_astro.cpp
+++ b/src/shared_lib/lib_astro.cpp
@@ -51,7 +51,7 @@ auto ut1_to_jd(const int32_t y, const uint32_t m, const uint32_t d, const double
     };
   } catch (const std::exception& e) {
     lib::set_last_error(e.what());
-    lib::info("Error in ut1_jd: {}", e.what());
+    lib::info("Error in ut1_to_jd: {}", e.what());
     lib::debug("ut1_to_jd: y = {}, m = {}, d = {}, fraction = {}", y, m, d, fraction);
 
     return {};
@@ -76,7 +76,7 @@ auto ut1_to_jde(const int32_t y, const uint32_t m, const uint32_t d, const doubl
     };
   } catch (const std::exception& e) {
     lib::set_last_error(e.what());
-    lib::info("Error in ut1_jde: {}", e.what());
+    lib::info("Error in ut1_to_jde: {}", e.what());
     lib::debug("ut1_to_jde: y = {}, m = {}, d = {}, fraction = {}", y, m, d, fraction);
 
     return {};
@@ -138,8 +138,8 @@ auto sun_apparent_geocentric_coord(const double jde) -> SunCoordinate {
       .r     = coord.r.au(),
     };
   } catch (const std::exception& e) {
-    lib::info("Error in sun_apparent_geocentric_position: {}", e.what());
-    lib::debug("sun_apparent_geocentric_position: jde = {}", jde);
+    lib::info("Error in sun_apparent_geocentric_coord: {}", e.what());
+    lib::debug("sun_apparent_geocentric_coord: jde = {}", jde);
 
     return {};
   } catch (...) {
@@ -169,8 +169,8 @@ auto moon_apparent_geocentric_coord(const double jde) -> MoonCoordinate {
       .r     = coord.r.km(),
     };
   } catch (const std::exception& e) {
-    lib::info("Error in moon_apparent_geocentric_position: {}", e.what());
-    lib::debug("moon_apparent_geocentric_position: jde = {}", jde);
+    lib::info("Error in moon_apparent_geocentric_coord: {}", e.what());
+    lib::debug("moon_apparent_geocentric_coord: jde = {}", jde);
 
     return {};
   } catch (...) {
@@ -196,8 +196,8 @@ auto solar_lon_root_discriminant(const int32_t year, const double longitude) -> 
       .count = astro::sun::geocentric_coord::math::discriminant(year, longitude),
     };
   } catch (const std::exception& e) {
-    lib::info("Exception raised during execution of root_discriminant");
-    lib::debug("root_discriminant: year = {}, lon = {}, error = {}", year, longitude, e.what());
+    lib::info("Exception raised during execution of solar_lon_root_discriminant");
+    lib::debug("solar_lon_root_discriminant: year = {}, lon = {}, error = {}", year, longitude, e.what());
     return {};
   } catch (...) {
     return {};
@@ -230,7 +230,7 @@ auto solar_lon_roots(
     // Some sanity check...
     const auto root_count = discriminant(year, longitude);
     if (roots.size() != root_count) [[unlikely]] {
-      lib::info("Error in copy_roots: roots.size() is {}, but expected size is {}", roots.size(), root_count);
+      lib::info("Error in solar_lon_roots: roots.size() is {}, but expected size is {}", roots.size(), root_count);
       lib::info("No root will be written to the slots.");
 
       return 0;
@@ -241,8 +241,8 @@ auto solar_lon_roots(
 
     return num_written;
   } catch (const std::exception& e) {
-    lib::info("Exception raised during execution of copy_roots");
-    lib::debug("copy_roots: year = {}, lon = {}, error = {}", year, longitude, e.what());
+    lib::info("Exception raised during execution of solar_lon_roots");
+    lib::debug("solar_lon_roots: year = {}, lon = {}, error = {}", year, longitude, e.what());
 
     return 0;
   } catch (...) {
@@ -281,8 +281,8 @@ auto new_moons_after_jde(
     std::copy(cbegin(roots), cend(roots), slots);
     return static_cast<uint32_t>(slot_count);
   } catch (const std::exception& e) {
-    lib::info("Exception thrown during execution of sun_moon_conjunctions_after_jde");
-    lib::debug("sun_moon_conjunctions_after_jde: jde = {}, error = {}", jde, e.what());
+    lib::info("Exception thrown during execution of new_moons_after_jde");
+    lib::debug("new_moons_after_jde: jde = {}, error = {}", jde, e.what());
 
     return 0;
   } catch (...) {
@@ -316,8 +316,8 @@ auto new_moons_in_year(
 
     return num_written;
   } catch (const std::exception& e) {
-    lib::info("Exception thrown during execution of sun_moon_conjunctions_in_year");
-    lib::debug("sun_moon_conjunctions_in_year: year = {}, error = {}", year, e.what());
+    lib::info("Exception thrown during execution of new_moons_in_year");
+    lib::debug("new_moons_in_year: year = {}, error = {}", year, e.what());
 
     return 0;
   } catch (...) {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -28,6 +28,10 @@ FetchContent_Declare(
 )
 
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# Keep googletest's own install rules out of the release: `cmake --install` is the
+# packaging path (build_and_test.yml), and the default INSTALL_GTEST would otherwise
+# drop gtest/gmock headers, static libs, and cmake configs into the release zip.
+set(INSTALL_GTEST OFF)
 FetchContent_MakeAvailable(googletest)
 
 # Suppress warnings from GTest

--- a/src/test/shared_lib/cabi_smoke_test.cpp
+++ b/src/test/shared_lib/cabi_smoke_test.cpp
@@ -98,6 +98,7 @@ TEST(CAbiSmoke, LogVerbosity) {
   EXPECT_TRUE(set_log_verbosity(1));
   EXPECT_TRUE(set_log_verbosity(2));
   EXPECT_FALSE(set_log_verbosity(3)); // Verbosity::COUNT
+  EXPECT_TRUE(set_log_verbosity(0)); // restore the default (NONE) — later cases must not inherit DEBUG
 }
 
 
@@ -394,5 +395,8 @@ TEST(CAbiSmoke, LoggingSurvivesClosedStdout) {
 // Portable counterpart of the test above: `std::vformat` throws `std::format_error` on a
 // runtime bad format string, and `log_noexcept` must swallow it on every platform.
 TEST(CAbiSmoke, LoggingSwallowsBadFormatString) {
+  // This TU has its own GLOBAL_VERBOSITY copy (hidden visibility), untouched by the
+  // C-ABI setter — and its default is now NONE (D-F). Open the gate or info() no-ops.
+  ASSERT_TRUE(lib::set_verbosity(lib::Verbosity::INFO));
   ASSERT_NO_THROW(lib::info("{"));
 }

--- a/src/test/shared_lib/cabi_smoke_test.cpp
+++ b/src/test/shared_lib/cabi_smoke_test.cpp
@@ -385,7 +385,7 @@ TEST(CAbiSmoke, LoggingSurvivesClosedStdout) {
 
   const JulianDay jd = ut1_to_jd(2024, 6, 1, NAN_VALUE); // logs via `lib::info` on failure
 
-  ASSERT_TRUE(set_log_verbosity(2)); // restore the default
+  ASSERT_TRUE(set_log_verbosity(0)); // restore the default
   EXPECT_FALSE(jd.valid);
 #endif
 }

--- a/src/test/shared_lib/cabi_smoke_test.cpp
+++ b/src/test/shared_lib/cabi_smoke_test.cpp
@@ -399,4 +399,5 @@ TEST(CAbiSmoke, LoggingSwallowsBadFormatString) {
   // C-ABI setter — and its default is now NONE (D-F). Open the gate or info() no-ops.
   ASSERT_TRUE(lib::set_verbosity(lib::Verbosity::INFO));
   ASSERT_NO_THROW(lib::info("{"));
+  EXPECT_TRUE(lib::set_verbosity(lib::Verbosity::NONE)); // restore the default, same discipline as LogVerbosity
 }

--- a/toolbox/artifact_downloader.py
+++ b/toolbox/artifact_downloader.py
@@ -16,9 +16,11 @@
 # See <https://www.gnu.org/licenses/> for more details.
 
 import sys
+import os
 import shutil
 import pprint
 import argparse
+import subprocess
 
 from pathlib import Path
 
@@ -45,28 +47,36 @@ def artifact_workflow(workflow_name: str = "Build and Test on Multiple Platforms
   return multi_platform_workflow[0]
 
 
-def latest_artifact_run() -> GitHub.Run:
-  """Find the latest artifact run."""
-  workflow = artifact_workflow()
+def release_commit_sha() -> str:
+  """The commit the artifacts must have been built from.
 
-  artifact_runs = list(filter(
-    lambda run: run.workflow_id == workflow.id, 
-    GitHub.list_runs()
-  ))
+  In CI (release.yml runs on a tag push) GITHUB_SHA is the tag's commit; locally, fall
+  back to `git rev-parse HEAD` -- release.yml checks the tag out, so HEAD there is the
+  tag's commit, and anywhere else HEAD is simply the commit the caller means.
+  """
+  sha = os.environ.get("GITHUB_SHA")
+  if sha:
+    return sha
+  ret = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True)
+  if ret.returncode != 0:
+    raise RuntimeError("Cannot resolve the release commit: GITHUB_SHA is unset and `git rev-parse HEAD` failed")
+  return ret.stdout.strip()
 
-  if len(artifact_runs) == 0:
-    red_print("Cannot find any artifact runs")
-    raise RuntimeError("Cannot find any artifact runs")
-  
-  # Find the latest run.
-  latest_run = sorted(artifact_runs, key=lambda run: run.created_at, reverse=True)[0]
 
-  # Ensure the run is successful.
-  if latest_run.status != "completed":
-    red_print(f"Cannot download artifacts from a non-completed run: {latest_run}")
-    raise RuntimeError("Cannot download artifacts from a non-completed run")
-  
-  return latest_run
+def find_artifact_run(workflow: GitHub.Workflow, sha: str) -> GitHub.Run:
+  """Find the run of `workflow` that built `sha` and succeeded.
+
+  Fail loud when there is none -- never settle for "the latest run", which can belong
+  to an unrelated, even failing, WIP branch: a release ships the artifacts of the
+  commit it tags, or it does not ship.
+  """
+  runs, pages = GitHub.list_workflow_runs(workflow.id)
+  for run in runs:
+    if run.head_sha == sha and run.conclusion == "success":
+      return run
+  red_print(f'No successful "{workflow.name}" run found for commit {sha} '
+            f"(scanned {pages} page(s), {len(runs)} runs)")
+  raise RuntimeError(f'No successful "{workflow.name}" run for commit {sha}')
 
 
 def parse_args() -> argparse.Namespace:
@@ -124,7 +134,7 @@ def main() -> None:
   # Download artifacts.
   run_id = args.run_id
   if run_id == 0:
-    run = latest_artifact_run()
+    run = find_artifact_run(artifact_workflow(), release_commit_sha())
     run_id = run.id
   
   downloaded_artifacts = GitHub.download_artifacts(run_id, args.save_to, args.parallel)

--- a/toolbox/artifact_downloader.py
+++ b/toolbox/artifact_downloader.py
@@ -55,9 +55,12 @@ def release_commit_sha() -> str:
   the commit the caller means. GITHUB_SHA is the fallback. The rev-parse runs at the
   repo root -- the caller's cwd may not be a repo at all.
   """
-  ret = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True,
-                       cwd=Path(__file__).parent.parent)
-  if ret.returncode == 0:
+  try:
+    ret = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True,
+                         cwd=Path(__file__).parent.parent)
+  except FileNotFoundError:  # no git binary at all -- fall through to GITHUB_SHA
+    ret = None
+  if ret is not None and ret.returncode == 0:
     return ret.stdout.strip()
   sha = os.environ.get("GITHUB_SHA")
   if sha:

--- a/toolbox/artifact_downloader.py
+++ b/toolbox/artifact_downloader.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Helper to download artifacts (latest builds) from GitHub.
+# Helper to download build artifacts from GitHub.
 #
 #########################################################################################
 #
@@ -50,17 +50,19 @@ def artifact_workflow(workflow_name: str = "Build and Test on Multiple Platforms
 def release_commit_sha() -> str:
   """The commit the artifacts must have been built from.
 
-  In CI (release.yml runs on a tag push) GITHUB_SHA is the tag's commit; locally, fall
-  back to `git rev-parse HEAD` -- release.yml checks the tag out, so HEAD there is the
-  tag's commit, and anywhere else HEAD is simply the commit the caller means.
+  `git rev-parse HEAD` first: release.yml checks the tag out, so HEAD there is the tag's
+  commit (already peeled, even for an annotated tag), and anywhere else HEAD is simply
+  the commit the caller means. GITHUB_SHA is the fallback. The rev-parse runs at the
+  repo root -- the caller's cwd may not be a repo at all.
   """
+  ret = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True,
+                       cwd=Path(__file__).parent.parent)
+  if ret.returncode == 0:
+    return ret.stdout.strip()
   sha = os.environ.get("GITHUB_SHA")
   if sha:
     return sha
-  ret = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True)
-  if ret.returncode != 0:
-    raise RuntimeError("Cannot resolve the release commit: GITHUB_SHA is unset and `git rev-parse HEAD` failed")
-  return ret.stdout.strip()
+  raise RuntimeError("Cannot resolve the release commit: `git rev-parse HEAD` failed and GITHUB_SHA is unset")
 
 
 def find_artifact_run(workflow: GitHub.Workflow, sha: str) -> GitHub.Run:
@@ -89,7 +91,7 @@ def parse_args() -> argparse.Namespace:
     type=int, 
     required=False,
     default=0,
-    help="The ID of the artifact run. If not specified, the latest artifact run will be used."
+    help="The ID of the artifact run. If not specified, the successful run that built the release commit is used."
   )
   parser.add_argument(
     "-s", "--save-to", 


### PR DESCRIPTION
收口共享库的导出面,并让发布链路在拿错产物时大声失败。

Closes #91
Closes #72

## 交付

**导出面**(#91)。`WINDOWS_EXPORT_ALL_SYMBOLS` 去掉,换成 `CXX_VISIBILITY_PRESET hidden`
+ `VISIBILITY_INLINES_HIDDEN` 加 25 个入口各自的 `CELESTIAL_API`。收口前 `nm -D --defined-only`
是 263 个动态符号,收口后**强符号导出集恰好等于 `celestial.h` 的 25 个入口**;幸存的 43 个
全是弱符号/unique(libstdc++ 的模板实例化与 RTTI,它们必须可见,否则跨 DSO 的
vague-linkage 合不了一)——**例外清单是空的**,判据写成模糊链接谓词而不是一份名单。

`SOVERSION` 取 `major.minor`(0.x 期间),SONAME 从 `libcelestial_calendar.so.0.4.0`
变成 `libcelestial_calendar.so.0.4`。原 issue 说"不写 DT_SONAME"其实不成立——SONAME 一直有,
真问题是它带全版本号、每个 patch 都变。规则连同它的触发器("1.0 时改成 major-only")
写进了 CMakeLists 注释。

全仓补上第一批 `install()` 规则,三平台打包块从手写 `-type f` 拷贝换成 `cmake --install`
——换掉被守护的量:断言的对象从"glob 匹配到东西了吗"变成"install 装出了什么"。
`INSTALL_GTEST OFF`,否则 gtest 会搭车进 artifact。

**新闸门 `--export-surface`**,两段:静态段断言 `celestial.h` 里每个入口声明都带宏
(**平台无关,纯解析头文件**),动态段拿 `nm -D` 的集合与入口集合对拍(Linux)。
静态段是关键——它不需要 Windows 就守住了"Windows 少导出"那类退化的根因。
真正需要 Windows 才能证的只剩"宏的分支写对了没有",那由 `cabi_smoke_test` 链接 DLL 来证。
真源是 `celestial.h` 本身,**没有钉任何名单**。

**发布链路**(#72)。今天 `release.yml` 在 tag push 上触发,而 `build_and_test` 只在
`pull_request` 上跑 —— downloader 挑的是"`created_at` 最新的那次 run",与 tag 毫无关系,
且只查 `status == "completed"`(失败的 run 也是 completed)。失效路径很实在:某人开一个
编译挂了的 WIP PR,你在 main 打 tag,release 就装着那个 PR 的失败产物发出去。
现在要求 `conclusion == "success"` **且 `head_sha == tag 指向的 commit`**,走 workflow-scoped
端点 + 分页,找不到就大声失败;单件下载失败即整体 fail(此前只红字打印继续,release 可静默缺件)。

**其余**:`lib_astro.cpp` 八处日志字符串打的是不存在的内部函数名,FFI 用户 grep 对不上导出符号
——全部对齐,并立 `--log-names` 闸门守住(复用导出面闸门的解析器)。`celestial.h` 补线程安全契约段。
共享库默认 verbosity 改 `NONE`:库不该替宿主决定它的 stdout 归谁。

## 审阅

R1 四席(正确性盲审 · 契约/话语 · 闸门区分力 · 减法)→ R6,七个修复批,逐提交 CI 绿。
最后三轮全部撞在**同一段注释**上:某个谓词放行分支的正当性说明连续三版被证伪
(命名空间那句 → POD 因果 → "名字提到本库类型")。第四轮没有再写第四句解释,而是
**删掉那个分支** —— 它在 43 个真实幸存者里 0 条命中,保护的是一个不存在的场景。
两条 P2 随之蒸发,下一轮 `VERIFIED · NO FINDINGS`。

闸门区分力席逐针重跑而非重读叙述,每一针的突变记录留档在
仓外的工作记录里(`.review/` 是 gitignored 的);新闸门每道至少一针,先核构建返回码再判闸门红
(摘掉某入口的宏会让构建 EXIT 2 —— 那是 smoke 断链,不是闸门在响;闸门自己另 EXIT 1 并给出
静态+动态两条 finding)。

驾驶者中途换过一次(kimi 撞额度),流程未受影响:上下文全在盘上,重跑的席位读同一份任务书。

## 验证

- 测试 **235 ran == 235 declared**(直跑二进制与 `TEST(` 宏对账,不用 ctest 数字)
- `--export-surface` / `--log-names` / `--abi-layout` / `--ctypes-smoke` / `--self-contained` /
  ruff 0.16.1 / clang-tidy 18.1.8 全 EXIT 0
- 谓词自测 12 组,两条 pass-through 各钉一条样本;重新放宽会让自测翻红(实证)
- 发布链路三条路径实机验证(找不到 / 找得到 / 单件失败),走真 `gh`,非 mock

## 已知限制

- **发版从此变三步**:推 tag → 在该 tag 上手动 `workflow_dispatch` 一次 `build_and_test`
  → 重跑 release。这是有意的取舍——换来"不对就不发"。两年发了 5 个版本,手动那一步很便宜。
  发版频率上来、或有人被这三步绊到时,再议 `workflow_call` 复用构建。
- **三平台打包已首证**(本 PR 的矩阵跑出来了,以下三条从「待证」变成结论):
  - `cmake --install` 落位正确:Unix `lib/` + `include/`,Windows `bin/`(DLL)+ `lib/`(import lib)。
  - macOS 版本链在 install 输出里成立(真 `.0.4.0.dylib` + `.0.4.dylib` + `.dylib` 两条软链),
    守卫逐条验过。
  - **`upload-artifact@v7` 会把软链解引用**:下载原始 zip 实测**零个 symlink 条目**,
    三个同样 374,896 字节的真文件。解引用发生在上传那一步,不是下载工具干的。
    功能无影响(无版本号那个名字仍在,照样能链),代价是产物体积与「这三个是同一个东西」
    这层语义。已写进 workflow 注释,免得下一个人以为消费者拿到的是版本链。
- **一个只有真跑才会暴露的 bug,被 macOS 腿抓到并修掉了**:`inline thread_local LAST_ERROR`
  在头文件里是 vague linkage,而本 PR 新加的 `VISIBILITY_INLINES_HIDDEN` 让 Mach-O 不再跨 TU
  合并它的 TLS 初始化例程,五个 `lib*.cpp` 各留一份 → dylib 链接失败。ELF 照常合并,
  所以 Linux 与本地全绿、复现不出来。修法是把存储与三个访问器移进 `lib.cpp`
  (`2c47082`),让链接器不必去合并我们刚让它藏起来的东西。
- 内建 RTTI 若真以已定义符号出现在本库里,现在会成为一条 finding。方向是对的
  ——它本就该被看一眼,`SURVIVOR_EXCEPTIONS` 就是写明理由的地方。今天 0 命中。
- `#91` §2(25 个入口的名字在平坦 C 命名空间里过于通用)本批不处置,理由与触发器随关账评论。


