### PR TITLE
ci: AI workflow 与发布链路的信任边界 —— 调用方门槛、钉 SHA、上下文过滤,以及一道守它们的闸门 (#144)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,8 @@ version: 2
 updates:
   # A SHA pin (#144) raises no Dependabot alert -- advisories are matched against semver refs --
   # so version updates are the only thing keeping it current. They rewrite the `# v1` marker
-  # next to the SHA, which is what makes those markers worth reading. Monthly and grouped:
-  # upstream ships several releases a week, and a pin whose diff nobody reads is a floating tag
-  # with extra steps.
+  # next to the SHA, which is what makes those markers worth reading. Monthly and grouped: a
+  # pin whose diff nobody reads is a floating tag with extra steps.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+  # Pinning the AI action to a SHA (#144) moved "stay current" from GitHub's shoulders to
+  # nobody's: security advisories are matched against semver refs, so a SHA-pinned action
+  # raises no alert. Dependabot's version updates do follow SHA pins -- it rewrites both the
+  # SHA and the `# v1` marker beside it -- and grouping keeps a quiet week down to one PR.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,15 @@
 version: 2
 
 updates:
-  # Pinning the AI action to a SHA (#144) moved "stay current" from GitHub's shoulders to
-  # nobody's: security advisories are matched against semver refs, so a SHA-pinned action
-  # raises no alert. Dependabot's version updates do follow SHA pins -- it rewrites both the
-  # SHA and the `# v1` marker beside it -- and grouping keeps a quiet week down to one PR.
+  # A SHA pin (#144) raises no Dependabot alert -- advisories are matched against semver refs --
+  # so version updates are the only thing keeping it current. They rewrite the `# v1` marker
+  # next to the SHA, which is what makes those markers worth reading. Monthly and grouped:
+  # upstream ships several releases a week, and a pin whose diff nobody reads is a floating tag
+  # with extra steps.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       actions:
         patterns: ["*"]

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   review:
-    # Dependabot's runs get a read-only token and no Actions secrets, so on its PRs this job
-    # could only ever fail — and a weekly red is how people learn to ignore red (#144).
+    # Dependabot's runs cannot read Actions secrets, so on its PRs the API key is empty and this
+    # job could only ever fail — and a standing red is how people learn to ignore red (#144).
     if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,13 +11,14 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
+      id-token: write # traded for the action's App token; drop it and claude[bot] goes silent (#148)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@c038e4dcdedfbbca18dfb17df35a17e40ded4ddc # v1 (#144: pin the single security gate, no floating tag)
+      # Pinned to a SHA: the only third-party action here that is handed a repo secret (#144).
+      - uses: anthropics/claude-code-action@c038e4dcdedfbbca18dfb17df35a17e40ded4ddc # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@c038e4dcdedfbbca18dfb17df35a17e40ded4ddc # v1 (#144: pin the single security gate, no floating tag)
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   review:
-    if: ${{ !github.event.pull_request.draft }}
+    # Dependabot's runs get a read-only token and no Actions secrets, so on its PRs this job
+    # could only ever fail — and a weekly red is how people learn to ignore red (#144).
+    if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,6 +26,12 @@ jobs:
       issues: read
       id-token: write
     steps:
+      # The action fetches into an existing checkout and has no clone fallback of its own,
+      # so the job needs this step to have a repository at all (#144).
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
       - uses: anthropics/claude-code-action@c038e4dcdedfbbca18dfb17df35a17e40ded4ddc # v1 (#144: pin the single security gate, no floating tag)
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,12 +10,13 @@ on:
 
 jobs:
   claude:
-    # The action checks the caller too, but only after minting an App token and putting the API
-    # key in the step env — this gate keeps the job from ever starting (#144).
+    # The action checks the caller only inside the job, once the API key is in the step env and
+    # an App token is minted — and it waves any [bot] straight through. This gate keeps the job
+    # from starting. OWNER alone: COLLABORATOR also covers read-only access (#144).
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.author_association == 'OWNER') ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.review.author_association == 'OWNER') ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && github.event.issue.author_association == 'OWNER')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -35,4 +36,6 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Only comments are filtered; title, body, labels, branch and file names all still reach
           # an agent holding the API key, so treat the key as injection-reachable (#144).
-          include_comments_by_actor: "0xf3cd, claude" # GraphQL bot logins carry no [bot] suffix
+          # `claude` is the bot's GraphQL login (no [bot] suffix there) — and also a real human
+          # account, which this therefore lets in too; GraphQL offers nothing finer to filter on.
+          include_comments_by_actor: "0xf3cd, claude"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   claude:
+    # #144: defense in depth — the action has its own actor gate (verified in the audit), but
+    # don't bet everything on upstream internals: require OWNER/MEMBER/COLLABORATOR here too.
+    # Side effect: bot-authored events (e.g. Copilot's review comments, association NONE) no
+    # longer reach the action, so they land `skipped` instead of `action_required`.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -24,6 +28,10 @@ jobs:
       issues: read
       id-token: write
     steps:
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@c038e4dcdedfbbca18dfb17df35a17e40ded4ddc # v1 (#144: pin the single security gate, no floating tag)
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # #144: keep machine/external text out of the agent's context — only the owner's and
+          # the bot's own comments are included. Residual: the triggering issue/PR body itself
+          # still enters, so treat the key as prompt-injection-reachable (#144 item 2).
+          include_comments_by_actor: "0xf3cd, claude[bot]"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,20 +3,17 @@ name: Claude Code
 on:
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
   issues:
-    types: [opened, assigned]
+    types: [opened]
   pull_request_review:
     types: [submitted]
 
 jobs:
   claude:
-    # #144: defense in depth — the action has its own actor gate, but don't bet everything on
-    # upstream internals: require OWNER/MEMBER/COLLABORATOR here too.
+    # The action checks the caller too, but only after minting an App token and putting the API
+    # key in the step env — this gate keeps the job from ever starting (#144).
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
@@ -24,18 +21,18 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
+      id-token: write # traded for the action's App token; drop it and claude[bot] goes silent (#148)
     steps:
-      # The action fetches into an existing checkout and has no clone fallback of its own,
-      # so the job needs this step to have a repository at all (#144).
-      - uses: actions/checkout@v6
+      # The action fetches into an existing checkout and never clones, so without this step the
+      # fetch fails on an empty workspace (#144).
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@c038e4dcdedfbbca18dfb17df35a17e40ded4ddc # v1 (#144: pin the single security gate, no floating tag)
+      # Pinned to a SHA: the only third-party action here that is handed a repo secret (#144).
+      - uses: anthropics/claude-code-action@c038e4dcdedfbbca18dfb17df35a17e40ded4ddc # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # #144: keep machine/external text out of the agent's context — only the owner's and
-          # the bot's own comments are included. Residual: the triggering issue/PR body itself
-          # still enters, so treat the key as prompt-injection-reachable (#144 item 2).
-          include_comments_by_actor: "0xf3cd, claude[bot]"
+          # Only comments are filtered; title, body, labels, branch and file names all still reach
+          # an agent holding the API key, so treat the key as injection-reachable (#144).
+          include_comments_by_actor: "0xf3cd, claude" # GraphQL bot logins carry no [bot] suffix

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,10 +12,8 @@ on:
 
 jobs:
   claude:
-    # #144: defense in depth — the action has its own actor gate (verified in the audit), but
-    # don't bet everything on upstream internals: require OWNER/MEMBER/COLLABORATOR here too.
-    # Side effect: bot-authored events (e.g. Copilot's review comments, association NONE) no
-    # longer reach the action, so they land `skipped` instead of `action_required`.
+    # #144: defense in depth — the action has its own actor gate, but don't bet everything on
+    # upstream internals: require OWNER/MEMBER/COLLABORATOR here too.
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,8 +11,8 @@ on:
 jobs:
   claude:
     # The action checks the caller only inside the job, once the API key is in the step env and
-    # an App token is minted — and it waves any [bot] straight through. This gate keeps the job
-    # from starting. OWNER alone: COLLABORATOR also covers read-only access (#144).
+    # an App token is minted — and its write-permission check short-circuits for any [bot]. This
+    # gate keeps the job from starting. OWNER alone: COLLABORATOR also covers read access (#144).
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.author_association == 'OWNER') ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.review.author_association == 'OWNER') ||
@@ -37,5 +37,5 @@ jobs:
           # Only comments are filtered; title, body, labels, branch and file names all still reach
           # an agent holding the API key, so treat the key as injection-reachable (#144).
           # `claude` is the bot's GraphQL login (no [bot] suffix there) — and also a real human
-          # account, which this therefore lets in too; GraphQL offers nothing finer to filter on.
+          # account, which this therefore lets in too: the input matches on login and nothing else.
           include_comments_by_actor: "0xf3cd, claude"

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -51,7 +51,7 @@ jobs:
           ./project.py --clean --cmake
           
           chmod +x linter.py
-          ./linter.py --ruff --clang-tidy --abi-layout
+          ./linter.py --ruff --clang-tidy --abi-layout --ai-workflows
 
           
   test-ubuntu-gcc14:  

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -33,6 +33,12 @@ jobs:
           # Both pinned; see AGENTS.md gotcha 9 (#72, #73).
           python3 -m pip install ruff==0.16.1 clang-tidy==18.1.8
 
+      # Pure parsing, so it rides this leg rather than paying for a job of its own -- but it
+      # goes before the toolchain: `linter.py` exits on the first finding, and behind the
+      # style checks a cmake or ruff failure would mask this verdict entirely (#144).
+      - name: Check the AI workflows
+        run: python3 ./linter.py --ai-workflows
+
       - name: Install LLVM and clang++
         run: |
           sudo add-apt-repository universe
@@ -49,9 +55,9 @@ jobs:
         run: |
           chmod +x project.py
           ./project.py --clean --cmake
-          
+
           chmod +x linter.py
-          ./linter.py --ruff --clang-tidy --abi-layout --ai-workflows
+          ./linter.py --ruff --clang-tidy --abi-layout
 
           
   test-ubuntu-gcc14:  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,8 @@ jobs:
 
       - name: Sanity Check on Version
         # The tag name is attacker-chosen text and this job runs with contents: write, so it
-        # goes through env rather than expression interpolation into the shell (#144).
+        # goes through env rather than expression interpolation into the shell (#144). The `v`
+        # stripped below is guaranteed by the tag filter above, not by anything in this step.
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,12 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Sanity Check on Version
+        # The tag name is attacker-chosen text and this job runs with contents: write, so it
+        # goes through env rather than expression interpolation into the shell (#144).
+        env:
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          github_ref=${{ github.ref }}
-          version_nums=${github_ref##refs/tags/v}
+          version_nums=${TAG_NAME#v}
 
           chmod +x project.py
           expected_version_nums=$(./project.py --version)
@@ -31,9 +34,9 @@ jobs:
           fi
 
       - name: Download Artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-
           chmod +x toolbox/artifact_downloader.py
           ./toolbox/artifact_downloader.py --save-to ./release_assets
 
@@ -42,7 +45,8 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: ncipollo/release-action@v1
+        # Pinned to a SHA: it runs in a contents: write job and publishes the release assets (#144).
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           artifacts: "release_assets/*"
           bodyFile: "docs/RELEASE_NOTES.md"

--- a/Requirements.txt
+++ b/Requirements.txt
@@ -3,3 +3,6 @@
 # Linters are installed separately (README section 4); the `statistics/` layer has
 # its own `Requirements-statistics.txt`.
 requests
+# The AI-workflow gate reads `.github/workflows/*.yml` for real: a per-job permission and a
+# pinned SHA cannot be told apart from a workflow's own prose by matching lines (#144).
+pyyaml

--- a/automation/__init__.py
+++ b/automation/__init__.py
@@ -32,6 +32,7 @@ from .abi_layout import check_abi_layout
 from .ctypes_smoke import check_ctypes_smoke
 from .export_surface import check_export_surface
 from .log_names import check_log_names
+from .ai_workflows import check_ai_workflows
 from .bench import build_benchmarks, run_benchmarks, find_benchmarks
 
 __all__ = [
@@ -44,5 +45,6 @@ __all__ = [
   "proj_root", "build_dir", "cpp_src_dir", "python_requirements", "cpp_test_dir",
   "GitHub", "run_ruff", "run_clang_tidy", "check_self_contained", "probe_features",
   "check_abi_layout", "check_ctypes_smoke", "check_export_surface", "check_log_names",
+  "check_ai_workflows",
   "build_benchmarks", "run_benchmarks", "find_benchmarks"
 ]

--- a/automation/ai_workflows.py
+++ b/automation/ai_workflows.py
@@ -11,17 +11,18 @@
 
 import re
 
-from typing import Final, List, Tuple
+import yaml
+
+from typing import Any, Dict, Final, List, Optional, Tuple
 
 from . import paths
 from .utils import green_print, red_print, yellow_print
 
 
-# The two workflows that hand an agent a repo secret. Each keeps two settings whose removal
-# breaks nothing that anyone would notice: the OIDC permission the action trades for its
-# GitHub App token (#148 deleted it once -- claude[bot] went silent while every other check
-# stayed green), and the SHA pin on the action itself (#144 -- a floating tag lets the only
-# gate on this path be rewritten upstream). Neither has a test that would go red.
+# The workflows that hand an agent the API key, and the only ones this gate covers. A third
+# one belongs in this tuple the day it appears; `release.yml` pins its publisher by hand and
+# stays outside on purpose -- holding all 18 `actions/*@v7` references to a SHA would drown
+# the gate in noise (#144).
 AI_WORKFLOWS: Final[Tuple[str, ...]] = (
   "claude.yml",
   "claude-review.yml",
@@ -29,23 +30,33 @@ AI_WORKFLOWS: Final[Tuple[str, ...]] = (
 
 PINNED_ACTION: Final[str] = "anthropics/claude-code-action"
 
-OIDC_RE: Final[re.Pattern] = re.compile(r"^\s*id-token:\s*write\b", re.MULTILINE)
-USES_RE: Final[re.Pattern] = re.compile(
-  rf"^\s*-?\s*uses:\s*{re.escape(PINNED_ACTION)}@(\S+)", re.MULTILINE
-)
 SHA_RE: Final[re.Pattern] = re.compile(r"^[0-9a-f]{40}$")
 
 
+def _uses_target(step: Any) -> Optional[str]:
+  """The action a step calls, or None if the step calls no action."""
+  if not isinstance(step, dict):
+    return None
+  uses = step.get("uses")
+  return uses if isinstance(uses, str) else None
+
+
+def _grants_oidc(permissions: Any) -> bool:
+  """Whether a `permissions:` value grants `id-token: write`."""
+  if permissions == "write-all":
+    return True
+  return isinstance(permissions, dict) and permissions.get("id-token") == "write"
+
+
 def check_ai_workflows() -> int:
-  """Hold the AI workflows to the two settings of theirs that fail silently.
+  """Hold the AI workflows to two settings whose loss nothing else would report.
 
-  Both failures are silent by construction, which is why they get a gate rather than a
-  comment: dropping `id-token: write` leaves every check green and only claude[bot] mute,
-  and swapping the pinned SHA back to a tag changes nothing until the day upstream moves
-  it. Pure parsing -- no build needed, any leg can run it.
-
-  Not a general "pin every action" rule: the repo's other actions are first-party and none
-  of them is handed a secret, so widening this gate would turn it into noise (#144).
+  Deleting `id-token: write` leaves every check green and only claude[bot] mute (#148);
+  swapping the pinned SHA back to a tag changes nothing until the day upstream moves it
+  (#144). Both are read from the parsed YAML, not from the file text: the permission is
+  per-job and has to be checked on the job that calls the action, and a workflow's prose
+  (`prompt:` blocks quote this repo's own CI) must not be able to satisfy the gate.
+  Pure parsing -- no build needed, any leg can run it.
   """
   print("#" * 60)
   yellow_print("Checking the AI workflows keep their OIDC permission and pinned action...")
@@ -62,26 +73,50 @@ def check_ai_workflows() -> int:
       )
       continue
 
-    text = path.read_text()
+    try:
+      workflow: Dict[str, Any] = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as exc:
+      failures.append(f"{name}: not valid YAML, so GitHub cannot run it either ({exc.__class__.__name__})")
+      continue
 
-    if not OIDC_RE.search(text):
-      failures.append(
-        f"{name}: no `id-token: write`. The action trades it for its GitHub App token, so "
-        f"removing it silences claude[bot] while the rest of CI stays green (#148)"
-      )
+    jobs = workflow.get("jobs") if isinstance(workflow, dict) else None
+    calling_jobs = {
+      job_id: job
+      for job_id, job in (jobs or {}).items()
+      if isinstance(job, dict)
+      for step in (job.get("steps") or [])
+      if (_uses_target(step) or "").split("@")[0] == PINNED_ACTION
+    }
 
-    refs = USES_RE.findall(text)
-    if not refs:
+    if not calling_jobs:
       # A gate that cannot find what it guards passes vacuously; say so instead.
       failures.append(
-        f"{name}: no `uses: {PINNED_ACTION}` line. Either this check's parsing broke, or the "
+        f"{name}: no job calls {PINNED_ACTION}. Either this check's parsing broke, or the "
         f"workflow no longer calls the action and belongs out of AI_WORKFLOWS"
       )
-    failures.extend(
-      f"{name}: {PINNED_ACTION} is at `{ref}`, not a commit SHA. It is the only third-party "
-      f"action here handed a repo secret; a floating tag lets upstream rewrite it (#144)"
-      for ref in refs if not SHA_RE.match(ref)
-    )
+      continue
+
+    for job_id, job in calling_jobs.items():
+      # A job's `permissions:` replaces the workflow-level block outright, it does not merge.
+      permissions = job["permissions"] if "permissions" in job else workflow.get("permissions")
+      if not _grants_oidc(permissions):
+        failures.append(
+          f"{name}: job `{job_id}` calls the action without `id-token: write`. The action "
+          f"trades it for its GitHub App token, so the job silences claude[bot] while the "
+          f"rest of CI stays green (#148)"
+        )
+
+      for step in job["steps"]:
+        uses = _uses_target(step) or ""
+        if uses.split("@")[0] != PINNED_ACTION:
+          continue
+        ref = uses.partition("@")[2]
+        if not SHA_RE.match(ref):
+          failures.append(
+            f"{name}: job `{job_id}` calls the action at `{ref}`, not a commit SHA. It is the "
+            f"only third-party action here handed a repo secret; a floating tag lets upstream "
+            f"rewrite it (#144)"
+          )
 
   print("#" * 60)
   if failures:

--- a/automation/ai_workflows.py
+++ b/automation/ai_workflows.py
@@ -81,7 +81,7 @@ def check_ai_workflows() -> int:
       continue
 
     try:
-      workflow: Dict[str, Any] = yaml.safe_load(path.read_text())
+      workflow: Dict[str, Any] = yaml.safe_load(path.read_text(encoding="utf-8"))
     except yaml.YAMLError as exc:
       failures.append(f"{name}: not valid YAML, so GitHub cannot run it either ({exc.__class__.__name__})")
       continue

--- a/automation/ai_workflows.py
+++ b/automation/ai_workflows.py
@@ -54,11 +54,16 @@ def check_ai_workflows() -> int:
   (#144). Both are read from the parsed YAML, not from the file text: the permission is
   per-job and has to be checked on the job that calls the action, and a workflow's prose
   (`prompt:` blocks quote this repo's own CI) must not be able to satisfy the gate.
-  Pure parsing -- no build needed, any leg can run it.
+  Pure parsing -- no build needed, so any leg that installs Requirements.txt can run it.
   """
-  # Imported here, not at module scope: `automation/__init__` is on the import path of every
-  # `project.py` invocation, including CI steps that never install Requirements.txt.
-  import yaml
+  # This gate is the only part of the automation that parses YAML, so it pays for the import
+  # itself rather than putting it on every `project.py` invocation (`requests` already is on
+  # that path -- see the note next to the linters leg in core_tests.yml).
+  try:
+    import yaml
+  except ModuleNotFoundError:
+    red_print("This check needs PyYAML: run `pip install -r Requirements.txt` first")
+    return 1
 
   print("#" * 60)
   yellow_print("Checking the AI workflows keep their OIDC permission and pinned action...")
@@ -84,7 +89,7 @@ def check_ai_workflows() -> int:
     jobs = workflow.get("jobs") if isinstance(workflow, dict) else None
     calling_jobs = {
       job_id: job
-      for job_id, job in (jobs or {}).items()
+      for job_id, job in (jobs if isinstance(jobs, dict) else {}).items()
       if isinstance(job, dict)
       for step in (job.get("steps") or [])
       if (_uses_target(step) or "").split("@")[0] == PINNED_ACTION

--- a/automation/ai_workflows.py
+++ b/automation/ai_workflows.py
@@ -19,8 +19,8 @@ from .utils import green_print, red_print, yellow_print
 
 # The workflows that hand an agent the API key, and the only ones this gate covers. A third
 # one belongs in this tuple the day it appears; `release.yml` pins its publisher by hand and
-# stays outside on purpose -- holding all 18 `actions/*@v7` references to a SHA would drown
-# the gate in noise (#144).
+# stays outside on purpose -- holding every first-party action reference to a SHA would
+# drown the gate in noise (#144).
 AI_WORKFLOWS: Final[Tuple[str, ...]] = (
   "claude.yml",
   "claude-review.yml",

--- a/automation/ai_workflows.py
+++ b/automation/ai_workflows.py
@@ -1,0 +1,94 @@
+# CelestialCalendar Automation:
+#   Python automation scripts for building and testing the CelestialCalendar C++ project.
+#
+# Author : Ningqi Wang (0xf3cd)
+# Email  : nq.maigre@gmail.com
+# Repo   : https://github.com/0xf3cd/celestial-calendar
+# License: GNU General Public License v3.0
+#
+# This software is distributed without any warranty.
+# See <https://www.gnu.org/licenses/> for more details.
+
+import re
+
+from typing import Final, List, Tuple
+
+from . import paths
+from .utils import green_print, red_print, yellow_print
+
+
+# The two workflows that hand an agent a repo secret. Each keeps two settings whose removal
+# breaks nothing that anyone would notice: the OIDC permission the action trades for its
+# GitHub App token (#148 deleted it once -- claude[bot] went silent while every other check
+# stayed green), and the SHA pin on the action itself (#144 -- a floating tag lets the only
+# gate on this path be rewritten upstream). Neither has a test that would go red.
+AI_WORKFLOWS: Final[Tuple[str, ...]] = (
+  "claude.yml",
+  "claude-review.yml",
+)
+
+PINNED_ACTION: Final[str] = "anthropics/claude-code-action"
+
+OIDC_RE: Final[re.Pattern] = re.compile(r"^\s*id-token:\s*write\b", re.MULTILINE)
+USES_RE: Final[re.Pattern] = re.compile(
+  rf"^\s*-?\s*uses:\s*{re.escape(PINNED_ACTION)}@(\S+)", re.MULTILINE
+)
+SHA_RE: Final[re.Pattern] = re.compile(r"^[0-9a-f]{40}$")
+
+
+def check_ai_workflows() -> int:
+  """Hold the AI workflows to the two settings of theirs that fail silently.
+
+  Both failures are silent by construction, which is why they get a gate rather than a
+  comment: dropping `id-token: write` leaves every check green and only claude[bot] mute,
+  and swapping the pinned SHA back to a tag changes nothing until the day upstream moves
+  it. Pure parsing -- no build needed, any leg can run it.
+
+  Not a general "pin every action" rule: the repo's other actions are first-party and none
+  of them is handed a secret, so widening this gate would turn it into noise (#144).
+  """
+  print("#" * 60)
+  yellow_print("Checking the AI workflows keep their OIDC permission and pinned action...")
+
+  workflow_dir = paths.proj_root() / ".github" / "workflows"
+  failures: List[str] = []
+
+  for name in AI_WORKFLOWS:
+    path = workflow_dir / name
+    if not path.is_file():
+      failures.append(
+        f"{name}: not found. This gate names the workflows it guards -- drop the name from "
+        f"AI_WORKFLOWS if the workflow is gone on purpose"
+      )
+      continue
+
+    text = path.read_text()
+
+    if not OIDC_RE.search(text):
+      failures.append(
+        f"{name}: no `id-token: write`. The action trades it for its GitHub App token, so "
+        f"removing it silences claude[bot] while the rest of CI stays green (#148)"
+      )
+
+    refs = USES_RE.findall(text)
+    if not refs:
+      # A gate that cannot find what it guards passes vacuously; say so instead.
+      failures.append(
+        f"{name}: no `uses: {PINNED_ACTION}` line. Either this check's parsing broke, or the "
+        f"workflow no longer calls the action and belongs out of AI_WORKFLOWS"
+      )
+    failures.extend(
+      f"{name}: {PINNED_ACTION} is at `{ref}`, not a commit SHA. It is the only third-party "
+      f"action here handed a repo secret; a floating tag lets upstream rewrite it (#144)"
+      for ref in refs if not SHA_RE.match(ref)
+    )
+
+  print("#" * 60)
+  if failures:
+    red_print(f"AI-workflow gate failed ({len(failures)} finding(s)):")
+    for f in failures:
+      red_print(f"  - {f}")
+    return 1
+
+  green_print(f"AI workflows keep OIDC and a pinned action ({len(AI_WORKFLOWS)} files)")
+  return 0

--- a/automation/ai_workflows.py
+++ b/automation/ai_workflows.py
@@ -11,8 +11,6 @@
 
 import re
 
-import yaml
-
 from typing import Any, Dict, Final, List, Optional, Tuple
 
 from . import paths
@@ -58,6 +56,10 @@ def check_ai_workflows() -> int:
   (`prompt:` blocks quote this repo's own CI) must not be able to satisfy the gate.
   Pure parsing -- no build needed, any leg can run it.
   """
+  # Imported here, not at module scope: `automation/__init__` is on the import path of every
+  # `project.py` invocation, including CI steps that never install Requirements.txt.
+  import yaml
+
   print("#" * 60)
   yellow_print("Checking the AI workflows keep their OIDC permission and pinned action...")
 

--- a/linter.py
+++ b/linter.py
@@ -19,7 +19,7 @@ import argparse
 
 from automation import (
   run_ruff, run_clang_tidy, check_self_contained, probe_features, check_abi_layout,
-  check_ctypes_smoke, check_export_surface, check_log_names,
+  check_ctypes_smoke, check_export_surface, check_log_names, check_ai_workflows,
 )
 
 
@@ -44,12 +44,14 @@ def parse_args() -> argparse.Namespace:
       "    ./linter.py --export-surface\n\n"
       "  To hold the lib_*.cpp log strings to the celestial.h entry-point names:\n"
       "    ./linter.py --log-names\n\n"
+      "  To hold the AI workflows to the settings of theirs that fail silently:\n"
+      "    ./linter.py --ai-workflows\n\n"
       "  To report which awaited C++ features this toolchain can compile:\n"
       "    ./linter.py --features\n\n"
       "  To hold a CI leg to the feature state this repo recorded for it:\n"
       "    ./linter.py --features libc++\n\n"
       "  To run every check (ruff, clang-tidy, self-containment, ABI layout, ctypes smoke,\n"
-      "  export surface, log names, feature report):\n"
+      "  export surface, log names, AI workflows, feature report):\n"
       "    ./linter.py -a/--all\n\n"
     ),
     formatter_class=argparse.RawTextHelpFormatter
@@ -68,6 +70,8 @@ def parse_args() -> argparse.Namespace:
                       help="Hold the built library's export surface to the celestial.h entry points")
   parser.add_argument("--log-names", action="store_true",
                       help="Hold the lib_*.cpp log strings to the celestial.h entry-point names")
+  parser.add_argument("--ai-workflows", action="store_true",
+                      help="Hold the AI workflows to the settings of theirs that fail silently")
   parser.add_argument("--features", nargs="?", const="", default=None, metavar="LEG",
                       help="Probe the awaited C++ features; with a CI leg name, hold it to the recorded state")
 
@@ -109,6 +113,11 @@ if __name__ == "__main__":
 
   if args.log_names or args.all:
     ret_code = check_log_names()
+    if ret_code != 0:
+      sys.exit(ret_code)
+
+  if args.ai_workflows or args.all:
+    ret_code = check_ai_workflows()
     if ret_code != 0:
       sys.exit(ret_code)
 

--- a/linter.py
+++ b/linter.py
@@ -101,6 +101,11 @@ if __name__ == "__main__":
     if ret_code != 0:
       sys.exit(ret_code)
 
+  if args.ai_workflows or args.all:
+    ret_code = check_ai_workflows()
+    if ret_code != 0:
+      sys.exit(ret_code)
+
   if args.ctypes_smoke or args.all:
     ret_code = check_ctypes_smoke()
     if ret_code != 0:
@@ -113,11 +118,6 @@ if __name__ == "__main__":
 
   if args.log_names or args.all:
     ret_code = check_log_names()
-    if ret_code != 0:
-      sys.exit(ret_code)
-
-  if args.ai_workflows or args.all:
-    ret_code = check_ai_workflows()
     if ret_code != 0:
       sys.exit(ret_code)
 


### PR DESCRIPTION
## 解决的问题

#144 是仓级安全审的产出,四条里有三条落在两个 AI workflow 的信任边界上。它们的共同形状是:**坏掉的时候没有任何东西会变红。**

- 唯一那道拦住「谁能不请自来地把这台机器点起来」的闸门,跟在浮动 tag `v1` 后面 —— 上游哪天改写这个 tag,仓库无感。
- 公开仓上任何人在 issue 里打一句 `@claude`,就能起一台 runner、铸出一个 GitHub App token、把明文 `ANTHROPIC_API_KEY` 放进 step env,然后才由跑在**同一个进程内部**的检查把他拒掉。可反复触发,无成本。
- 任何人写的评论都会进入 agent 的上下文。

顺带查出第四件,不在 #144 里:`claude.yml` 从来没有 `actions/checkout`,而这个 action 自己不 clone —— 它开局就是 `git fetch origin <branch>`。也就是说这个 workflow 一年来**一次都没有真正执行过**,「它到底能不能工作」此前是零证据(对照:带 checkout 的 `claude-review.yml` 有 45 次成功)。

## 做了什么

| 面 | 改动 |
|---|---|
| 调用方 | job 级 `if` 要求 `author_association == 'OWNER'` —— 门在 job 启动**之前**,key 不会被物化到 runner 上 |
| 供应链 | `claude-code-action` 与 `ncipollo/release-action` 钉到 commit SHA;`.github/dependabot.yml` 接管它们的升级 |
| 上下文 | `include_comments_by_actor` 只放行仓主与 bot 自己的评论 |
| 可用性 | `claude.yml` 补 `actions/checkout`;触发面收掉两条(见下) |
| 发布链路 | tag 名不再插值进 shell(**这条堵的是一个真洞**,见下) |
| 闸门 | 新增 `./linter.py --ai-workflows`,守上面两条静默不变量 |

## 一个真的洞:`release.yml` 的 tag 名注入

版本自检原本把 `github.ref` 直接插进未加引号的 shell 赋值,而这个 job 带 `contents: write`。构造一个 tag:

```
v1.2.3$(touch /tmp/PWNED)
```

`git check-ref-format` 收得下,`on.push.tags: ['v*.*.*']` 也放得过。实测老写法**同时拿到执行和绕过** —— 命令执行了,而 `$(…)` 展开成空串后剩下的正好等于 `1.2.3`,版本自检还是绿的。改走 `env` 之后,同一个 payload 原样变成字符串,闸门红。

```yaml
env:
  TAG_NAME: ${{ github.ref_name }}
run: |
  version_nums=${TAG_NAME#v}
```

## 新增的闸门

`id-token: write` 与那个钉死的 SHA,删掉或换回浮动 tag,**在此之前不会有任何东西变红**。前者被删过一次(#148):claude[bot] 当场失声,其余 CI 全绿。所以这两条不是靠注释守得住的,注释拦的是「结论被形成」,闸门拦的是「改动落地」——两者都留。

它读解析后的 YAML,不读文件文本。这一条是被打回来重写的:第一版逐行匹配,而 `claude-review.yml` 有一大段 `prompt:` 散文讲的正是本仓的 CI —— 散文里随便一行 `id-token: write` 就能替真配置满足闸门。同时权限是 **per-job** 的,按文件搜等于放过「把权限挪到另一个 job」这种半截重构,而那正是 #148 的形状。

区分力实测(注入 → 期望 → 实际):

```
delete `id-token: write`                              RED  ✅
comment it out                                        RED  ✅
SHA back to a floating tag                            RED  ✅
permission hoisted, job block keeps the rest          RED  ✅   ← 第一版是绿的
only prose in a prompt block says id-token: write     RED  ✅   ← 第一版是绿的
`id-token: 'write'` / flow mapping / quoted `uses:`   green ✅   ← 第一版全是红的
dependabot-style bump (new SHA + new marker)          green ✅
```

**范围只框这两个 workflow**,不是「所有 action 必须钉 SHA」的全仓规矩:仓里 18 处 `actions/*@v7` 会当场变红,那是典型的误报闸门,一周内就会被学会绕过。`release.yml` 的钉版因此是一个**可见的、有意的缺口**,不是被论证掉的不存在。

## 没做什么,以及为什么

- **不把闸门推到全仓** —— 同上。
- **不给 Dependabot 配一份 `ANTHROPIC_API_KEY`** —— 方向与本 PR 相反。改为让自动审阅跳过 dependabot 的 PR:它的 run 读不到 Actions secrets,在那类 PR 上只可能失败,而一条常驻的红是训练人忽略红的最好办法。
- **不改仓库设置**(分支保护、tag ruleset、secret scanning)—— 都是真问题,但改动的是日常推送手感,单独议。
- **不收 `#144` 第 4 条**(审阅材料归档管道)—— 流程侧,与代码无关。
- **发布产物与 tag 的绑定不在这里** —— 已由 #91 落地(`artifact_downloader` 现在要求 `head_sha == release commit && conclusion == success`)。
- **`if` 里的 `contains('@claude')` 比 action 自己的词边界正则松,有意不修** —— GitHub 表达式没有正则,硬凑出来的字符串匹配比现状更脆。代价是偶尔一次空转;加了调用方门槛之后,外人已经点不动它。

## 触发面收掉的两条

- `issues` 的 `assigned`:本仓没有配 `assignee_trigger`,所以 assign 一个正文里写过 `@claude` 的老 issue,会起 job、铸 token、把 key 放进 env,然后在触发判定处 early return。**更正一处措辞**:早先的提交信息说「action 对 assigned 没有任何反应」,那是全称过满 —— 死的是本仓的配置,不是 action 的能力。
- `pull_request_review_comment`:历史上 48 条常驻「等待审批」的空 run 全部来自这一个事件(Copilot 的行内评论)。代价是不能在行内评论里 `@claude`;会话区评论与 review 正文两条路都还在。

## 已知边界

三条,都钉在它们该在的地方而不是这里:上下文过滤只管评论(`claude.yml` 的 `include_comments_by_actor` 旁)、白名单里那个 slug 同时是一个真人账号(同处)、闸门是名单式的(`ai_workflows.py` 的 `AI_WORKFLOWS` 旁)。三条都是站得住的负声明,不是待办。

## 验证

- 闸门在真 CI 上跑绿过(不是只在本地绿的检查);`actionlint` 六个 workflow、`ruff` 全清。
- 注入矩阵两套独立实现,互不共用代码,结论一致。
- `claude-code-action` 的行为断言全部读自**钉住的那个 SHA 的源码**,不读 README。
- `v1` 是注解 tag,解引用做过两跳;`ncipollo` 的是轻量 tag,直接指 commit。两者都用 tag ref 端点定案,而不是 `commits/<sha>` —— 后者在同一 fork network 里也会返回 fork 上的 commit。

一条记账:某条提交信息里写「阻断 yaml 模块实测 import 均成功」,那次的拦截器用了 Python 3.12 已移除的 `find_module` 协议,静默失效,**证据是空的**。结论为真(已用 `find_spec` 复验),但当时那句话没有支撑 —— 与这个 PR 通篇在追的失败形状同源,记在这里而不是让它过去。

## 一件本 PR 自己撞上的事

**这个 PR 没有拿到 Claude 的自动审阅。** action 有一条自保:当 PR 改动了 workflow 文件、与默认分支上的版本不一致时,它拒绝执行 —— 否则一个 PR 可以先改写 workflow 再用它去偷 key。设计是对的,但**它以成功退出,check 显示绿**:

```
Skipping action due to workflow validation: Workflow validation failed.
The workflow file must exist and have identical content to the version on
the repository's default branch.
Exiting due to workflow validation skip
```

推广开来:**任何改动 AI workflow 的 PR 都不会被它审,而那一格照样绿** —— 恰恰是最该被多看一眼的那类改动。记在这里,不让它作为一次「审过了」被读。

## 与 #144 的关系

**不 close。** 四条的逐条去向写在 #144 的关账评论里 —— 那里是这条信任边界的账本,写两份将来只会漂。简言之:第 1 条已被 #148 实测证伪,第 3 条本 PR 做完,第 2 条做了缓解、还欠 key 的轮换与告警预案,第 4 条状态不变。
