### PR TITLE
chore(linter): run-clang-tidy 随仓 vendor,删掉每次 CI 从 llvm main 现拉执行的路径 (#165)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,10 @@ check_platform_arch.py
 
 artifacts/
 release/
-run-clang-tidy.py
+
+# `run-clang-tidy.py` used to be ignored and re-downloaded from llvm-project `main` on every run.
+# It is now vendored and tracked, pinned to the same LLVM release as the clang-tidy binary
+# (`automation/linter.py`). Do not re-add it here.
 
 build_info.json
 cpu_info.json

--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,6 @@ check_platform_arch.py
 artifacts/
 release/
 
-# `run-clang-tidy.py` used to be ignored and re-downloaded from llvm-project `main` on every run.
-# It is now vendored and tracked, pinned to the same LLVM release as the clang-tidy binary
-# (`automation/linter.py`). Do not re-add it here.
-
 build_info.json
 cpu_info.json
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,7 +1,7 @@
 exclude = [
   "*.ipynb",
-  # Vendored verbatim from llvmorg-18.1.8 so it stays diffable against upstream. Our style rules
-  # are not upstream's -- linting it would only pressure us to edit a file we must not edit.
+  # Vendored verbatim from upstream so it stays diffable against it. Our style rules are not
+  # upstream's -- linting it would only pressure us to edit a file we must not edit.
   "run-clang-tidy.py",
 ]
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,8 @@
 exclude = [
   "*.ipynb",
+  # Vendored verbatim from llvmorg-18.1.8 so it stays diffable against upstream. Our style rules
+  # are not upstream's -- linting it would only pressure us to edit a file we must not edit.
+  "run-clang-tidy.py",
 ]
 
 # Matches the Python version used across CI jobs.

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,7 +1,7 @@
 exclude = [
   "*.ipynb",
-  # Vendored verbatim from upstream so it stays diffable against it. Our style rules are not
-  # upstream's -- linting it would only pressure us to edit a file we must not edit.
+  # Vendored upstream code. Our style rules are not upstream's -- linting it would only
+  # pressure us to edit a file we must not edit.
   "run-clang-tidy.py",
 ]
 

--- a/automation/linter.py
+++ b/automation/linter.py
@@ -17,44 +17,9 @@ from .env import Tool, check_tool
 from .utils import run_cmd, yellow_print, red_print, green_print
 
 
-# `run-clang-tidy.py` is vendored verbatim from this LLVM release, and the CI jobs install
-# `clang-tidy==CLANG_TIDY_PIN`. The runner and the binary are one pin, not two -- the runner is
-# that release's own driver, and pairing it with another clang-tidy is a combination nobody
-# chose. Until 2026-08-07 the runner was gitignored and re-fetched from llvm-project `main` on
-# every CI run, so the pinned binary was in fact driven by an unpinned script (#72, #73).
-CLANG_TIDY_PIN = "18.1.8"
+# Tracked, not fetched: until 2026-08-07 this file was gitignored and pulled from llvm-project
+# `main` on every CI run, so a mutable third-party script drove the pinned clang-tidy (#72, #73).
 VENDORED_RUNNER = "run-clang-tidy.py"
-
-
-def check_clang_tidy_pin() -> int:
-  """Refuse to run unless the vendored runner, the installed binary and the CI pin all agree."""
-  runner = paths.proj_root() / VENDORED_RUNNER
-  if not runner.exists():
-    red_print(f"{VENDORED_RUNNER} is missing from the repo root.")
-    yellow_print(f"It is vendored from llvmorg-{CLANG_TIDY_PIN}, not downloaded -- restore it from git.")
-    return 1
-
-  ret = run_cmd(["clang-tidy", "--version"], print_cmd=False, print_stdout=False, print_stderr=False)
-  installed = re.search(r"LLVM version (\S+)", ret.stdout)
-  if installed is None:
-    red_print("Cannot read the clang-tidy version.")
-    return 1
-  if installed.group(1) != CLANG_TIDY_PIN:
-    red_print(f"clang-tidy is {installed.group(1)}, but {VENDORED_RUNNER} is vendored from {CLANG_TIDY_PIN}.")
-    yellow_print(f"Install the pin with `pip install clang-tidy=={CLANG_TIDY_PIN}`, or re-vendor the runner.")
-    return 1
-
-  # The workflow is what actually installs the binary in CI. If its pin drifts from ours, CI would
-  # run a pair this gate never saw -- so the gate reads the workflow instead of trusting a comment.
-  workflow = paths.proj_root() / ".github" / "workflows" / "core_tests.yml"
-  declared = re.search(r"clang-tidy==(\S+)", workflow.read_text(encoding="utf-8"))
-  if declared is None or declared.group(1) != CLANG_TIDY_PIN:
-    found = "no clang-tidy pin at all" if declared is None else declared.group(1)
-    red_print(f"core_tests.yml installs {found}, but {VENDORED_RUNNER} is vendored from {CLANG_TIDY_PIN}.")
-    yellow_print("Bump the workflow pin and re-vendor the runner together, or neither.")
-    return 1
-
-  return 0
 
 
 def run_ruff() -> int:
@@ -84,10 +49,12 @@ def run_clang_tidy() -> int:
 
   if not check_tool(Tool("clang-tidy")):
     red_print("clang-tidy not found!")
-    yellow_print(f"Install clang-tidy by `pip install clang-tidy=={CLANG_TIDY_PIN}`")
+    yellow_print("Install clang-tidy by `pip install clang-tidy` -- the version CI pins is in core_tests.yml")
     return 1
 
-  if check_clang_tidy_pin() != 0:
+  if not (paths.proj_root() / VENDORED_RUNNER).exists():
+    red_print(f"{VENDORED_RUNNER} is missing from the repo root.")
+    yellow_print(f"It is tracked -- restore it with `git checkout -- {VENDORED_RUNNER}`.")
     return 1
 
   build_dir = paths.build_dir()

--- a/automation/linter.py
+++ b/automation/linter.py
@@ -17,23 +17,41 @@ from .env import Tool, check_tool
 from .utils import run_cmd, yellow_print, red_print, green_print
 
 
-def ensure_run_clang_tidy() -> int:
-  """Ensure that the runner 'run-clang-tidy.py' is installed."""
-  proj_root = paths.proj_root()
-  run_clang_tidy = proj_root / "run-clang-tidy.py"
-  if run_clang_tidy.exists():
-    return 0
+# `run-clang-tidy.py` is vendored verbatim from this LLVM release, and the CI jobs install
+# `clang-tidy==CLANG_TIDY_PIN`. The runner and the binary are one pin, not two -- the runner is
+# that release's own driver, and pairing it with another clang-tidy is a combination nobody
+# chose. Until 2026-08-07 the runner was gitignored and re-fetched from llvm-project `main` on
+# every CI run, so the pinned binary was in fact driven by an unpinned script (#72, #73).
+CLANG_TIDY_PIN = "18.1.8"
+VENDORED_RUNNER = "run-clang-tidy.py"
 
-  # Otherwise, download it.
-  if not check_tool(Tool("curl")):
-    red_print("curl not found!")
+
+def check_clang_tidy_pin() -> int:
+  """Refuse to run unless the vendored runner, the installed binary and the CI pin all agree."""
+  runner = paths.proj_root() / VENDORED_RUNNER
+  if not runner.exists():
+    red_print(f"{VENDORED_RUNNER} is missing from the repo root.")
+    yellow_print(f"It is vendored from llvmorg-{CLANG_TIDY_PIN}, not downloaded -- restore it from git.")
     return 1
 
-  yellow_print("Downloading run-clang-tidy.py...")
-  ret = run_cmd(["curl", "-s", "https://raw.githubusercontent.com/LLVM/llvm-project/main/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py", 
-                 "-o", str(run_clang_tidy)])
-  if ret.retcode != 0:
-    red_print("Failed to download run-clang-tidy.py")
+  ret = run_cmd(["clang-tidy", "--version"], print_cmd=False, print_stdout=False, print_stderr=False)
+  installed = re.search(r"LLVM version (\S+)", ret.stdout)
+  if installed is None:
+    red_print("Cannot read the clang-tidy version.")
+    return 1
+  if installed.group(1) != CLANG_TIDY_PIN:
+    red_print(f"clang-tidy is {installed.group(1)}, but {VENDORED_RUNNER} is vendored from {CLANG_TIDY_PIN}.")
+    yellow_print(f"Install the pin with `pip install clang-tidy=={CLANG_TIDY_PIN}`, or re-vendor the runner.")
+    return 1
+
+  # The workflow is what actually installs the binary in CI. If its pin drifts from ours, CI would
+  # run a pair this gate never saw -- so the gate reads the workflow instead of trusting a comment.
+  workflow = paths.proj_root() / ".github" / "workflows" / "core_tests.yml"
+  declared = re.search(r"clang-tidy==(\S+)", workflow.read_text(encoding="utf-8"))
+  if declared is None or declared.group(1) != CLANG_TIDY_PIN:
+    found = "no clang-tidy pin at all" if declared is None else declared.group(1)
+    red_print(f"core_tests.yml installs {found}, but {VENDORED_RUNNER} is vendored from {CLANG_TIDY_PIN}.")
+    yellow_print("Bump the workflow pin and re-vendor the runner together, or neither.")
     return 1
 
   return 0
@@ -66,10 +84,10 @@ def run_clang_tidy() -> int:
 
   if not check_tool(Tool("clang-tidy")):
     red_print("clang-tidy not found!")
-    yellow_print("Install clang-tidy by `pip install clang-tidy`")
+    yellow_print(f"Install clang-tidy by `pip install clang-tidy=={CLANG_TIDY_PIN}`")
     return 1
 
-  if ensure_run_clang_tidy() != 0:
+  if check_clang_tidy_pin() != 0:
     return 1
 
   build_dir = paths.build_dir()
@@ -81,7 +99,7 @@ def run_clang_tidy() -> int:
 
   yellow_print("Running clang-tidy...")
   # Ensure non-0 exit code on any warning or error
-  ret = run_cmd(["python3", "run-clang-tidy.py", "-p", str(build_dir), "-header-filter=src/"], 
+  ret = run_cmd(["python3", VENDORED_RUNNER, "-p", str(build_dir), "-header-filter=src/"],
                 cwd=str(paths.proj_root()))
 
   if ret.retcode == 0:

--- a/automation/linter.py
+++ b/automation/linter.py
@@ -17,11 +17,6 @@ from .env import Tool, check_tool
 from .utils import run_cmd, yellow_print, red_print, green_print
 
 
-# Tracked, not fetched: until 2026-08-07 this file was gitignored and pulled from llvm-project
-# `main` on every CI run, so a mutable third-party script drove the pinned clang-tidy (#72, #73).
-VENDORED_RUNNER = "run-clang-tidy.py"
-
-
 def run_ruff() -> int:
   """Run ruff on the project source code."""  
   print("#" * 60)
@@ -49,12 +44,7 @@ def run_clang_tidy() -> int:
 
   if not check_tool(Tool("clang-tidy")):
     red_print("clang-tidy not found!")
-    yellow_print("Install clang-tidy by `pip install clang-tidy` -- the version CI pins is in core_tests.yml")
-    return 1
-
-  if not (paths.proj_root() / VENDORED_RUNNER).exists():
-    red_print(f"{VENDORED_RUNNER} is missing from the repo root.")
-    yellow_print(f"It is tracked -- restore it with `git checkout -- {VENDORED_RUNNER}`.")
+    yellow_print("Install clang-tidy by `pip install clang-tidy`")
     return 1
 
   build_dir = paths.build_dir()
@@ -66,7 +56,7 @@ def run_clang_tidy() -> int:
 
   yellow_print("Running clang-tidy...")
   # Ensure non-0 exit code on any warning or error
-  ret = run_cmd(["python3", VENDORED_RUNNER, "-p", str(build_dir), "-header-filter=src/"],
+  ret = run_cmd(["python3", "run-clang-tidy.py", "-p", str(build_dir), "-header-filter=src/"],
                 cwd=str(paths.proj_root()))
 
   if ret.retcode == 0:

--- a/run-clang-tidy.py
+++ b/run-clang-tidy.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+#
+# ===- run-clang-tidy.py - Parallel clang-tidy runner --------*- python -*--===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===-----------------------------------------------------------------------===#
+# FIXME: Integrate with clang-tidy-diff.py
+
+
+"""
+Parallel clang-tidy runner
+==========================
+
+Runs clang-tidy over all files in a compilation database. Requires clang-tidy
+and clang-apply-replacements in $PATH.
+
+Example invocations.
+- Run clang-tidy on all files in the current working directory with a default
+  set of checks and show warnings in the cpp files and all project headers.
+    run-clang-tidy.py $PWD
+
+- Fix all header guards.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard
+
+- Fix all header guards included from clang-tidy and header guards
+  for clang-tidy headers.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard extra/clang-tidy \
+                      -header-filter=extra/clang-tidy
+
+Compilation database setup:
+http://clang.llvm.org/docs/HowToSetupToolingForLLVM.html
+"""
+
+from __future__ import print_function
+
+import argparse
+import glob
+import json
+import multiprocessing
+import os
+import queue
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import traceback
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+
+def strtobool(val):
+    """Convert a string representation of truth to a bool following LLVM's CLI argument parsing."""
+
+    val = val.lower()
+    if val in ["", "true", "1"]:
+        return True
+    elif val in ["false", "0"]:
+        return False
+
+    # Return ArgumentTypeError so that argparse does not substitute its own error message
+    raise argparse.ArgumentTypeError(
+        "'{}' is invalid value for boolean argument! Try 0 or 1.".format(val)
+    )
+
+
+def find_compilation_database(path):
+    """Adjusts the directory until a compilation database is found."""
+    result = os.path.realpath("./")
+    while not os.path.isfile(os.path.join(result, path)):
+        parent = os.path.dirname(result)
+        if result == parent:
+            print("Error: could not find compilation database.")
+            sys.exit(1)
+        result = parent
+    return result
+
+
+def make_absolute(f, directory):
+    if os.path.isabs(f):
+        return f
+    return os.path.normpath(os.path.join(directory, f))
+
+
+def get_tidy_invocation(
+    f,
+    clang_tidy_binary,
+    checks,
+    tmpdir,
+    build_path,
+    header_filter,
+    allow_enabling_alpha_checkers,
+    extra_arg,
+    extra_arg_before,
+    quiet,
+    config_file_path,
+    config,
+    line_filter,
+    use_color,
+    plugins,
+    warnings_as_errors,
+):
+    """Gets a command line for clang-tidy."""
+    start = [clang_tidy_binary]
+    if allow_enabling_alpha_checkers:
+        start.append("-allow-enabling-analyzer-alpha-checkers")
+    if header_filter is not None:
+        start.append("-header-filter=" + header_filter)
+    if line_filter is not None:
+        start.append("-line-filter=" + line_filter)
+    if use_color is not None:
+        if use_color:
+            start.append("--use-color")
+        else:
+            start.append("--use-color=false")
+    if checks:
+        start.append("-checks=" + checks)
+    if tmpdir is not None:
+        start.append("-export-fixes")
+        # Get a temporary file. We immediately close the handle so clang-tidy can
+        # overwrite it.
+        (handle, name) = tempfile.mkstemp(suffix=".yaml", dir=tmpdir)
+        os.close(handle)
+        start.append(name)
+    for arg in extra_arg:
+        start.append("-extra-arg=%s" % arg)
+    for arg in extra_arg_before:
+        start.append("-extra-arg-before=%s" % arg)
+    start.append("-p=" + build_path)
+    if quiet:
+        start.append("-quiet")
+    if config_file_path:
+        start.append("--config-file=" + config_file_path)
+    elif config:
+        start.append("-config=" + config)
+    for plugin in plugins:
+        start.append("-load=" + plugin)
+    if warnings_as_errors:
+        start.append("--warnings-as-errors=" + warnings_as_errors)
+    start.append(f)
+    return start
+
+
+def merge_replacement_files(tmpdir, mergefile):
+    """Merge all replacement files in a directory into a single file"""
+    # The fixes suggested by clang-tidy >= 4.0.0 are given under
+    # the top level key 'Diagnostics' in the output yaml files
+    mergekey = "Diagnostics"
+    merged = []
+    for replacefile in glob.iglob(os.path.join(tmpdir, "*.yaml")):
+        content = yaml.safe_load(open(replacefile, "r"))
+        if not content:
+            continue  # Skip empty files.
+        merged.extend(content.get(mergekey, []))
+
+    if merged:
+        # MainSourceFile: The key is required by the definition inside
+        # include/clang/Tooling/ReplacementsYaml.h, but the value
+        # is actually never used inside clang-apply-replacements,
+        # so we set it to '' here.
+        output = {"MainSourceFile": "", mergekey: merged}
+        with open(mergefile, "w") as out:
+            yaml.safe_dump(output, out)
+    else:
+        # Empty the file:
+        open(mergefile, "w").close()
+
+
+def find_binary(arg, name, build_path):
+    """Get the path for a binary or exit"""
+    if arg:
+        if shutil.which(arg):
+            return arg
+        else:
+            raise SystemExit(
+                "error: passed binary '{}' was not found or is not executable".format(
+                    arg
+                )
+            )
+
+    built_path = os.path.join(build_path, "bin", name)
+    binary = shutil.which(name) or shutil.which(built_path)
+    if binary:
+        return binary
+    else:
+        raise SystemExit(
+            "error: failed to find {} in $PATH or at {}".format(name, built_path)
+        )
+
+
+def apply_fixes(args, clang_apply_replacements_binary, tmpdir):
+    """Calls clang-apply-fixes on a given directory."""
+    invocation = [clang_apply_replacements_binary]
+    invocation.append("-ignore-insert-conflict")
+    if args.format:
+        invocation.append("-format")
+    if args.style:
+        invocation.append("-style=" + args.style)
+    invocation.append(tmpdir)
+    subprocess.call(invocation)
+
+
+def run_tidy(args, clang_tidy_binary, tmpdir, build_path, queue, lock, failed_files):
+    """Takes filenames out of queue and runs clang-tidy on them."""
+    while True:
+        name = queue.get()
+        invocation = get_tidy_invocation(
+            name,
+            clang_tidy_binary,
+            args.checks,
+            tmpdir,
+            build_path,
+            args.header_filter,
+            args.allow_enabling_alpha_checkers,
+            args.extra_arg,
+            args.extra_arg_before,
+            args.quiet,
+            args.config_file,
+            args.config,
+            args.line_filter,
+            args.use_color,
+            args.plugins,
+            args.warnings_as_errors,
+        )
+
+        proc = subprocess.Popen(
+            invocation, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        output, err = proc.communicate()
+        if proc.returncode != 0:
+            if proc.returncode < 0:
+                msg = "%s: terminated by signal %d\n" % (name, -proc.returncode)
+                err += msg.encode("utf-8")
+            failed_files.append(name)
+        with lock:
+            sys.stdout.write(" ".join(invocation) + "\n" + output.decode("utf-8"))
+            if len(err) > 0:
+                sys.stdout.flush()
+                sys.stderr.write(err.decode("utf-8"))
+        queue.task_done()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Runs clang-tidy over all files "
+        "in a compilation database. Requires "
+        "clang-tidy and clang-apply-replacements in "
+        "$PATH or in your build directory."
+    )
+    parser.add_argument(
+        "-allow-enabling-alpha-checkers",
+        action="store_true",
+        help="allow alpha checkers from clang-analyzer.",
+    )
+    parser.add_argument(
+        "-clang-tidy-binary", metavar="PATH", help="path to clang-tidy binary"
+    )
+    parser.add_argument(
+        "-clang-apply-replacements-binary",
+        metavar="PATH",
+        help="path to clang-apply-replacements binary",
+    )
+    parser.add_argument(
+        "-checks",
+        default=None,
+        help="checks filter, when not specified, use clang-tidy default",
+    )
+    config_group = parser.add_mutually_exclusive_group()
+    config_group.add_argument(
+        "-config",
+        default=None,
+        help="Specifies a configuration in YAML/JSON format: "
+        "  -config=\"{Checks: '*', "
+        '                       CheckOptions: {x: y}}" '
+        "When the value is empty, clang-tidy will "
+        "attempt to find a file named .clang-tidy for "
+        "each source file in its parent directories.",
+    )
+    config_group.add_argument(
+        "-config-file",
+        default=None,
+        help="Specify the path of .clang-tidy or custom config "
+        "file: e.g. -config-file=/some/path/myTidyConfigFile. "
+        "This option internally works exactly the same way as "
+        "-config option after reading specified config file. "
+        "Use either -config-file or -config, not both.",
+    )
+    parser.add_argument(
+        "-header-filter",
+        default=None,
+        help="regular expression matching the names of the "
+        "headers to output diagnostics from. Diagnostics from "
+        "the main file of each translation unit are always "
+        "displayed.",
+    )
+    parser.add_argument(
+        "-line-filter",
+        default=None,
+        help="List of files with line ranges to filter the warnings.",
+    )
+    if yaml:
+        parser.add_argument(
+            "-export-fixes",
+            metavar="file_or_directory",
+            dest="export_fixes",
+            help="A directory or a yaml file to store suggested fixes in, "
+            "which can be applied with clang-apply-replacements. If the "
+            "parameter is a directory, the fixes of each compilation unit are "
+            "stored in individual yaml files in the directory.",
+        )
+    else:
+        parser.add_argument(
+            "-export-fixes",
+            metavar="directory",
+            dest="export_fixes",
+            help="A directory to store suggested fixes in, which can be applied "
+            "with clang-apply-replacements. The fixes of each compilation unit are "
+            "stored in individual yaml files in the directory.",
+        )
+    parser.add_argument(
+        "-j",
+        type=int,
+        default=0,
+        help="number of tidy instances to be run in parallel.",
+    )
+    parser.add_argument(
+        "files", nargs="*", default=[".*"], help="files to be processed (regex on path)"
+    )
+    parser.add_argument("-fix", action="store_true", help="apply fix-its")
+    parser.add_argument(
+        "-format", action="store_true", help="Reformat code after applying fixes"
+    )
+    parser.add_argument(
+        "-style",
+        default="file",
+        help="The style of reformat code after applying fixes",
+    )
+    parser.add_argument(
+        "-use-color",
+        type=strtobool,
+        nargs="?",
+        const=True,
+        help="Use colors in diagnostics, overriding clang-tidy's"
+        " default behavior. This option overrides the 'UseColor"
+        "' option in .clang-tidy file, if any.",
+    )
+    parser.add_argument(
+        "-p", dest="build_path", help="Path used to read a compile command database."
+    )
+    parser.add_argument(
+        "-extra-arg",
+        dest="extra_arg",
+        action="append",
+        default=[],
+        help="Additional argument to append to the compiler command line.",
+    )
+    parser.add_argument(
+        "-extra-arg-before",
+        dest="extra_arg_before",
+        action="append",
+        default=[],
+        help="Additional argument to prepend to the compiler command line.",
+    )
+    parser.add_argument(
+        "-quiet", action="store_true", help="Run clang-tidy in quiet mode"
+    )
+    parser.add_argument(
+        "-load",
+        dest="plugins",
+        action="append",
+        default=[],
+        help="Load the specified plugin in clang-tidy.",
+    )
+    parser.add_argument(
+        "-warnings-as-errors",
+        default=None,
+        help="Upgrades warnings to errors. Same format as '-checks'",
+    )
+    args = parser.parse_args()
+
+    db_path = "compile_commands.json"
+
+    if args.build_path is not None:
+        build_path = args.build_path
+    else:
+        # Find our database
+        build_path = find_compilation_database(db_path)
+
+    clang_tidy_binary = find_binary(args.clang_tidy_binary, "clang-tidy", build_path)
+
+    if args.fix:
+        clang_apply_replacements_binary = find_binary(
+            args.clang_apply_replacements_binary, "clang-apply-replacements", build_path
+        )
+
+    combine_fixes = False
+    export_fixes_dir = None
+    delete_fixes_dir = False
+    if args.export_fixes is not None:
+        # if a directory is given, create it if it does not exist
+        if args.export_fixes.endswith(os.path.sep) and not os.path.isdir(
+            args.export_fixes
+        ):
+            os.makedirs(args.export_fixes)
+
+        if not os.path.isdir(args.export_fixes):
+            if not yaml:
+                raise RuntimeError(
+                    "Cannot combine fixes in one yaml file. Either install PyYAML or specify an output directory."
+                )
+
+            combine_fixes = True
+
+        if os.path.isdir(args.export_fixes):
+            export_fixes_dir = args.export_fixes
+
+    if export_fixes_dir is None and (args.fix or combine_fixes):
+        export_fixes_dir = tempfile.mkdtemp()
+        delete_fixes_dir = True
+
+    try:
+        invocation = get_tidy_invocation(
+            "",
+            clang_tidy_binary,
+            args.checks,
+            None,
+            build_path,
+            args.header_filter,
+            args.allow_enabling_alpha_checkers,
+            args.extra_arg,
+            args.extra_arg_before,
+            args.quiet,
+            args.config_file,
+            args.config,
+            args.line_filter,
+            args.use_color,
+            args.plugins,
+            args.warnings_as_errors,
+        )
+        invocation.append("-list-checks")
+        invocation.append("-")
+        if args.quiet:
+            # Even with -quiet we still want to check if we can call clang-tidy.
+            with open(os.devnull, "w") as dev_null:
+                subprocess.check_call(invocation, stdout=dev_null)
+        else:
+            subprocess.check_call(invocation)
+    except:
+        print("Unable to run clang-tidy.", file=sys.stderr)
+        sys.exit(1)
+
+    # Load the database and extract all files.
+    database = json.load(open(os.path.join(build_path, db_path)))
+    files = set(
+        [make_absolute(entry["file"], entry["directory"]) for entry in database]
+    )
+
+    max_task = args.j
+    if max_task == 0:
+        max_task = multiprocessing.cpu_count()
+
+    # Build up a big regexy filter from all command line arguments.
+    file_name_re = re.compile("|".join(args.files))
+
+    return_code = 0
+    try:
+        # Spin up a bunch of tidy-launching threads.
+        task_queue = queue.Queue(max_task)
+        # List of files with a non-zero return code.
+        failed_files = []
+        lock = threading.Lock()
+        for _ in range(max_task):
+            t = threading.Thread(
+                target=run_tidy,
+                args=(
+                    args,
+                    clang_tidy_binary,
+                    export_fixes_dir,
+                    build_path,
+                    task_queue,
+                    lock,
+                    failed_files,
+                ),
+            )
+            t.daemon = True
+            t.start()
+
+        # Fill the queue with files.
+        for name in files:
+            if file_name_re.search(name):
+                task_queue.put(name)
+
+        # Wait for all threads to be done.
+        task_queue.join()
+        if len(failed_files):
+            return_code = 1
+
+    except KeyboardInterrupt:
+        # This is a sad hack. Unfortunately subprocess goes
+        # bonkers with ctrl-c and we start forking merrily.
+        print("\nCtrl-C detected, goodbye.")
+        if delete_fixes_dir:
+            shutil.rmtree(export_fixes_dir)
+        os.kill(0, 9)
+
+    if combine_fixes:
+        print("Writing fixes to " + args.export_fixes + " ...")
+        try:
+            merge_replacement_files(export_fixes_dir, args.export_fixes)
+        except:
+            print("Error exporting fixes.\n", file=sys.stderr)
+            traceback.print_exc()
+            return_code = 1
+
+    if args.fix:
+        print("Applying fixes ...")
+        try:
+            apply_fixes(args, clang_apply_replacements_binary, export_fixes_dir)
+        except:
+            print("Error applying fixes.\n", file=sys.stderr)
+            traceback.print_exc()
+            return_code = 1
+
+    if delete_fixes_dir:
+        shutil.rmtree(export_fixes_dir)
+    sys.exit(return_code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 内容

`run-clang-tidy.py` 此前被 `.gitignore` 忽略,CI checkout 后仓里没有它,于是每次
`--clang-tidy` 都从 llvm-project `main` 现拉一份未钉版脚本并执行。本 PR 把它从
`llvmorg-18.1.8` 原样 vendor 进仓、删掉下载段,并为它加一条 ruff 排除。

`automation/linter.py` 对 `origin/main` 的净效果是**删除**:忽略空白后新增 0 行、删除 25 行
(`git diff origin/main --ignore-all-space --numstat -- automation/linter.py`),
唯一的非删除行是一处行尾空格。

三条提交信息记录了完整的推导与两次结构调整,不在此复述。

## 测试

`./linter.py --ruff` 与 `./linter.py --clang-tidy` 均绿(本机 `.venv`,clang-tidy 18.1.8,
与 CI 同款钉版)。未触碰 C++ 源码,无新增或删除测试。

## 验证

- **runner A/B**:固定 binary 于 18.1.8、只换 runner。干净态两版均 0 诊断——该结果零区分力,
  故补注入:人造一处裸违规后,796 行 main 版与 537 行 18.1.8 版报出逐字相同的 3 条诊断、均 exit 1。
- **门未被删空**:40 次 `clang-tidy` 调用对 40 条 `compile_commands.json` 条目,
  `file not found` 计数 0。
- **runner 缺失**:退出 2,报错含绝对路径与 errno。
- **文件身份由 git 承担**:截断 / 换成 main 版 / 追加内容 / 改模式 / 换行尾,`git status`
  与 `git diff --stat` 均可见。边界:`git update-index --assume-unchanged` 与 `--skip-worktree`
  可致盲,属本地 index opt-out,不进推送面。

## 范围说明

- 本 PR 做掉 **#165 第二项**(删除 llvm main 下载回退路径)。**该条目的理由需更正**:
  原文写「仓根已 commit run-clang-tidy.py……该下载段不可达」,实际该文件当时是 gitignored、
  从未被 commit,下载段每次 CI 都在执行。本 PR 反而是第一次让「仓根已 commit」成真。
  另注:该条目的坐标 `automation/linter.py:20-39` 已随本 PR 失效,现指向 `run_ruff`。
  #165 其余项不在本 PR 范围,故不写 closing keyword。
- **不含 #73**(clang-tidy 18.1.8 → 21.x)。实测本机 21.1.8 对当前代码报 3785 条诊断
  (`modernize-use-designated-initializers` 3442 / `readability-math-missing-parentheses` 216 /
  `modernize-use-trailing-return-type` 79 / `portability-avoid-pragma-once` 32,长尾 16 条),
  需要单独分诊。
- 未采纳的提案:自研 driver 替代 vendoring(审阅中提出,用户裁决保留 vendoring);
  给 vendored 文件加 sha256 身份闸门(判定 git 已承担该职责)。

## 审阅

本地三轮。R1 四席(闸门区分力 / 契约 / 减法 / 盲审),R2 三席,R3 两席。
R1 报 P1 三条,均已处置并致使 PR 两次结构收缩;R3 无 P1/P2,收敛。
报告在 `.review/`(未入仓)。

两处需如实标注:R3 未派契约席,勘误由驾驶者自查(作者查自证据力打折,该批为机械查表);
本轮未派风格席,行文质感无人承包,已书面降级。
