### PR TITLE
docs+fix: 设计台账落地 AGENTS.md,错误契约小账清零 (#127 #86 #82 #155)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,13 +209,7 @@ is intentional. Keep it. That buys a discipline:
   (as `sun.hpp` already does with `using namespace astro::toolbox::literals;`) or fully-qualify.
   Closed-set forms that *are* allowed: `using X = Y` type aliases, and using-declarations that
   import a named template from another namespace (see `datetime.hpp` for the chrono set —
-  class templates for CTAD, plus matching shape for stdlib alias templates). Remaining
-  ordinary using-declarations still left in production lunar headers after the #51 sweep
-  (documented exceptions, not a live cleanup ticket):
-  `using std::chrono::year_month_day` in `lunar/common.hpp` and `lunar/converter.hpp`;
-  `using std::chrono::sys_days` in `lunar/converter.hpp`;
-  `using calendar::lunar::common::LunarYear` in `lunar/algo2.hpp`.
-  Fully-qualify those when the files are next touched for other reasons. Test-only headers
+  class templates for CTAD, plus matching shape for stdlib alias templates). Test-only headers
   may still carry function-body or file-local usings (e.g. `delta_t_test_helper.hpp`).
 - **Nested `lower_case` namespaces** by domain (`astro::earth::nutation`,
   `lib::`, `calendar::`); close with a `} // namespace …` comment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,28 @@ project — keep the header.
   any quantization the source applied (e.g. USNO evaluating LAST at 4-decimal longitudes).
   Otherwise tolerances silently absorb the mismatch and the dataset loses discriminating power.
 
+### Acceptance: run the binaries, and reconcile the count
+
+**Do not accept on ctest's numbers.** ctest reports on what it was told about, and that
+registration goes stale in both directions: `ctest --test-dir build` finds *zero* tests and
+reports success (the registry lives in `build/test`), and a `--build --test` run after adding a
+source file silently omits it, because the `GLOB` that discovers tests expands at configure time.
+
+Run the binaries directly, then reconcile the total against the `TEST` macros:
+
+```sh
+total=0; for exe in build/test/*; do [ -x "$exe" ] && [ -f "$exe" ] || continue
+  out=$("$exe" 2>&1) || echo "FAIL $exe"
+  n=$(echo "$out" | grep -oE "^\[==========\] [0-9]+ test" | grep -oE "[0-9]+" | head -1)
+  total=$((total + ${n:-0})); done
+echo "$total"; grep -rhoE '^\s*TEST(_F)?\(' src/test --include=*.cpp | wc -l   # must be equal
+```
+
+**The reconciliation is the load-bearing half.** Running the binaries proves that what ran
+passed; only the count proves that everything that should have run *did*. A stale binary skews
+it in the greener direction — the one nobody goes looking for — which is why the build now
+clears `build/test/` before re-creating it (#155).
+
 ## Project Layout
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,7 +282,7 @@ Sort by *what happened to the answer*, not by how the failure feels:
 |---|---|---|
 | **Cannot be produced correctly** — bad input, outside a declared window, or the solver did not converge | `throw` | `sunrise_sunset::validate`; `algo2` outside [410, 2500]; `jieqi_jde` outside [1, 32766] (#154); the residual guard that throws rather than mislabel a day as polar |
 | **Was produced, and it is "none"** | `std::optional` | no sunrise on a polar night; no leap month in a common year |
-| **Is beside the point — the library's own bookkeeping is broken** | `assert` | internal invariants only, never an input guard (see gotcha 8) |
+| **Is beside the point — the library's own bookkeeping is broken** | `assert` | internal invariants only (NDEBUG mechanics: gotcha 8) |
 
 A declared model window *is* the contract's domain, so leaving it is a bad argument like any
 other. `optional` never carries an error — it carries a legitimate "none". `std::expected` was
@@ -349,9 +349,8 @@ echo "ran=$total macros=$macros fail=$fail"
 
 The two checks catch different failures and neither implies the other: a binary that fails
 still prints its test count, so the totals can agree while `fail=1` — and a binary that is
-missing (or stale: a leftover whose source is gone skews the count in the *greener* direction,
-which is why the build clears `build/test/` before re-creating it, #155) trips the count while
-every survivor exits 0.
+missing or stale (cleared before every build, #155) trips the count while every survivor
+exits 0.
 
 ## Project Layout
 
@@ -442,8 +441,8 @@ say so and reopen it — that is what it is for.
 **Decided and already done** (kept because the reasoning gets re-proposed): longitude sign is
 west-positive in `sidereal`, east-positive elsewhere, disambiguated by name, not by type (D2) ·
 `nutation::longitude` and `obliquity` stay verbatim twins with `@note`s pointing at each other,
-so a fix to one cannot silently miss the other (#49) · core-layer `std::expected` was evaluated
-and declined (#97).
+so a fix to one cannot silently miss the other (#49). (`std::expected`'s rejection lives with
+the mechanism table above.)
 
 **Decided and not yet built** (the decision is real, the artifact is not — do not cite either
 as existing): a `wrap_export` helper to collect the C-ABI per-export `try`/`catch` boilerplate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,7 +254,8 @@ is intentional. Keep it. That buys a discipline:
   free functions over them); enum + table lookup is the sum-type idiom (`nutation::Model`
   → `find_model`), not vtables.
 - **Compile-time over runtime**: `constexpr` wherever the language allows (but don't force it —
-  `std::cos` / `std::pow` / `std::remainder` are only constexpr from C++26); constrain
+  `std::cos` / `std::pow` are only constexpr from C++26, and `std::remainder` — C++23 on
+  paper — is still rejected by the pinned toolchains, see the ledger, #82); constrain
   templates with `requires` clauses, never SFINAE.
 - **Names as contracts**: parameter names carry semantics that make misuse visible at the
   call site — e.g. the `jd_ut1` / `jde_tt` suffixes are the UT1/TT guard (issue #41).
@@ -279,7 +280,7 @@ Sort by *what happened to the answer*, not by how the failure feels:
 
 | The answer | Mechanism | Examples |
 |---|---|---|
-| **Cannot be produced correctly** — bad input, outside a declared window, or the solver did not converge | `throw` | `sunrise_sunset::validate`; `algo2` outside [410, 2500]; `jieqi_jde` outside the `chrono::year` range (#154); the residual guard that throws rather than mislabel a day as polar |
+| **Cannot be produced correctly** — bad input, outside a declared window, or the solver did not converge | `throw` | `sunrise_sunset::validate`; `algo2` outside [410, 2500]; `jieqi_jde` outside [1, 32766] (#154); the residual guard that throws rather than mislabel a day as polar |
 | **Was produced, and it is "none"** | `std::optional` | no sunrise on a polar night; no leap month in a common year |
 | **Is beside the point — the library's own bookkeeping is broken** | `assert` | internal invariants only, never an input guard (see gotcha 8) |
 
@@ -327,25 +328,30 @@ project — keep the header.
 
 ### Acceptance: run the binaries, and reconcile the count
 
-**Do not accept on ctest's numbers.** ctest reports on what it was told about, and that
-registration goes stale in both directions: `ctest --test-dir build` finds *zero* tests and
-reports success (the registry lives in `build/test`), and a `--build --test` run after adding a
-source file silently omits it, because the `GLOB` that discovers tests expands at configure time.
+**Do not accept on ctest's numbers.** ctest reports on what it was told about, and its
+registration goes stale: the `GLOB` that discovers tests expands at configure time, so a
+`--build --test` run after adding a source file silently omits it — the suite passes with the
+new tests never compiled in.
 
-Run the binaries directly, then reconcile the total against the `TEST` macros:
+Run the binaries directly, and track two things: did every binary exit 0, and does the total
+reconcile against the `TEST` macros:
 
 ```sh
-total=0; for exe in build/test/*; do [ -x "$exe" ] && [ -f "$exe" ] || continue
-  out=$("$exe" 2>&1) || echo "FAIL $exe"
+total=0; fail=0
+for exe in build/test/*; do [ -x "$exe" ] && [ -f "$exe" ] || continue
+  out=$("$exe" 2>&1) || { echo "FAIL $exe"; fail=1; }
   n=$(echo "$out" | grep -oE "^\[==========\] [0-9]+ test" | grep -oE "[0-9]+" | head -1)
   total=$((total + ${n:-0})); done
-echo "$total"; grep -rhoE '^\s*TEST(_F)?\(' src/test --include=*.cpp | wc -l   # must be equal
+macros=$(grep -rhoE '^\s*TEST(_F)?\(' src/test --include=*.cpp | wc -l)
+echo "ran=$total macros=$macros fail=$fail"
+[ "$fail" -eq 0 ] && [ "$total" -eq "$macros" ]   # this line is the verdict
 ```
 
-**The reconciliation is the load-bearing half.** Running the binaries proves that what ran
-passed; only the count proves that everything that should have run *did*. A stale binary skews
-it in the greener direction — the one nobody goes looking for — which is why the build now
-clears `build/test/` before re-creating it (#155).
+The two checks catch different failures and neither implies the other: a binary that fails
+still prints its test count, so the totals can agree while `fail=1` — and a binary that is
+missing (or stale: a leftover whose source is gone skews the count in the *greener* direction,
+which is why the build clears `build/test/` before re-creating it, #155) trips the count while
+every survivor exits 0.
 
 ## Project Layout
 
@@ -390,10 +396,9 @@ toolbox/        Helper scripts for artifacts, releases, build info
    and test filtering consistently across platforms.
 8. **Assertions:** the default build is `Release` (`automation/build.py`), so `assert` is dead
    code in production. Test targets strip `NDEBUG` (`src/test/CMakeLists.txt`, #89), so asserts
-   ARE live inside test binaries — `build_integrity_test.cpp` guards this. The error contract
-   (target state; #77, #67 and #64 are closed, #70 is the last one open): public input
-   validation must `throw` (fail-fast, independent of build type); `assert` is only
-   for internal invariants, never as an input guard.
+   ARE live inside test binaries — `build_integrity_test.cpp` guards this. Which failure gets
+   `throw` vs `assert` vs `optional` is the mechanism table under "honest errors" — the short
+   of it: an input guard is never an `assert`.
 
 9. **CI toolchains are pinned — every one that can emit a diagnostic.** A tool that updates
    itself turns "the code changed" and "the tool changed" into the same red X, on a day nobody
@@ -411,8 +416,9 @@ toolbox/        Helper scripts for artifacts, releases, build info
 Review after review kept re-litigating the same handful of deliberate bets. Each entry below
 records the **decision**, the **premise** it rests on, the **trigger** that would reopen it, and
 the **date** — a decision without a falsifiable premise is an opinion, and one without a trigger
-is a shackle. Deciding *not* to do something is a decision: it belongs here, not in a comment
-thread. Full argument in #127; these are the conclusions.
+is a shackle. A trigger of "—" is deliberate: it marks the entry as structural (a line we hold),
+not provisional (a bet we revisit). Deciding *not* to do something is a decision: it belongs
+here, not in a comment thread. Full argument in #127; these are the conclusions.
 
 If you are about to propose one of these, check the trigger first. If the trigger has fired,
 say so and reopen it — that is what it is for.
@@ -421,10 +427,10 @@ say so and reopen it — that is what it is for.
 |---|---|---|---|
 | **No strong types for time scales** (`JdUt1` / `JdeTt`); the `jd_ut1` / `jde_tt` suffix convention carries it | Naming has held so far; #41 was the one near-miss and the suffixes came out of it | The Moon's rise/set work lands (#62), or a second #41-class mix-up reaches a test | 2026-08-02 |
 | **No caching or memoisation in the core layer**; `util/cache.hpp` wraps at the calendar layer instead | Core functions are pure evaluations of a formula; caching there hides cost from the caller who chose to pay it | — (structural, not provisional) | 2026-08-02 |
-| **Header-only is the identity, and its compile cost is accepted** | Cost is real but unmeasured | Anyone produces a compile-time measurement (touch-one-header rebuild, TU count). Reopen on that data, not on taste | 2026-08-02 |
-| **The cache never evicts** — no LRU, no `clear` | Two separate things: the *mechanism* has no eviction by design (the hit path copies out of lock, and references into the map survive rehash — only `erase` would invalidate them), and the *key space* is bounded by each caller's declared window (`jieqi` since #154, `algo2` by its year range) | A caller appears whose key space is unbounded — then the bound has to move into the cache | 2026-08-02 |
+| **Header-only is the identity, and its compile cost is accepted** | The "Header-only" style section is the argument; the cost is real but unmeasured | Anyone produces a compile-time measurement (touch-one-header rebuild, TU count). Reopen on that data, not on taste | 2026-08-02 |
+| **The cache never evicts** — no LRU, no `clear` | Two separate things: the *mechanism* has no eviction by design (the invariant and why is `cache.hpp`'s own note), and the *key space* is bounded by each caller's declared window (`jieqi` to [1, 32766] since #154, `algo2` by its year range) | A caller appears whose key space is unbounded — then the bound has to move into the cache | 2026-08-02 |
 | **`algo1` and `algo3` stay near-duplicates** | They are two transcriptions that happen to rhyme; three similar lines beat an abstraction that makes each one harder to check against its source | A third algorithm of the same shape arrives | 2026-08-02 |
-| **`moon_phase`'s year-boundary hole is `wontfix`** | A conjunction exactly at Jan 1 00:00:00 UTC belongs to neither year; the set of such instants has measure zero and no test can pin one | A caller needs total coverage of the boundary | 2026-08-02 |
+| **`moon_phase`'s year-boundary hole is `wontfix`** | A conjunction exactly at Jan 1 00:00:00 UTC has no defined owner (floating-point noise decides); the set of such instants has measure zero and no test can pin one | A caller needs total coverage of the boundary | 2026-08-02 |
 | **No one-off namespace rename**; new code lands in the intended shape and old names stay | A rename touches everything and settles nothing; the drawer names (`sun::geocentric_coord::math`) are ugly, not wrong. #125 tightened the public surface without renaming | — (do it incidentally or not at all) | 2026-08-02 |
 | **No policy/context object for model selection**; the model stays a function parameter (`nutation::Model`) | Two models today, chosen at the call site. A policy object would be an abstraction over one real axis | A third real *ephemeris/nutation/EOP* backend appears — the lunar `Algo` set and the frozen ΔT exhibits do not count | 2026-08-02 |
 | **Coordinate frames stay untagged** (no frame / corrected-state tag in `SphericalCoordinate`) | D2's names-as-contracts pass (west-positive vs east-positive) covered the failure that motivated tagging, at a fraction of the cost | Another mix-up survives naming and reaches a result | 2026-08-05 |
@@ -436,17 +442,21 @@ say so and reopen it — that is what it is for.
 **Decided and already done** (kept because the reasoning gets re-proposed): longitude sign is
 west-positive in `sidereal`, east-positive elsewhere, disambiguated by name, not by type (D2) ·
 `nutation::longitude` and `obliquity` stay verbatim twins with `@note`s pointing at each other,
-so a fix to one cannot silently miss the other (#49) · the C-ABI error channel gets a
-`wrap_export` helper rather than an `expected` middle layer (#97) · the `cpp26-lab` experiment
-branch is agreed in principle but **has not been created**, and nothing has been tried on it yet.
+so a fix to one cannot silently miss the other (#49) · core-layer `std::expected` was evaluated
+and declined (#97).
+
+**Decided and not yet built** (the decision is real, the artifact is not — do not cite either
+as existing): a `wrap_export` helper to collect the C-ABI per-export `try`/`catch` boilerplate
+(#127 entry 20, option B; today every export still hand-writes it) · the `cpp26-lab` experiment
+branch (agreed in principle, never created, nothing tried on it yet).
 
 **Two conventions that look like drift and are not.** Time scales are spelled in the parameter
 name inside C++ (`jd_ut1`, `jde_tt`) and in the *function* name at the C boundary
-(`ut1_to_jde`, `jde_to_ut1`, whose parameter is a bare `jde` documented by `@param`), because a
-C entry point only ever takes one scale while a C++ scope can hold both. Reopen if a C entry
-point ever needs to accept two. And `last_error` is filled in by the three Julian Day exports
-only — a pilot with its boundary written down in `celestial.h`, not an oversight; it spreads
-when an out-of-repo consumer reports getting `valid = false` with no way to learn why.
+(`jde_to_ut1` takes a bare `jde` documented by `@param`; `ut1_to_jde` takes a calendar date),
+because a C entry point only ever speaks one scale while a C++ scope can hold both. Reopen if a
+C entry point ever needs to accept two. And `last_error` is filled in by the three Julian Day
+exports only — a pilot with its boundary written down in `celestial.h`, not an oversight; it
+spreads when an out-of-repo consumer reports getting `valid = false` with no way to learn why.
 
 ## AI do / don't
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,29 @@ is intentional. Keep it. That buys a discipline:
 - **KISS / minimal abstraction**: three similar lines beat a premature abstraction. Generalize
   when a second or third real caller demands it, not in anticipation.
 
+#### Which failure gets which mechanism (#97)
+
+Sort by *what happened to the answer*, not by how the failure feels:
+
+| The answer | Mechanism | Examples |
+|---|---|---|
+| **Cannot be produced correctly** — bad input, outside a declared window, or the solver did not converge | `throw` | `sunrise_sunset::validate`; `algo2` outside [410, 2500]; `jieqi_jde` outside the `chrono::year` range (#154); the residual guard that throws rather than mislabel a day as polar |
+| **Was produced, and it is "none"** | `std::optional` | no sunrise on a polar night; no leap month in a common year |
+| **Is beside the point — the library's own bookkeeping is broken** | `assert` | internal invariants only, never an input guard (see gotcha 8) |
+
+A declared model window *is* the contract's domain, so leaving it is a bad argument like any
+other. `optional` never carries an error — it carries a legitimate "none". `std::expected` was
+evaluated for the core and declined (#97); the C-ABI boundary keeps its own translation
+(`catch` → `valid = false`, see `celestial.h`).
+
+#### Comments sit in one of three slots (#127)
+
+**Contract** (time scale, unit, valid range, sign convention) · **citation** (`@ref` to the
+formula or table number) · **numeric argument** (why this tolerance, this bracket, this step).
+Textbook exposition — "what nutation is" — is not a slot; move it out when passing through.
+What gets cut is the exposition, never the contract: the twin `@note`s on `nutation::longitude`
+and `obliquity` ("fix both or neither") are as load-bearing as the code.
+
 ### File header
 
 Every file opens with the full GPL-3.0 block comment (copy from any src file), verbatim except
@@ -382,6 +405,48 @@ toolbox/        Helper scripts for artifacts, releases, build info
    not here — there is no gate reconciling two copies. Chocolatey's `make` is deliberately outside
    this: it drives the build rather than diagnosing it, so a new version cannot turn `-Werror` red.
    Bump deliberately, never incidentally (#72, #73).
+
+## Design ledger — decisions taken, and what would reopen them
+
+Review after review kept re-litigating the same handful of deliberate bets. Each entry below
+records the **decision**, the **premise** it rests on, the **trigger** that would reopen it, and
+the **date** — a decision without a falsifiable premise is an opinion, and one without a trigger
+is a shackle. Deciding *not* to do something is a decision: it belongs here, not in a comment
+thread. Full argument in #127; these are the conclusions.
+
+If you are about to propose one of these, check the trigger first. If the trigger has fired,
+say so and reopen it — that is what it is for.
+
+| Decision | Premise | Trigger to reopen | Date |
+|---|---|---|---|
+| **No strong types for time scales** (`JdUt1` / `JdeTt`); the `jd_ut1` / `jde_tt` suffix convention carries it | Naming has held so far; #41 was the one near-miss and the suffixes came out of it | The Moon's rise/set work lands (#62), or a second #41-class mix-up reaches a test | 2026-08-02 |
+| **No caching or memoisation in the core layer**; `util/cache.hpp` wraps at the calendar layer instead | Core functions are pure evaluations of a formula; caching there hides cost from the caller who chose to pay it | — (structural, not provisional) | 2026-08-02 |
+| **Header-only is the identity, and its compile cost is accepted** | Cost is real but unmeasured | Anyone produces a compile-time measurement (touch-one-header rebuild, TU count). Reopen on that data, not on taste | 2026-08-02 |
+| **The cache never evicts** — no LRU, no `clear` | Two separate things: the *mechanism* has no eviction by design (the hit path copies out of lock, and references into the map survive rehash — only `erase` would invalidate them), and the *key space* is bounded by each caller's declared window (`jieqi` since #154, `algo2` by its year range) | A caller appears whose key space is unbounded — then the bound has to move into the cache | 2026-08-02 |
+| **`algo1` and `algo3` stay near-duplicates** | They are two transcriptions that happen to rhyme; three similar lines beat an abstraction that makes each one harder to check against its source | A third algorithm of the same shape arrives | 2026-08-02 |
+| **`moon_phase`'s year-boundary hole is `wontfix`** | A conjunction exactly at Jan 1 00:00:00 UTC belongs to neither year; the set of such instants has measure zero and no test can pin one | A caller needs total coverage of the boundary | 2026-08-02 |
+| **No one-off namespace rename**; new code lands in the intended shape and old names stay | A rename touches everything and settles nothing; the drawer names (`sun::geocentric_coord::math`) are ugly, not wrong. #125 tightened the public surface without renaming | — (do it incidentally or not at all) | 2026-08-02 |
+| **No policy/context object for model selection**; the model stays a function parameter (`nutation::Model`) | Two models today, chosen at the call site. A policy object would be an abstraction over one real axis | A third real *ephemeris/nutation/EOP* backend appears — the lunar `Algo` set and the frozen ΔT exhibits do not count | 2026-08-02 |
+| **Coordinate frames stay untagged** (no frame / corrected-state tag in `SphericalCoordinate`) | D2's names-as-contracts pass (west-positive vs east-positive) covered the failure that motivated tagging, at a fraction of the cost | Another mix-up survives naming and reaches a result | 2026-08-05 |
+| **Transcription runs on a single track**; equivalence is proved once during a migration, not maintained as a permanent second implementation | #81's ELP merge did exactly this: a verbatim copy compared bit-for-bit in the same run, then deleted. A permanent audit track is a second thing to keep correct | A transcription lands that cannot be diffed against its predecessor in one run | 2026-08-06 |
+| **Error budgets are not part of the API contract** | Accuracy notes exist where they were measured (`obliquity`'s ±2000-year figure, the sunrise brackets), but there is no per-epoch, per-model budget and no one has asked for one. A fitted residual must never be dressed up as a 1σ | A caller needs a declared accuracy to decide something | 2026-08-06 |
+| **External ephemerides are oracles, never dependencies** | ytliu0, Horizons and USNO appear only under `src/test/` and in `@ref` comments; the build links none of them. Being able to check ourselves against an independent source depends on not being built on it | — (this one is a line, not a bet) | 2026-08-02 |
+| **`normalize_deg` / `normalize_rad` keep calling `std::remainder`, and stay `constexpr`** | Standards-compliant is not the same as usable: P0533 made `std::remainder` constexpr in C++23, yet clang 18.1.8 and MSVC's UCRT both reject `constexpr double c = normalize_deg(361.0)` today. Four constexpr entry points, two direct call sites, all IF-NDR — recorded rather than papered over (#82) | A pinned toolchain bump. The probe is one line: the `constexpr` initialisation above either compiles or does not | 2026-08-05 |
+
+**Decided and already done** (kept because the reasoning gets re-proposed): longitude sign is
+west-positive in `sidereal`, east-positive elsewhere, disambiguated by name, not by type (D2) ·
+`nutation::longitude` and `obliquity` stay verbatim twins with `@note`s pointing at each other,
+so a fix to one cannot silently miss the other (#49) · the C-ABI error channel gets a
+`wrap_export` helper rather than an `expected` middle layer (#97) · the `cpp26-lab` experiment
+branch is agreed in principle but **has not been created**, and nothing has been tried on it yet.
+
+**Two conventions that look like drift and are not.** Time scales are spelled in the parameter
+name inside C++ (`jd_ut1`, `jde_tt`) and in the *function* name at the C boundary
+(`ut1_to_jde`, `jde_to_ut1`, whose parameter is a bare `jde` documented by `@param`), because a
+C entry point only ever takes one scale while a C++ scope can hold both. Reopen if a C entry
+point ever needs to accept two. And `last_error` is filled in by the three Julian Day exports
+only — a pilot with its boundary written down in `celestial.h`, not an oversight; it spreads
+when an out-of-repo consumer reports getting `valid = false` with no way to learn why.
 
 ## AI do / don't
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,7 +282,7 @@ Sort by *what happened to the answer*, not by how the failure feels:
 |---|---|---|
 | **Cannot be produced correctly** — bad input, outside a declared window, or the solver did not converge | `throw` | `sunrise_sunset::validate`; `algo2` outside [410, 2500]; `jieqi_jde` outside [1, 32766] (#154); the residual guard that throws rather than mislabel a day as polar |
 | **Was produced, and it is "none"** | `std::optional` | no sunrise on a polar night; no leap month in a common year |
-| **Is beside the point — the library's own bookkeeping is broken** | `assert` | internal invariants only (NDEBUG mechanics: gotcha 8) |
+| **Is beside the point — the library's own bookkeeping is broken** | `assert` | internal invariants only |
 
 A declared model window *is* the contract's domain, so leaving it is a bad argument like any
 other. `optional` never carries an error — it carries a legitimate "none". `std::expected` was

--- a/automation/bench.py
+++ b/automation/bench.py
@@ -59,7 +59,8 @@ def find_benchmarks() -> List[Path]:
   if not BENCH_OUTPUT_DIR.is_dir():
     return []
   return sorted(p for p in BENCH_OUTPUT_DIR.iterdir()
-                if p.is_file() and p.suffix.lower() in ("", ".exe") and os.access(p, os.X_OK))
+                if p.is_file() and p.suffix.lower() in ("", ".exe")
+                and p.name != "Makefile" and os.access(p, os.X_OK))  # See gtest.find_test_binaries on `Makefile`.
 
 
 def run_benchmarks() -> int:

--- a/automation/build.py
+++ b/automation/build.py
@@ -81,8 +81,6 @@ def build_project(cpu_cores: int = 8) -> int:
   assert BUILD_DIR.is_dir(), "Build directory is not a directory"
 
   # Clear the test binaries first, so that the build is what puts every one of them back (#155).
-  # Acceptance runs `build/test/*` and reconciles the count against the `TEST` macros, and a
-  # binary whose source is gone answers that reconciliation with a stale pass.
   clear_test_binaries()
 
   yellow_print("# Building the C++ projects...")

--- a/automation/build.py
+++ b/automation/build.py
@@ -14,6 +14,7 @@ import json
 import shutil
 
 from . import paths
+from .gtest import clear_test_binaries
 from .utils import (
   run_cmd, yellow_print, red_print, green_print, ProcReturn
 )
@@ -78,6 +79,11 @@ def build_project(cpu_cores: int = 8) -> int:
 
   assert BUILD_DIR.exists(), "Build directory not found"
   assert BUILD_DIR.is_dir(), "Build directory is not a directory"
+
+  # Clear the test binaries first, so that the build is what puts every one of them back (#155).
+  # Acceptance runs `build/test/*` and reconciles the count against the `TEST` macros, and a
+  # binary whose source is gone answers that reconciliation with a stale pass.
+  clear_test_binaries()
 
   yellow_print("# Building the C++ projects...")
   ret: ProcReturn = run_cmd(["cmake", "--build", ".", "--parallel", str(cpu_cores)], 

--- a/automation/gtest.py
+++ b/automation/gtest.py
@@ -33,7 +33,8 @@ def find_test_binaries() -> List[Path]:
   (`CTestTestfile.cmake`, `<target>[1]_tests.cmake`) falls out of that check; `Makefile` is
   suffixless, so it is excluded by name -- on Unix the executable bit happens to exclude it,
   but on Windows (unreliable `X_OK`, and the build does use Unix Makefiles there) nothing else
-  would, and unlinking it breaks the next build.
+  would. Deleting build-system files is simply not this step's job; whether the next build
+  would shrug it off is beside the point.
   """
   if not TEST_DIR.is_dir():
     return []

--- a/automation/gtest.py
+++ b/automation/gtest.py
@@ -33,8 +33,7 @@ def find_test_binaries() -> List[Path]:
   (`CTestTestfile.cmake`, `<target>[1]_tests.cmake`) falls out of that check; `Makefile` is
   suffixless, so it is excluded by name -- on Unix the executable bit happens to exclude it,
   but on Windows (unreliable `X_OK`, and the build does use Unix Makefiles there) nothing else
-  would. Deleting build-system files is simply not this step's job; whether the next build
-  would shrug it off is beside the point.
+  would. Deleting build-system files is not this step's job.
   """
   if not TEST_DIR.is_dir():
     return []

--- a/automation/gtest.py
+++ b/automation/gtest.py
@@ -29,14 +29,17 @@ def find_test_binaries() -> List[Path]:
   """Every test binary under the test output directory, sorted by name.
 
   Same discovery as `bench.find_benchmarks`: the suffix is what carries the check on Windows,
-  where `os.access(X_OK)` passes for nearly any readable file. It also keeps CMake's own
-  scaffolding out -- `CTestTestfile.cmake`, `<target>[1]_tests.cmake` and `Makefile` all carry
-  a suffix, so none of them can be mistaken for a binary and unlinked.
+  where `os.access(X_OK)` passes for nearly any readable file. CMake's suffixed scaffolding
+  (`CTestTestfile.cmake`, `<target>[1]_tests.cmake`) falls out of that check; `Makefile` is
+  suffixless, so it is excluded by name -- on Unix the executable bit happens to exclude it,
+  but on Windows (unreliable `X_OK`, and the build does use Unix Makefiles there) nothing else
+  would, and unlinking it breaks the next build.
   """
   if not TEST_DIR.is_dir():
     return []
   return sorted(p for p in TEST_DIR.iterdir()
-                if p.is_file() and p.suffix.lower() in ("", ".exe") and os.access(p, os.X_OK))
+                if p.is_file() and p.suffix.lower() in ("", ".exe")
+                and p.name != "Makefile" and os.access(p, os.X_OK))
 
 
 def clear_test_binaries() -> None:

--- a/automation/gtest.py
+++ b/automation/gtest.py
@@ -47,9 +47,7 @@ def clear_test_binaries() -> None:
 
   Tests are run by scanning `build/test/`, so a binary left behind by a test file that has since
   been renamed or deleted keeps being run forever -- and keeps passing, from a source file that
-  no longer exists. It skews acceptance in the *greener* direction, which is the one nobody goes
-  looking for: the util-batch acceptance once read 212 ran against 211 `TEST` macros, the extra
-  one being a `common_test` whose source had been deleted two days earlier.
+  no longer exists. It skews acceptance in the *greener* direction, the one nobody goes looking for.
 
   `--bench` has had this step since #133 (`build_benchmarks` unlinks before building). This is
   the same step on the test side, which never got one.

--- a/automation/gtest.py
+++ b/automation/gtest.py
@@ -9,8 +9,10 @@
 # This software is distributed without any warranty.
 # See <https://www.gnu.org/licenses/> for more details.
 
+import os
 import re
 
+from pathlib import Path
 from typing import List, Dict, Optional
 
 from . import paths
@@ -21,6 +23,39 @@ from .utils import (
 
 BUILD_DIR = paths.build_dir()
 TEST_DIR = paths.cpp_test_dir()
+
+
+def find_test_binaries() -> List[Path]:
+  """Every test binary under the test output directory, sorted by name.
+
+  Same discovery as `bench.find_benchmarks`: the suffix is what carries the check on Windows,
+  where `os.access(X_OK)` passes for nearly any readable file. It also keeps CMake's own
+  scaffolding out -- `CTestTestfile.cmake`, `<target>[1]_tests.cmake` and `Makefile` all carry
+  a suffix, so none of them can be mistaken for a binary and unlinked.
+  """
+  if not TEST_DIR.is_dir():
+    return []
+  return sorted(p for p in TEST_DIR.iterdir()
+                if p.is_file() and p.suffix.lower() in ("", ".exe") and os.access(p, os.X_OK))
+
+
+def clear_test_binaries() -> None:
+  """Unlink every test binary, for a build to re-create right after (#155).
+
+  Tests are run by scanning `build/test/`, so a binary left behind by a test file that has since
+  been renamed or deleted keeps being run forever -- and keeps passing, from a source file that
+  no longer exists. It skews acceptance in the *greener* direction, which is the one nobody goes
+  looking for: the util-batch acceptance once read 212 ran against 211 `TEST` macros, the extra
+  one being a `common_test` whose source had been deleted two days earlier.
+
+  `--bench` has had this step since #133 (`build_benchmarks` unlinks before building). This is
+  the same step on the test side, which never got one.
+  """
+  stale = find_test_binaries()
+  for binary in stale:
+    binary.unlink()
+  if stale:
+    yellow_print(f"# Cleared {len(stale)} stale test binary/binaries before building")
 
 
 def list_gtests() -> Dict[str, str]:

--- a/src/astro/delta_t.hpp
+++ b/src/astro/delta_t.hpp
@@ -196,6 +196,7 @@ namespace algo2 {
  * @example `compute(1984.0)` returns the delta T for the first moment of year 1984.
  * 
  * @ref https://eclipse.gsfc.nasa.gov/SEcat5/deltatpoly.html
+ * @note `noexcept`: a non-finite year propagates to a non-finite ΔT (#86).
  */
 [[nodiscard]] constexpr auto compute(const double year) noexcept -> double {
   if (year < -500) {

--- a/src/astro/delta_t.hpp
+++ b/src/astro/delta_t.hpp
@@ -25,7 +25,6 @@
 
 #include <array>
 #include <cmath>
-#include <limits>
 #include <format>
 #include <ranges>
 #include <cassert>
@@ -132,9 +131,7 @@ find_coefficients(const int32_t year) -> std::optional<
  *       with the hope of getting more accurate results.
  */
 [[nodiscard]] constexpr auto compute(const double year) -> double {
-  // Every non-finite year fails a bound here (NaN fails both, each infinity fails one);
-  // the plain `year < -4000` form let them all through (#86).
-  if (not (year >= -4000 and year <= std::numeric_limits<double>::max())) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#86).
+  if (not std::isfinite(year) or year < -4000) {
     throw std::out_of_range {
       std::vformat("Year {} is not supported by algorithm 1.", std::make_format_args(year))
     };
@@ -313,7 +310,7 @@ namespace algo3 {
  * @ref https://eclipsewise.com/help/deltatpoly2014.html
  */
 [[nodiscard]] constexpr auto compute(const double year) -> double {
-  if (not (year < 3000 and year >= std::numeric_limits<double>::lowest())) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#86).
+  if (not std::isfinite(year) or year >= 3000) {
     throw std::out_of_range {
       std::vformat("Year {} is not supported by algorithm 3.", std::make_format_args(year))
     };
@@ -370,7 +367,7 @@ namespace algo4 {
  * @note For 2024.0 <= year < 2035.0, poly model trained on USNO ΔT predictions (deltat.preds) is used.
  */
 [[nodiscard]] constexpr auto compute(const double year) -> double {
-  if (not (year < 2035 and year >= std::numeric_limits<double>::lowest())) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#86).
+  if (not std::isfinite(year) or year >= 2035) {
     throw std::out_of_range {
       std::format("The year {} is out of range for algorithm 4.", year)
     };

--- a/src/astro/delta_t.hpp
+++ b/src/astro/delta_t.hpp
@@ -122,7 +122,7 @@ find_coefficients(const int32_t year) -> std::optional<
  * @param year The year, of double type.
  * @return The delta T.
  *
- * @throw std::out_of_range if the year is < -4000.
+ * @throw std::out_of_range if the year is < -4000 or not finite.
  * @example `compute(2005.99999999....)` returns the delta T for the last moment of year 2005.
  * @example `compute(1984.0)` returns the delta T for the first moment of year 1984.
  * 
@@ -131,7 +131,9 @@ find_coefficients(const int32_t year) -> std::optional<
  *       with the hope of getting more accurate results.
  */
 [[nodiscard]] constexpr auto compute(const double year) -> double {
-  if (year < -4000) {
+  // Negated form so NaN fails too (#86): `year < -4000` is false for NaN, which then reaches
+  // the float→int cast below — the one true UB site in this family (UBSan-reproducible).
+  if (not (year >= -4000)) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#86).
     throw std::out_of_range {
       std::vformat("Year {} is not supported by algorithm 1.", std::make_format_args(year))
     };
@@ -297,14 +299,15 @@ namespace algo3 {
  * @param year The year, of double type.
  * @return The delta T.
  * 
- * @throw std::out_of_range if the year is >= 3000.
+ * @throw std::out_of_range if the year is >= 3000 or not finite.
  * @example `compute(2005.99999999....)` returns the delta T for the last moment of year 2005.
  * @example `compute(1984.0)` returns the delta T for the first moment of year 1984.
  * 
  * @ref https://eclipsewise.com/help/deltatpoly2014.html
  */
 [[nodiscard]] constexpr auto compute(const double year) -> double {
-  if (year >= 3000) {
+  // Negated forms below so NaN fails a bound instead of flowing through the polynomial (#86).
+  if (not (year < 3000)) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#86).
     throw std::out_of_range {
       std::vformat("Year {} is not supported by algorithm 3.", std::make_format_args(year))
     };
@@ -348,7 +351,7 @@ namespace algo4 {
  * @param year The year, of double type.
  * @return The delta T.
  *
- * @throw std::out_of_range if the year is >= 2035.
+ * @throw std::out_of_range if the year is >= 2035 or not finite.
  * @example `compute(2005.99999999....)` returns the delta T for the last moment of year 2005.
  * @example `compute(1984.0)` returns the delta T for the first moment of year 1984.
  * 
@@ -361,7 +364,7 @@ namespace algo4 {
  * @note For 2024.0 <= year < 2035.0, poly model trained on USNO ΔT predictions (deltat.preds) is used.
  */
 [[nodiscard]] constexpr auto compute(const double year) -> double {
-  if (year >= 2035) {
+  if (not (year < 2035)) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#86).
     throw std::out_of_range {
       std::format("The year {} is out of range for algorithm 4.", year)
     };
@@ -421,6 +424,9 @@ inline constexpr double LAST_OBSERVATION_YEAR = 2026.4135844748857;
  * @note For year < 2005.0, algo2 is used instead (same delegation as algo4).
  * @note There is no upper bound: beyond the last observation, the anchored integrated-lod
  *       curve extrapolates smoothly for all future years.
+ * @note `noexcept` (as is algo2), so a non-finite year propagates to a non-finite ΔT instead
+ *       of throwing — IEEE propagation, not UB. The C ABI rejects non-finite years before
+ *       calling; direct C++ callers get NaN back for NaN in (#86).
  */
 [[nodiscard]] constexpr auto compute(const double year) noexcept -> double {
   if (year < 2005) {

--- a/src/astro/delta_t.hpp
+++ b/src/astro/delta_t.hpp
@@ -139,8 +139,7 @@ find_coefficients(const int32_t year) -> std::optional<
 
   // The cast lives inside the table's era on purpose: the table ends at 2005, so for any later
   // year the closed-form segments below apply and no integer year is ever formed — which keeps
-  // the float→int cast inside int32's range by construction (#86; it used to run for every
-  // year, where a large-enough finite one was as undefined as NaN).
+  // the float→int cast inside int32's range by construction (#86).
   if (year < 2005.0) {
     // #64: `static_cast` truncates toward zero — negative fractional years picked the wrong segment.
     const auto coefficients = find_coefficients(static_cast<int32_t>(std::floor(year)));

--- a/src/astro/delta_t.hpp
+++ b/src/astro/delta_t.hpp
@@ -25,6 +25,7 @@
 
 #include <array>
 #include <cmath>
+#include <limits>
 #include <format>
 #include <ranges>
 #include <cassert>
@@ -131,25 +132,31 @@ find_coefficients(const int32_t year) -> std::optional<
  *       with the hope of getting more accurate results.
  */
 [[nodiscard]] constexpr auto compute(const double year) -> double {
-  // Negated form so NaN fails too (#86): `year < -4000` is false for NaN, which then reaches
-  // the float→int cast below — the one true UB site in this family (UBSan-reproducible).
-  if (not (year >= -4000)) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#86).
+  // Every non-finite year fails a bound here (NaN fails both, each infinity fails one);
+  // the plain `year < -4000` form let them all through (#86).
+  if (not (year >= -4000 and year <= std::numeric_limits<double>::max())) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#86).
     throw std::out_of_range {
       std::vformat("Year {} is not supported by algorithm 1.", std::make_format_args(year))
     };
   }
 
-  // #64: `static_cast` truncates toward zero — negative fractional years picked the wrong segment.
-  const auto coefficients = find_coefficients(static_cast<int32_t>(std::floor(year)));
-  if (coefficients) {
-    const auto& [start, end] = *coefficients;
-    assert(year >= start.year and year < end.year);
+  // The cast lives inside the table's era on purpose: the table ends at 2005, so for any later
+  // year the closed-form segments below apply and no integer year is ever formed — which keeps
+  // the float→int cast inside int32's range by construction (#86; it used to run for every
+  // year, where a large-enough finite one was as undefined as NaN).
+  if (year < 2005.0) {
+    // #64: `static_cast` truncates toward zero — negative fractional years picked the wrong segment.
+    const auto coefficients = find_coefficients(static_cast<int32_t>(std::floor(year)));
+    if (coefficients) {
+      const auto& [start, end] = *coefficients;
+      assert(year >= start.year and year < end.year);
 
-    const double t1 = (year - start.year) / (end.year - start.year) * 10.0;
-    const double t2 = t1 * t1;
-    const double t3 = t2 * t1;
+      const double t1 = (year - start.year) / (end.year - start.year) * 10.0;
+      const double t2 = t1 * t1;
+      const double t3 = t2 * t1;
 
-    return start.a + start.b * t1 + start.c * t2 + start.d * t3;
+      return start.a + start.b * t1 + start.c * t2 + start.d * t3;
+    }
   }
 
   assert(year >= 2005);
@@ -306,8 +313,7 @@ namespace algo3 {
  * @ref https://eclipsewise.com/help/deltatpoly2014.html
  */
 [[nodiscard]] constexpr auto compute(const double year) -> double {
-  // Negated forms below so NaN fails a bound instead of flowing through the polynomial (#86).
-  if (not (year < 3000)) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#86).
+  if (not (year < 3000 and year >= std::numeric_limits<double>::lowest())) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#86).
     throw std::out_of_range {
       std::vformat("Year {} is not supported by algorithm 3.", std::make_format_args(year))
     };
@@ -364,7 +370,7 @@ namespace algo4 {
  * @note For 2024.0 <= year < 2035.0, poly model trained on USNO ΔT predictions (deltat.preds) is used.
  */
 [[nodiscard]] constexpr auto compute(const double year) -> double {
-  if (not (year < 2035)) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#86).
+  if (not (year < 2035 and year >= std::numeric_limits<double>::lowest())) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#86).
     throw std::out_of_range {
       std::format("The year {} is out of range for algorithm 4.", year)
     };

--- a/src/astro/julian_day.hpp
+++ b/src/astro/julian_day.hpp
@@ -161,7 +161,10 @@ inline constexpr double J2000 = 2451545.0;
   // JD 1867522.5 (#77: the old cutoff 1867524.457118 sat ~2 days high and wrongly rejected
   // the first two days of year 401).
   if (jd < 1867522.5) {
-    throw std::runtime_error("The estimated gregorian year is < 401.");
+    throw std::runtime_error {
+      std::format("The julian day number {} is below JD 1867522.5 (401-01-01), "
+                  "where the estimated gregorian year drops under 401.", jd)
+    };
   }
 
   // #67: bound the domain at the last `year_month_day`-representable day — JD 13689325.5 is

--- a/src/astro/moon.hpp
+++ b/src/astro/moon.hpp
@@ -24,6 +24,8 @@
 #pragma once
 
 #include <cmath>
+#include <format>
+#include <stdexcept>
 
 #include "earth.hpp"
 #include "julian_day.hpp"
@@ -111,9 +113,25 @@ inline constexpr double EARTH_EQUATORIAL_RADIUS_KM = 6378.14;
  * @brief Calculate the equatorial horizontal parallax of the Moon.
  * @param distance The geocentric distance of the Moon.
  * @return The equatorial horizontal parallax of the Moon.
+ * @throw std::invalid_argument if `distance` is not finite, or is not greater than Earth's
+ *        equatorial radius.
+ * @note The guard is the contract, not a reachability claim: the real Moon never comes near,
+ *       but this is a public function over a `Distance<KM>` that is open to any value, and
+ *       `asin` of an argument above 1 returns a silent NaN rather than failing (#86).
  */
 [[nodiscard]] inline auto equatorial_horizontal_parallax(const toolbox::DistanceKm& distance) -> toolbox::AngleRad {
-  const auto ppi_rad = std::asin(EARTH_EQUATORIAL_RADIUS_KM / distance.km());
+  const double km = distance.km();
+
+  // Written as `not (km > r)` so that a NaN distance fails the check too — `km <= r` is always
+  // false for NaN and would let it through to `asin` (#67's lesson, same shape).
+  if (not (km > EARTH_EQUATORIAL_RADIUS_KM)) {
+    throw std::invalid_argument {
+      std::format("Argument `distance` must exceed Earth's equatorial radius {} km, got {}",
+                  EARTH_EQUATORIAL_RADIUS_KM, km)
+    };
+  }
+
+  const auto ppi_rad = std::asin(EARTH_EQUATORIAL_RADIUS_KM / km);
   return toolbox::AngleRad { ppi_rad };
 }
 

--- a/src/astro/moon.hpp
+++ b/src/astro/moon.hpp
@@ -123,8 +123,10 @@ inline constexpr double EARTH_EQUATORIAL_RADIUS_KM = 6378.14;
   const double km = distance.km();
 
   // Written as `not (km > r)` so that a NaN distance fails the check too — `km <= r` is always
-  // false for NaN and would let it through to `asin` (#67's lesson, same shape).
-  if (not (km > EARTH_EQUATORIAL_RADIUS_KM)) {
+  // false for NaN and would let it through to `asin` (#67's lesson, same shape). NaN is not the
+  // whole job: `inf > r` is true, and `asin(r / inf)` is a well-formed 0 rad — a plausible-looking
+  // answer for a nonsense input — so finiteness needs its own check.
+  if (not std::isfinite(km) or not (km > EARTH_EQUATORIAL_RADIUS_KM)) {
     throw std::invalid_argument {
       std::format("Argument `distance` must exceed Earth's equatorial radius {} km, got {}",
                   EARTH_EQUATORIAL_RADIUS_KM, km)

--- a/src/astro/moon_phase.hpp
+++ b/src/astro/moon_phase.hpp
@@ -219,6 +219,9 @@ public:
  * @param year The Gregorian year.
  * @return The vector of the conjunction moments, in JDE (Julian Ephemeris Day).
  * @note The year runs from Jan 1 to Jan 1 in UTC; before 1972 the bounds degrade to UT1.
+ * @note A conjunction falling exactly on Jan 1 00:00:00 UTC is claimed by neither year:
+ *       the range starts closed and ends open, so it misses both. Left as is on purpose
+ *       (#127) — the set of such instants has measure zero, and no test can pin one.
  * @details The Sun's position is calculated using VSOP87D,
  * @details The Moon's position is calculated using truncated ELP2000-82B.
  * @see VSOP87D, ELP2000-82B, and Astronomical Algorithms, Jean Meeus, 1998.

--- a/src/astro/moon_phase.hpp
+++ b/src/astro/moon_phase.hpp
@@ -219,9 +219,10 @@ public:
  * @param year The Gregorian year.
  * @return The vector of the conjunction moments, in JDE (Julian Ephemeris Day).
  * @note The year runs from Jan 1 to Jan 1 in UTC; before 1972 the bounds degrade to UT1.
- * @note A conjunction falling exactly on Jan 1 00:00:00 UTC is claimed by neither year:
- *       the range starts closed and ends open, so it misses both. Left as is on purpose
- *       (#127) — the set of such instants has measure zero, and no test can pin one.
+ * @note A conjunction falling exactly on Jan 1 00:00:00 UTC has no defined owner: whether the
+ *       generator seeded at that instant returns it or skips to the next moon turns on
+ *       floating-point noise in the longitude difference. Left as is on purpose (#127) —
+ *       the set of such instants has measure zero, and no test can pin one.
  * @details The Sun's position is calculated using VSOP87D,
  * @details The Moon's position is calculated using truncated ELP2000-82B.
  * @see VSOP87D, ELP2000-82B, and Astronomical Algorithms, Jean Meeus, 1998.

--- a/src/astro/solar_time.hpp
+++ b/src/astro/solar_time.hpp
@@ -115,7 +115,7 @@ namespace detail {
   const double lon = longitude.deg();
   if (not std::isfinite(lon) or lon < -180.0 or lon > 180.0) {
     throw std::invalid_argument {
-      std::format("Argument `longitude` out of range [-180, 180], whose value is {}", lon)
+      std::format("Argument `longitude` out of range [-180, 180], got {}", lon)
     };
   }
 

--- a/src/astro/sunrise_sunset.hpp
+++ b/src/astro/sunrise_sunset.hpp
@@ -178,13 +178,13 @@ inline void validate(const GeoLocation& location) {
 
   if (not std::isfinite(lat) or lat < -90.0 or lat > 90.0) {
     throw std::invalid_argument {
-      std::format("Argument `location.latitude` out of range [-90, 90], whose value is {}", lat)
+      std::format("Argument `location.latitude` out of range [-90, 90], got {}", lat)
     };
   }
 
   if (not std::isfinite(lon) or lon < -180.0 or lon > 180.0) {
     throw std::invalid_argument {
-      std::format("Argument `location.longitude` out of range [-180, 180], whose value is {}", lon)
+      std::format("Argument `location.longitude` out of range [-180, 180], got {}", lon)
     };
   }
 }
@@ -287,12 +287,12 @@ inline void validate_rise_set_inputs(
 
   if (not std::isfinite(transit)) {
     throw std::invalid_argument {
-      std::format("Argument `transit` is not finite, whose value is {}", transit)
+      std::format("Argument `transit` is not finite, got {}", transit)
     };
   }
   if (not std::isfinite(h0.deg()) or h0.deg() < -90.0 or h0.deg() > 90.0) {
     throw std::invalid_argument {
-      std::format("Argument `h0` out of range [-90, 90], whose value is {}", h0.deg())
+      std::format("Argument `h0` out of range [-90, 90], got {}", h0.deg())
     };
   }
 }
@@ -368,7 +368,7 @@ requires std::invocable<const Func&, double>
   const auto reject_outside_pm90 = [](const char* name, const double deg) {
     if (not std::isfinite(deg) or deg < -90.0 or deg > 90.0) {
       throw std::invalid_argument {
-        std::format("Argument `{}` out of range [-90, 90], whose value is {}", name, deg)
+        std::format("Argument `{}` out of range [-90, 90], got {}", name, deg)
       };
     }
   };

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -291,17 +291,23 @@ namespace literals {
 /** @enum The unit of distance, either AU or KM. */
 enum class DistanceUnit : uint8_t { AU, KM };
 
-/** @brief The scaling factor from AU to KM. */
-inline constexpr double au_km_scale = 149597870.691; 
+/**
+ * @brief The scaling factor from AU to KM.
+ * @ref IAU 2012 Resolution B2, which redefines the astronomical unit as exactly this many
+ *      metres -- a defined constant, not a measured one, so it takes no uncertainty and will
+ *      not be revised. The previous value here (149597870.691) was the IAU 1976 / DE405
+ *      measured figure, 9 mm/AU below the definition.
+ */
+inline constexpr double AU_KM_SCALE = 149597870.700;
 
 /** @brief Convert from AU to KM. */
 [[nodiscard]] constexpr auto au_to_km(const double au) -> double { 
-  return au * au_km_scale; 
+  return au * AU_KM_SCALE; 
 }
 
 /** @brief Convert from KM to AU. */
 [[nodiscard]] constexpr auto km_to_au(const double km) -> double { 
-  return km / au_km_scale; 
+  return km / AU_KM_SCALE; 
 }
 
 

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -47,7 +47,7 @@ namespace astro::toolbox {
 [[nodiscard]] constexpr auto normalize_deg(const double deg) -> double {
   if (not std::isfinite(deg)) [[unlikely]] {
     throw std::invalid_argument {
-      std::format("Argument `deg` is not finite, whose value is {}", deg)
+      std::format("Argument `deg` is not finite, got {}", deg)
     };
   }
 
@@ -67,7 +67,7 @@ namespace astro::toolbox {
 [[nodiscard]] constexpr auto normalize_rad(const double rad) -> double {
   if (not std::isfinite(rad)) [[unlikely]] {
     throw std::invalid_argument {
-      std::format("Argument `rad` is not finite, whose value is {}", rad)
+      std::format("Argument `rad` is not finite, got {}", rad)
     };
   }
 

--- a/src/astro/toolbox.hpp
+++ b/src/astro/toolbox.hpp
@@ -293,10 +293,8 @@ enum class DistanceUnit : uint8_t { AU, KM };
 
 /**
  * @brief The scaling factor from AU to KM.
- * @ref IAU 2012 Resolution B2, which redefines the astronomical unit as exactly this many
- *      metres -- a defined constant, not a measured one, so it takes no uncertainty and will
- *      not be revised. The previous value here (149597870.691) was the IAU 1976 / DE405
- *      measured figure, 9 mm/AU below the definition.
+ * @ref IAU 2012 Resolution B2: the astronomical unit is defined as exactly 149'597'870'700 m
+ *      -- a defined constant, not a measured one, so it carries no uncertainty.
  */
 inline constexpr double AU_KM_SCALE = 149597870.700;
 

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -136,7 +136,7 @@ concept Fractionable = requires (T t) {
     throw std::invalid_argument {
       std::vformat(
         "Argument `fraction` does not fit an int64 nanosecond count (|fraction| < {}), "
-        "whose value is {}",
+        "got {}",
         std::make_format_args(MAX_DAYS, fraction)
       )
     };
@@ -165,7 +165,7 @@ concept Fractionable = requires (T t) {
   if (not (fraction >= 0.0 and fraction < 1.0)) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#67).
     throw std::invalid_argument {
       std::vformat(
-        "Argument `fraction` out of range [0.0, 1.0), whose value is {}",
+        "Argument `fraction` out of range [0.0, 1.0), got {}",
         std::make_format_args(fraction)
       )
     };
@@ -248,7 +248,7 @@ struct Datetime {
     if (not ymd.ok()) {
       throw std::invalid_argument { 
         std::vformat(
-          "Argument gregorian date `ymd` is invalid, whose value is `{}`", 
+          "Argument gregorian date `ymd` is invalid, got `{}`", 
           std::make_format_args(this->ymd)
         ) 
       };

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -200,9 +200,10 @@ struct Datetime {
       const double ns = static_cast<double>(
         time_of_day.to_duration().count()
       );
-      throw std::runtime_error {
+      throw std::invalid_argument {
         std::vformat(
-          "Sanity check failed, `ymd` is {} and `time_of_day` is {}ns",
+          "Arguments do not form a valid datetime: `ymd` is {} and `time_of_day` is {}ns "
+          "(a time of day must be within [0, 24h))",
           std::make_format_args(ymd, ns)
         )
       };
@@ -223,9 +224,10 @@ struct Datetime {
       const double ns = static_cast<double>(
         this->time_of_day.to_duration().count()
       );
-      throw std::runtime_error {
+      throw std::invalid_argument {
         std::vformat(
-          "Sanity check failed, `ymd` is {} and `time_of_day` is {}ns",
+          "Arguments do not form a valid datetime: `ymd` is {} and `time_of_day` is {}ns "
+          "(a time of day must be within [0, 24h))",
           std::make_format_args(this->ymd, ns)
         )
       };
@@ -256,9 +258,10 @@ struct Datetime {
       const double ns = static_cast<double>(
         time_of_day.to_duration().count()
       );
-      throw std::runtime_error {
+      throw std::invalid_argument {
         std::vformat(
-          "Sanity check failed, `ymd` is {} and `time_of_day` is {}ns",
+          "Arguments do not form a valid datetime: `ymd` is {} and `time_of_day` is {}ns "
+          "(a time of day must be within [0, 24h))",
           std::make_format_args(ymd, ns)
         )
       };

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -119,13 +119,10 @@ concept Fractionable = requires (T t) {
  * @note The precision of the returned value is `std::chrono::nanoseconds`.
  * @throw std::invalid_argument if `fraction` days do not fit an `int64_t` count of nanoseconds
  *        (which includes NaN and either infinity).
- * @note Unlike `validate_fraction`, this does not require [0.0, 1.0) -- the examples above are
- *       the contract, and callers do pass whole days. What it does require is that the product
- *       survives the cast: `static_cast<int64_t>` of a value outside the destination's range is
- *       undefined, and NaN is the case that reaches it most quietly (#86).
- * @note Written as `not (lo < x and x < hi)` rather than a pair of `or`s, so that NaN fails the
- *       check -- every comparison against NaN is false, which the negated form turns into a
- *       throw and the plain form would turn into a pass. Same shape as `validate_fraction` (#67).
+ * @note Unlike `validate_fraction` this does not require [0.0, 1.0) — whole days are the
+ *       documented contract. What it requires is that the product survives the cast, which is
+ *       undefined outside int64's range; the guard's negated form is `validate_fraction`'s
+ *       NaN-safe shape (#67, #86).
  */
 [[nodiscard]] constexpr auto from_fraction(const double fraction) -> hh_mm_ss<nanoseconds> {
   // The largest whole-day count whose nanoseconds still fit an int64_t, kept a hair inside the
@@ -203,7 +200,7 @@ struct Datetime {
       throw std::invalid_argument {
         std::vformat(
           "Arguments do not form a valid datetime: `ymd` is {} and `time_of_day` is {}ns "
-          "(a time of day must be within [0, 24h))",
+          "(the date must be valid and the time of day within [0, 24h))",
           std::make_format_args(ymd, ns)
         )
       };
@@ -227,7 +224,7 @@ struct Datetime {
       throw std::invalid_argument {
         std::vformat(
           "Arguments do not form a valid datetime: `ymd` is {} and `time_of_day` is {}ns "
-          "(a time of day must be within [0, 24h))",
+          "(the date must be valid and the time of day within [0, 24h))",
           std::make_format_args(this->ymd, ns)
         )
       };
@@ -253,19 +250,8 @@ struct Datetime {
         ) 
       };
     }
-
-    if (not ok()) {
-      const double ns = static_cast<double>(
-        time_of_day.to_duration().count()
-      );
-      throw std::invalid_argument {
-        std::vformat(
-          "Arguments do not form a valid datetime: `ymd` is {} and `time_of_day` is {}ns "
-          "(a time of day must be within [0, 24h))",
-          std::make_format_args(ymd, ns)
-        )
-      };
-    }
+    // No `ok()` re-check: `ymd` was just validated, and `validate_fraction` bounds the fraction
+    // to [0.0, 1.0), which `from_fraction` maps inside [0, 24h) — the branch would be dead.
   }
 
   /** 

--- a/src/calendar/datetime.hpp
+++ b/src/calendar/datetime.hpp
@@ -117,8 +117,31 @@ concept Fractionable = requires (T t) {
  * @example `from_fraction(1.0) == 24:00:00.000000000`
  * @example `from_fraction(2.0) == 48:00:00.000000000`
  * @note The precision of the returned value is `std::chrono::nanoseconds`.
+ * @throw std::invalid_argument if `fraction` days do not fit an `int64_t` count of nanoseconds
+ *        (which includes NaN and either infinity).
+ * @note Unlike `validate_fraction`, this does not require [0.0, 1.0) -- the examples above are
+ *       the contract, and callers do pass whole days. What it does require is that the product
+ *       survives the cast: `static_cast<int64_t>` of a value outside the destination's range is
+ *       undefined, and NaN is the case that reaches it most quietly (#86).
+ * @note Written as `not (lo < x and x < hi)` rather than a pair of `or`s, so that NaN fails the
+ *       check -- every comparison against NaN is false, which the negated form turns into a
+ *       throw and the plain form would turn into a pass. Same shape as `validate_fraction` (#67).
  */
 [[nodiscard]] constexpr auto from_fraction(const double fraction) -> hh_mm_ss<nanoseconds> {
+  // The largest whole-day count whose nanoseconds still fit an int64_t, kept a hair inside the
+  // boundary: the exact ratio is not representable, so compare against a value known to convert.
+  constexpr double MAX_DAYS = 9.2e18 / static_cast<double>(in_a_day<nanoseconds>());
+
+  if (not (-MAX_DAYS < fraction and fraction < MAX_DAYS)) { // NOLINT(readability-simplify-boolean-expr) — NaN must fail this check (#86).
+    throw std::invalid_argument {
+      std::vformat(
+        "Argument `fraction` does not fit an int64 nanosecond count (|fraction| < {}), "
+        "whose value is {}",
+        std::make_format_args(MAX_DAYS, fraction)
+      )
+    };
+  }
+
   return hh_mm_ss {
     nanoseconds {
       static_cast<int64_t>(

--- a/src/calendar/lunar/algo2.hpp
+++ b/src/calendar/lunar/algo2.hpp
@@ -46,7 +46,7 @@
 
 namespace calendar::lunar::algo2 {
 
-using calendar::lunar::common::LunarYear;
+using LunarYear = calendar::lunar::common::LunarYear;
 
 // A convention, not a physical ceiling — the method computes rather than looks up. The ceiling
 // sits where the UTC+8 civil-day assignment stops being reliable: the ΔAT table freezes at 37 s

--- a/src/calendar/lunar/common.hpp
+++ b/src/calendar/lunar/common.hpp
@@ -37,7 +37,7 @@
 
 namespace calendar::lunar::common {
 
-using std::chrono::year_month_day;
+using year_month_day = std::chrono::year_month_day;
 
 /** 
  * @struct LunarYear 

--- a/src/calendar/lunar/converter.hpp
+++ b/src/calendar/lunar/converter.hpp
@@ -35,8 +35,8 @@
 
 namespace calendar::lunar::converter {
 
-using std::chrono::year_month_day;
-using std::chrono::sys_days;
+using year_month_day = std::chrono::year_month_day;
+using sys_days = std::chrono::sys_days;
 
 /**
  * @struct Converter

--- a/src/shared_lib/lib_astro.cpp
+++ b/src/shared_lib/lib_astro.cpp
@@ -125,7 +125,7 @@ auto sun_apparent_geocentric_coord(const double jde) -> SunCoordinate {
   try {
     if (not std::isfinite(jde)) {
       throw std::invalid_argument {
-        std::format("Argument `jde` is not finite, whose value is {}", jde)
+        std::format("Argument `jde` is not finite, got {}", jde)
       };
     }
 
@@ -156,7 +156,7 @@ auto moon_apparent_geocentric_coord(const double jde) -> MoonCoordinate {
   try {
     if (not std::isfinite(jde)) {
       throw std::invalid_argument {
-        std::format("Argument `jde` is not finite, whose value is {}", jde)
+        std::format("Argument `jde` is not finite, got {}", jde)
       };
     }
 
@@ -187,7 +187,7 @@ auto solar_lon_root_discriminant(const int32_t year, const double longitude) -> 
   try {
     if (not std::isfinite(longitude)) {
       throw std::invalid_argument {
-        std::format("Argument `longitude` is not finite, whose value is {}", longitude)
+        std::format("Argument `longitude` is not finite, got {}", longitude)
       };
     }
 
@@ -221,7 +221,7 @@ auto solar_lon_roots(
   try {
     if (not std::isfinite(longitude)) {
       throw std::invalid_argument {
-        std::format("Argument `longitude` is not finite, whose value is {}", longitude)
+        std::format("Argument `longitude` is not finite, got {}", longitude)
       };
     }
 
@@ -268,7 +268,7 @@ auto new_moons_after_jde(
   try {
     if (not std::isfinite(jde)) {
       throw std::invalid_argument {
-        std::format("Argument `jde` is not finite, whose value is {}", jde)
+        std::format("Argument `jde` is not finite, got {}", jde)
       };
     }
 
@@ -334,7 +334,7 @@ auto equation_of_time(const double jde) -> EquationOfTime {
   try {
     if (not std::isfinite(jde)) {
       throw std::invalid_argument {
-        std::format("Argument `jde` is not finite, whose value is {}", jde)
+        std::format("Argument `jde` is not finite, got {}", jde)
       };
     }
 

--- a/src/shared_lib/lib_delta_t.cpp
+++ b/src/shared_lib/lib_delta_t.cpp
@@ -34,7 +34,7 @@ auto delta_t_algo1(double year) -> DeltaT {
   try {
     if (not std::isfinite(year)) {
       throw std::invalid_argument {
-        std::format("Argument `year` is not finite, whose value is {}", year)
+        std::format("Argument `year` is not finite, got {}", year)
       };
     }
 
@@ -56,7 +56,7 @@ auto delta_t_algo2(double year) -> DeltaT {
   try {
     if (not std::isfinite(year)) {
       throw std::invalid_argument {
-        std::format("Argument `year` is not finite, whose value is {}", year)
+        std::format("Argument `year` is not finite, got {}", year)
       };
     }
 
@@ -78,7 +78,7 @@ auto delta_t_algo3(double year) -> DeltaT {
   try {
     if (not std::isfinite(year)) {
       throw std::invalid_argument {
-        std::format("Argument `year` is not finite, whose value is {}", year)
+        std::format("Argument `year` is not finite, got {}", year)
       };
     }
 
@@ -100,7 +100,7 @@ auto delta_t_algo4(double year) -> DeltaT {
   try {
     if (not std::isfinite(year)) {
       throw std::invalid_argument {
-        std::format("Argument `year` is not finite, whose value is {}", year)
+        std::format("Argument `year` is not finite, got {}", year)
       };
     }
 
@@ -122,7 +122,7 @@ auto delta_t_algo5(double year) -> DeltaT {
   try {
     if (not std::isfinite(year)) {
       throw std::invalid_argument {
-        std::format("Argument `year` is not finite, whose value is {}", year)
+        std::format("Argument `year` is not finite, got {}", year)
       };
     }
 
@@ -144,7 +144,7 @@ auto delta_t(double year) -> DeltaT {
   try {
     if (not std::isfinite(year)) {
       throw std::invalid_argument {
-        std::format("Argument `year` is not finite, whose value is {}", year)
+        std::format("Argument `year` is not finite, got {}", year)
       };
     }
 

--- a/src/test/astro/delta_t_test.cpp
+++ b/src/test/astro/delta_t_test.cpp
@@ -22,6 +22,8 @@
  */
 
 #include <gtest/gtest.h>
+#include <cmath>
+#include <limits>
 
 #include <tuple>
 #include <numeric>
@@ -104,6 +106,20 @@ TEST(DeltaT, Algo5) {
   ASSERT_NEAR(algo5::compute(algo5::LAST_OBSERVATION_YEAR - 1e-6),
               algo5::compute(algo5::LAST_OBSERVATION_YEAR + 1e-6), 1e-3);
 }
+
+TEST(DeltaT, NonFiniteYears) {
+  // #86: NaN slips through plain `<` guards (every comparison is false), and in algo1 it used
+  // to reach the float→int cast — UB, UBSan-reproducible. The bounded algos now throw; the
+  // noexcept ones (algo2, algo5, the dispatcher) propagate NaN, which is IEEE, not UB.
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  ASSERT_THROW(std::ignore = algo1::compute(nan), std::out_of_range);
+  ASSERT_THROW(std::ignore = algo3::compute(nan), std::out_of_range);
+  ASSERT_THROW(std::ignore = algo4::compute(nan), std::out_of_range);
+  ASSERT_TRUE(std::isnan(algo2::compute(nan)));
+  ASSERT_TRUE(std::isnan(algo5::compute(nan)));
+  ASSERT_TRUE(std::isnan(compute(nan)));
+}
+
 
 TEST(DeltaT, DefaultDispatch) {
   // The default `compute` is algo5 for all years.

--- a/src/test/astro/delta_t_test.cpp
+++ b/src/test/astro/delta_t_test.cpp
@@ -108,9 +108,8 @@ TEST(DeltaT, Algo5) {
 }
 
 TEST(DeltaT, NonFiniteYears) {
-  // #86: NaN slips through plain `<` guards (every comparison is false), and in algo1 it used
-  // to reach the float→int cast — UB, UBSan-reproducible. The bounded algos now throw; the
-  // noexcept ones (algo2, algo5, the dispatcher) propagate NaN, which is IEEE, not UB.
+  // #86: the throwing algos reject every non-finite year; the noexcept ones (algo2, algo5,
+  // the dispatcher) propagate it — IEEE, not UB.
   const double nan = std::numeric_limits<double>::quiet_NaN();
   const double inf = std::numeric_limits<double>::infinity();
   ASSERT_THROW(std::ignore = algo1::compute(nan), std::out_of_range);

--- a/src/test/astro/delta_t_test.cpp
+++ b/src/test/astro/delta_t_test.cpp
@@ -112,12 +112,28 @@ TEST(DeltaT, NonFiniteYears) {
   // to reach the float→int cast — UB, UBSan-reproducible. The bounded algos now throw; the
   // noexcept ones (algo2, algo5, the dispatcher) propagate NaN, which is IEEE, not UB.
   const double nan = std::numeric_limits<double>::quiet_NaN();
+  const double inf = std::numeric_limits<double>::infinity();
   ASSERT_THROW(std::ignore = algo1::compute(nan), std::out_of_range);
   ASSERT_THROW(std::ignore = algo3::compute(nan), std::out_of_range);
   ASSERT_THROW(std::ignore = algo4::compute(nan), std::out_of_range);
+  // ±inf sail past a single comparison exactly the way NaN does not: `inf >= -4000` is true.
+  // Each throwing algo bounds both ends now, so every non-finite year fails one of them.
+  ASSERT_THROW(std::ignore = algo1::compute(inf),  std::out_of_range);
+  ASSERT_THROW(std::ignore = algo1::compute(-inf), std::out_of_range);
+  ASSERT_THROW(std::ignore = algo3::compute(inf),  std::out_of_range);
+  ASSERT_THROW(std::ignore = algo3::compute(-inf), std::out_of_range);
+  ASSERT_THROW(std::ignore = algo4::compute(inf),  std::out_of_range);
+  ASSERT_THROW(std::ignore = algo4::compute(-inf), std::out_of_range);
+  // The noexcept ones propagate: non-finite in, non-finite out.
   ASSERT_TRUE(std::isnan(algo2::compute(nan)));
   ASSERT_TRUE(std::isnan(algo5::compute(nan)));
   ASSERT_TRUE(std::isnan(compute(nan)));
+  ASSERT_FALSE(std::isfinite(algo2::compute(inf)));
+  ASSERT_FALSE(std::isfinite(algo5::compute(inf)));
+  ASSERT_FALSE(std::isfinite(compute(-inf)));
+  // A huge *finite* year is legal for algo1 (its late-era formula is open-ended); before the
+  // cast moved inside the table branch, this line was the same float→int UB as the NaN case.
+  ASSERT_NO_THROW(std::ignore = algo1::compute(1e300));
 }
 
 

--- a/src/test/astro/delta_t_test.cpp
+++ b/src/test/astro/delta_t_test.cpp
@@ -116,8 +116,7 @@ TEST(DeltaT, NonFiniteYears) {
   ASSERT_THROW(std::ignore = algo1::compute(nan), std::out_of_range);
   ASSERT_THROW(std::ignore = algo3::compute(nan), std::out_of_range);
   ASSERT_THROW(std::ignore = algo4::compute(nan), std::out_of_range);
-  // ±inf sail past a single comparison exactly the way NaN does not: `inf >= -4000` is true.
-  // Each throwing algo bounds both ends now, so every non-finite year fails one of them.
+  // The throwing algos bound both ends, so every non-finite year fails one of them.
   ASSERT_THROW(std::ignore = algo1::compute(inf),  std::out_of_range);
   ASSERT_THROW(std::ignore = algo1::compute(-inf), std::out_of_range);
   ASSERT_THROW(std::ignore = algo3::compute(inf),  std::out_of_range);
@@ -131,8 +130,7 @@ TEST(DeltaT, NonFiniteYears) {
   ASSERT_FALSE(std::isfinite(algo2::compute(inf)));
   ASSERT_FALSE(std::isfinite(algo5::compute(inf)));
   ASSERT_FALSE(std::isfinite(compute(-inf)));
-  // A huge *finite* year is legal for algo1 (its late-era formula is open-ended); before the
-  // cast moved inside the table branch, this line was the same float→int UB as the NaN case.
+  // A huge finite year is inside algo1's throw contract; it used to be the same cast UB as NaN.
   ASSERT_NO_THROW(std::ignore = algo1::compute(1e300));
 }
 

--- a/src/test/astro/delta_t_test.cpp
+++ b/src/test/astro/delta_t_test.cpp
@@ -116,7 +116,6 @@ TEST(DeltaT, NonFiniteYears) {
   ASSERT_THROW(std::ignore = algo1::compute(nan), std::out_of_range);
   ASSERT_THROW(std::ignore = algo3::compute(nan), std::out_of_range);
   ASSERT_THROW(std::ignore = algo4::compute(nan), std::out_of_range);
-  // The throwing algos bound both ends, so every non-finite year fails one of them.
   ASSERT_THROW(std::ignore = algo1::compute(inf),  std::out_of_range);
   ASSERT_THROW(std::ignore = algo1::compute(-inf), std::out_of_range);
   ASSERT_THROW(std::ignore = algo3::compute(inf),  std::out_of_range);
@@ -130,7 +129,6 @@ TEST(DeltaT, NonFiniteYears) {
   ASSERT_FALSE(std::isfinite(algo2::compute(inf)));
   ASSERT_FALSE(std::isfinite(algo5::compute(inf)));
   ASSERT_FALSE(std::isfinite(compute(-inf)));
-  // A huge finite year is inside algo1's throw contract; it used to be the same cast UB as NaN.
   ASSERT_NO_THROW(std::ignore = algo1::compute(1e300));
 }
 

--- a/src/test/astro/moon_test.cpp
+++ b/src/test/astro/moon_test.cpp
@@ -22,6 +22,8 @@
  */
 
 #include <gtest/gtest.h>
+#include <cmath>
+#include <limits>
 #include <tuple>
 #include <unordered_map>
 #include "util.hpp"
@@ -102,6 +104,23 @@ TEST(Moon, CoordAndPpi) {
 
     const auto ppi = equatorial_horizontal_parallax(DistanceKm { r });
     ASSERT_NEAR(ppi.rad(),  std::get<3>(expected), 1e-14);
+  }
+
+  // #86: the function is public over a `Distance<KM>` open to any value, and `asin` of an
+  // argument above 1 returns a silent NaN. The Moon never gets here; the contract still holds.
+  {
+    ASSERT_THROW(std::ignore = equatorial_horizontal_parallax(DistanceKm { 0.0 }),
+                 std::invalid_argument);
+    ASSERT_THROW(std::ignore = equatorial_horizontal_parallax(DistanceKm { -1.0 }),
+                 std::invalid_argument);
+    ASSERT_THROW(std::ignore = equatorial_horizontal_parallax(
+                   DistanceKm { EARTH_EQUATORIAL_RADIUS_KM }), std::invalid_argument);
+    ASSERT_THROW(std::ignore = equatorial_horizontal_parallax(
+                   DistanceKm { std::numeric_limits<double>::quiet_NaN() }),
+                 std::invalid_argument);
+    // Just outside the radius is legal, and lands near the asin domain edge rather than in it.
+    ASSERT_NO_THROW(std::ignore = equatorial_horizontal_parallax(
+                      DistanceKm { std::nextafter(EARTH_EQUATORIAL_RADIUS_KM, 1e9) }));
   }
 }
 

--- a/src/test/astro/moon_test.cpp
+++ b/src/test/astro/moon_test.cpp
@@ -118,6 +118,13 @@ TEST(Moon, CoordAndPpi) {
     ASSERT_THROW(std::ignore = equatorial_horizontal_parallax(
                    DistanceKm { std::numeric_limits<double>::quiet_NaN() }),
                  std::invalid_argument);
+    // ±inf pass `inf > r` and would come back as a plausible 0 rad — the guard's other half.
+    ASSERT_THROW(std::ignore = equatorial_horizontal_parallax(
+                   DistanceKm { std::numeric_limits<double>::infinity() }),
+                 std::invalid_argument);
+    ASSERT_THROW(std::ignore = equatorial_horizontal_parallax(
+                   DistanceKm { -std::numeric_limits<double>::infinity() }),
+                 std::invalid_argument);
     // Just outside the radius is legal, and lands near the asin domain edge rather than in it.
     ASSERT_NO_THROW(std::ignore = equatorial_horizontal_parallax(
                       DistanceKm { std::nextafter(EARTH_EQUATORIAL_RADIUS_KM, 1e9) }));

--- a/src/test/astro/moon_test.cpp
+++ b/src/test/astro/moon_test.cpp
@@ -106,8 +106,7 @@ TEST(Moon, CoordAndPpi) {
     ASSERT_NEAR(ppi.rad(),  std::get<3>(expected), 1e-14);
   }
 
-  // #86: the function is public over a `Distance<KM>` open to any value, and `asin` of an
-  // argument above 1 returns a silent NaN. The Moon never gets here; the contract still holds.
+  // #86: the guard's contract is the @throw/@note on the function itself; these pin it.
   {
     ASSERT_THROW(std::ignore = equatorial_horizontal_parallax(DistanceKm { 0.0 }),
                  std::invalid_argument);

--- a/src/test/astro/sidereal_time_test.cpp
+++ b/src/test/astro/sidereal_time_test.cpp
@@ -119,7 +119,9 @@ TEST(SiderealTime, LocalApparentMeeus13b) {
   constexpr double lon = 77.0 + 3.0 / 60.0 + 56.0 / 3600.0;
 
   constexpr double α_hours = 23.0 + 9.0 / 60.0 + 16.641 / 3600.0;
-  const double expected = normalize_deg(64.352133 + α_hours * 15.0); // std::remainder is not constexpr until C++26.
+  // Not `constexpr`: `std::remainder` is constexpr since C++23 on paper (P0533) but not in the
+  // pinned toolchains — see the design ledger in AGENTS.md (#82).
+  const double expected = normalize_deg(64.352133 + α_hours * 15.0);
 
   ASSERT_NEAR(local_apparent(jd_ut1, jde_tt, AngleDeg { lon }).deg(), expected, 2e-4);
 }

--- a/src/test/astro/sidereal_time_test.cpp
+++ b/src/test/astro/sidereal_time_test.cpp
@@ -119,8 +119,7 @@ TEST(SiderealTime, LocalApparentMeeus13b) {
   constexpr double lon = 77.0 + 3.0 / 60.0 + 56.0 / 3600.0;
 
   constexpr double α_hours = 23.0 + 9.0 / 60.0 + 16.641 / 3600.0;
-  // Not `constexpr`: `std::remainder` is constexpr since C++23 on paper (P0533) but not in the
-  // pinned toolchains — see the design ledger in AGENTS.md (#82).
+  // Not `constexpr`: the pinned toolchains still reject constexpr `std::remainder` (#82).
   const double expected = normalize_deg(64.352133 + α_hours * 15.0);
 
   ASSERT_NEAR(local_apparent(jd_ut1, jde_tt, AngleDeg { lon }).deg(), expected, 2e-4);

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -331,9 +331,10 @@ TEST(AstroMath, Distance) {
   static_assert(not std::is_convertible_v<double, DistanceAu>);
   static_assert(not std::is_convertible_v<DistanceAu, DistanceKm>);
 
-  // Pinned against the constant, not against its literal value: the re-value and rename to the
-  // IAU 2012 definition (#86) repointed this test rather than forcing expected values to be
-  // re-derived, which is what pinning the symbol bought.
+  // Two pins with different jobs: the literal pin holds the IAU 2012 defined value (nothing
+  // else in the suite would notice a re-value — every other assertion closes over the symbol),
+  // and the symbolic pins hold the wiring.
+  ASSERT_EQ(AU_KM_SCALE, 149597870.700); // IAU 2012 Resolution B2
   ASSERT_EQ(au_to_km(1.0), AU_KM_SCALE);
   ASSERT_EQ(km_to_au(AU_KM_SCALE), 1.0);
   ASSERT_EQ(au_to_km(0.0), 0.0);

--- a/src/test/astro/toolbox_test.cpp
+++ b/src/test/astro/toolbox_test.cpp
@@ -331,10 +331,11 @@ TEST(AstroMath, Distance) {
   static_assert(not std::is_convertible_v<double, DistanceAu>);
   static_assert(not std::is_convertible_v<DistanceAu, DistanceKm>);
 
-  // Pinned against the constant, not the literal 149597870.691: a re-value or rename (#86) then
-  // repoints this test instead of forcing its expected values to be re-derived.
-  ASSERT_EQ(au_to_km(1.0), au_km_scale);
-  ASSERT_EQ(km_to_au(au_km_scale), 1.0);
+  // Pinned against the constant, not against its literal value: the re-value and rename to the
+  // IAU 2012 definition (#86) repointed this test rather than forcing expected values to be
+  // re-derived, which is what pinning the symbol bought.
+  ASSERT_EQ(au_to_km(1.0), AU_KM_SCALE);
+  ASSERT_EQ(km_to_au(AU_KM_SCALE), 1.0);
   ASSERT_EQ(au_to_km(0.0), 0.0);
   ASSERT_EQ(km_to_au(0.0), 0.0);
 

--- a/src/test/datetime_test.cpp
+++ b/src/test/datetime_test.cpp
@@ -394,9 +394,11 @@ TEST(Datetime, EdgeCases) {
     }
 
     {
+      // #86: a time of day outside [0, 24h) is a bad argument, not an internal sanity failure —
+      // all three constructors now say so with the same exception type.
       const hh_mm_ss<nanoseconds> hms { nanoseconds { -1 } };
       ASSERT_THROW((Datetime { today_tp, hms }),
-                   std::runtime_error);
+                   std::invalid_argument);
     }
 
     {
@@ -408,7 +410,7 @@ TEST(Datetime, EdgeCases) {
     {
       const hh_mm_ss<nanoseconds> hms { nanoseconds { in_a_day<nanoseconds>() } };
       ASSERT_THROW((Datetime { today_tp, hms }),
-                   std::runtime_error);
+                   std::invalid_argument);
     }
   }
 }

--- a/src/test/datetime_test.cpp
+++ b/src/test/datetime_test.cpp
@@ -394,8 +394,7 @@ TEST(Datetime, EdgeCases) {
     }
 
     {
-      // #86: a time of day outside [0, 24h) is a bad argument, not an internal sanity failure —
-      // all three constructors now say so with the same exception type.
+      // #86: a time of day outside [0, 24h) is a bad argument, not an internal sanity failure.
       const hh_mm_ss<nanoseconds> hms { nanoseconds { -1 } };
       ASSERT_THROW((Datetime { today_tp, hms }),
                    std::invalid_argument);

--- a/src/test/datetime_test.cpp
+++ b/src/test/datetime_test.cpp
@@ -366,6 +366,21 @@ TEST(Datetime, EdgeCases) {
       ASSERT_THROW((Datetime { today_tp, 1e300 }),
                    std::invalid_argument);
     }
+
+    {
+      // #86: `from_fraction` is public and reachable without going through `validate_fraction`,
+      // whose [0.0, 1.0) contract it deliberately does not share (whole days are legal here).
+      // What it cannot accept is a product that does not fit the int64 cast.
+      ASSERT_NO_THROW(std::ignore = from_fraction(2.0));      // documented as legal
+      ASSERT_NO_THROW(std::ignore = from_fraction(-1.5));     // negative days likewise
+      ASSERT_THROW(std::ignore = from_fraction(std::numeric_limits<double>::quiet_NaN()),
+                   std::invalid_argument);
+      ASSERT_THROW(std::ignore = from_fraction(std::numeric_limits<double>::infinity()),
+                   std::invalid_argument);
+      ASSERT_THROW(std::ignore = from_fraction(-std::numeric_limits<double>::infinity()),
+                   std::invalid_argument);
+      ASSERT_THROW(std::ignore = from_fraction(1e300), std::invalid_argument);
+    }
   }
 
   { // Test ymd and hms constructor.


### PR DESCRIPTION
把这一批攒下的设计决定写成 AGENTS.md 的正式规矩,并清掉错误契约的小账。

Closes #127
Closes #86
Closes #82
Closes #155

## 交付

**设计台账**(#127)。AGENTS.md 新增「Design ledger」:13 行四件套表(裁决 / 前提 / 触发器 /
日期)+「已做」与「**已拍未建**」两个桶 + 两条「看似漂移实为有意」的约定(C 边界时间尺度住
函数名、C++ 内部住参数后缀;`last_error` 是有文档边界的 pilot)。22 条候选全部按当前 HEAD
重核后落笔 —— 9 条成立照写,1 条已变、3 条形变按**现在的形状**写,不照 issue 原文抄:
错误分类按「答案的状态」三分(throw / optional / assert)取代评论区的四分法,缓存拆成
「机制无驱逐 / key 由调用方契约钉界」两句,ELP 转录记成一次性迁移闸而非常驻双轨,
cpp26-lab 如实写「分支从未创建」。配套:注释三槽、错误机制表、验收配方各一节。

**错误契约**(#86)。`Datetime` 三处 `runtime_error` → `std::invalid_argument`(输入错不再
伪装内部错);`jd_to_ut1` 消息补触发值;`AU_KM_SCALE` 换 IAU 2012 定义值 + UPPER_CASE +
`@ref` + 字面钉;sweep 23 处 `whose value is` → `got`。评论区扩权三项:一项已被 #67 消解
(核销),`from_fraction` 与 `equatorial_horizontal_parallax` 两道守卫补上(后者 ±inf 曾
静默返回 0 rad)。**顺藤清掉同族账**:`delta_t` 系非有限输入 —— algo1 的 float→int cast
是 UBSan 可复现的真 UB,cast 收进查表分支按构造安全;三个 throw 型 algo 换 `std::isfinite`
惯用形守卫,九格全 throw;noexcept 侧文档写明传播语义。

**#82 入台账**:`std::remainder` C++23 合规、钉版工具链实测仍拒 ⇒ IF-NDR,记为
反「合规所以没事」样本,触发器 = 工具链升级重验(一行探针)。

**#155**:测试侧「建前清」工序,与 `--bench` 同形;验收配方(直跑 + 宏对账 + fail 位)
入 AGENTS.md。4 条遗留 using-declaration 转同名别名,例外段删除,规矩一字未放宽。

## 审阅

R1 五席(契约/话语 · 减法 · 正确性 · 闸门区分力 · 盲审)→ R4,修复批 ×3。代码零 P1;
三条 P1 全在新写的散文里(台账把未建的 helper 写成已建 · 验收配方拿已修掉的失效论证自己 ·
边界注释与实测 180/204 相悖)。四处多家独立撞车。**卡点中断触发一次**:algo1 守卫上方的
注释连续两轮被证伪,处置按规矩不写第四句 —— 换成全仓既有的 isfinite 惯用形,
需要解释的东西整个消失。闸门区分力席逐针独立重注入(含 DeMorgan 化简针:NOLINT 守的
NaN 语义有测试钉着);验收配方两方向注入(红二进制 → verdict 1,干净树 → 0)。

## 验证

- 236 ran == 236 declared,fail=0(新配方,含失败位)
- 九格非有限探针 9/9 throw(UBSan 静默);`algo1(1e300)` 合法返回(修复前是 cast UB)
- cast 收分支改动:17 定点位级相同 + 200 万点固定种子扫描新旧哈希逐位全同
- 突变全谱:每道新守卫/工序摘除或写松 → 构建 EXIT 0、对应测试非 0
- 七道门禁(ruff / 自包含 / export-surface / log-names / abi-layout / ctypes-smoke /
  clang-tidy 18.1.8)全绿

## 勘误(提交信息不可改,以此为准)

- `94ae205`:「9 mm/AU」应为 **9 m/AU**;「metres」处数值单位是公里。
- `69961cd`:「assert row no longer points back」当时为假,`02a8ca6` 才使其为真。
- `02a8ca6`:「the other thirteen guards」应为 **23 处**(13 是审阅席举证样本被误当普查;
  方向是低估,不影响选型)。
